### PR TITLE
修复前端缺少 @ctrl/tinycolor 依赖库,以及不兼容4.1.x版本的问题

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@ctrl/tinycolor": "^4.1.0",
     "axios": "^0.28.0",
     "echarts": "^5.5.0",
     "element-plus": "^2.5.6",

--- a/ui/src/theme/index.ts
+++ b/ui/src/theme/index.ts
@@ -5,7 +5,7 @@ import type {
   UpdateInferData,
   UpdateKeyValueData
 } from './type'
-import tinycolor from '@ctrl/tinycolor'
+import { TinyColor } from '@ctrl/tinycolor'
 // 引入默认推断数据
 import inferData from './defaultInferData'
 // 引入默认keyValue数据
@@ -119,7 +119,7 @@ class Theme {
                   l.toString()
                 )
                 return {
-                  [varName]: tinycolor(inferData.value)
+                  [varName]: new TinyColor(inferData.value)
                     .mix(key === 'light' ? this.colorWhite : this.colorBlack, l * 10)
                     .toHexString()
                 }


### PR DESCRIPTION
#### 前端缺少 @ctrl/tinycolor 依赖库,以及不兼容4.1.x版本

原来的依赖包中，缺少一个库"@ctrl/tinycolor"，运行开发环境会报错，而如果直接通过 `npm install @ctrl/tinycolor` 安装这个库的话，会发现安装的是 4.1.0 版，但代码不能兼容。

#### 修改
- 在 package.json 文件中增加 "@ctrl/tinycolor" 依赖
- 在 index.ts 文件中，修改引入 TinyColor 的方式，原来是一个函数，现在是一个类，同时也修改调用的位置
