### PR TITLE
feat: 支持导出单次对话的全部提问记录为Markdown文件或HTML文件

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "cropperjs": "^1.6.2",
     "echarts": "^5.5.0",
     "element-plus": "^2.5.6",
+    "file-saver": "^2.0.5",
     "install": "^0.13.0",
     "katex": "^0.16.10",
     "lodash": "^4.17.21",
@@ -31,6 +32,7 @@
     "markdown-it-sup": "^1.0.0",
     "markdown-it-task-lists": "^2.1.1",
     "markdown-it-toc-done-right": "^4.2.0",
+    "marked": "^12.0.2",
     "md-editor-v3": "4.12.1",
     "medium-zoom": "^1.1.0",
     "mermaid": "^10.9.0",
@@ -49,6 +51,7 @@
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.3.2",
     "@tsconfig/node18": "^18.2.0",
+    "@types/file-saver": "^2.0.7",
     "@types/jsdom": "^21.1.1",
     "@types/markdown-it": "^13.0.7",
     "@types/markdown-it-highlightjs": "^3.3.4",


### PR DESCRIPTION
#### What this PR does / why we need it?
与 #471 有关，但未实现PDF导出
#### Summary of your change
![image](https://github.com/1Panel-dev/MaxKB/assets/32493237/4ad990e3-317a-4945-a6ab-b5bea9cd60c7)
![image](https://github.com/1Panel-dev/MaxKB/assets/32493237/b8c57a99-e2cb-4f27-9208-82cea4ee592f)
![image](https://github.com/1Panel-dev/MaxKB/assets/32493237/d4fc1eff-c526-4d96-bb20-5c43aebf087c)
使用marked和file-saver实现Markdown文件和HTML文件导出。
在实现PDF导出时，发现中文和特殊字符在导出PDF时会出现乱码问题。如果使用html2canvas后再导出PDF，则会导致文本无法复制。对于面向程序开发等场景的知识库来说，无法复制文本/代码是一个非常糟糕的问题，因此决定暂时不放出导出PDF的方法。
#### Please indicate you've done the following:

- [ Y ] Made sure tests are passing and test coverage is added if needed.
- [ Y ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ Y ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.