### PR TITLE
perf: Update .gitignore poetry.lock should be commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,4 +180,3 @@ apps/static
 models/
 data
 .dev
-poetry.lock


### PR DESCRIPTION
deps: poetry.lock should be commit

#### What this PR does / why we need it?
poetry.lock should be commit to repo, If not commit why not using requirements.txt.

https://python-poetry.org/docs/basic-usage/#committing-your-poetrylock-file-to-version-control

#### Summary of your change

#### Please indicate you've done the following:

- [ x ] Made sure tests are passing and test coverage is added if needed.
- [ x ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ x ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.