### PR TITLE
fix:知识库上传文档操作报异常，错误的原因是正则表达式模式在某个位置缺少一个右括号，该提交修复了这个问题。

### DIFF
--- a/apps/common/util/ts_vecto_util.py
+++ b/apps/common/util/ts_vecto_util.py
@@ -49,7 +49,8 @@ def get_word_list(text: str):
 
 def replace_word(word_dict, text: str):
     for key in word_dict:
-        text = re.sub('(?<!#)' + word_dict[key] + '(?!#)', key, text)
+        pattern = '(?<!#)' + re.escape(word_dict[key]) + '(?!#)'
+        text = re.sub(pattern, key, text)
     return text
 
 


### PR DESCRIPTION
fix:知识库上传文档操作报异常，错误发生在 ts_vecto_util.py 文件的 replace_word 函数中：错误的原因是正则表达式模式在某个位置缺少一个右括号，使得子模式未完全结束。该提交修复了这个问题。

# What this PR does / why we need it?
**MaxKB 版本**
v1.2.0

**问题描述**
[BUG]知识库上传文档操作报异常，错误发生在 ts_vecto_util.py 文件的 replace_word 函数中：错误的原因是正则表达式模式在某个位置缺少一个右括号，使得子模式未完全结束。

**重现步骤**
1.知识库，上传文档：<Oracle21C-database-pl-sql-language-reference.pdf>
[Oracle21C-database-pl-sql-language-reference.pdf](https://github.com/user-attachments/files/15984729/Oracle21C-database-pl-sql-language-reference.pdf)

2.界面和日志出现如下异常：
![error](https://github.com/1Panel-dev/MaxKB/assets/19249636/18adba20-d21c-4a30-bb7d-fa9c9d995b2a)
```shell
2024-06-26 13:25:09 [listener_manage ERROR] 向量化文档:323837a2-3360-11ef-aaed-0242ac120003出现错误missing ), unterminated subpattern at position 8Traceback (most recent call last):
  File "/opt/maxkb/app/apps/common/event/listener_manage.py", line 141, in embedding_by_document
    VectorStore.get_embedding_vector().batch_save(data_list)
  File "/opt/maxkb/app/apps/embedding/vector/base_vector.py", line 88, in batch_save
    self._batch_save(child_array, embedding)
  File "/opt/maxkb/app/apps/embedding/vector/pg_vector.py", line 70, in _batch_save
    embedding_list = [Embedding(id=uuid.uuid1(),
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/maxkb/app/apps/embedding/vector/pg_vector.py", line 78, in <listcomp>
    search_vector=to_ts_vector(text_list[index]['text'])) for index in
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/maxkb/app/apps/common/util/ts_vecto_util.py", line 86, in to_ts_vector
    text = replace_word(word_dict, text)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/maxkb/app/apps/common/util/ts_vecto_util.py", line 52, in replace_word
    text = re.sub('(?<!#)' + word_dict[key] + '(?!#)', key, text)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/__init__.py", line 185, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/__init__.py", line 294, in _compile
    p = _compiler.compile(pattern, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_compiler.py", line 743, in compile
    p = _parser.parse(p, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_parser.py", line 980, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_parser.py", line 455, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/_parser.py", line 865, in _parse
    raise source.error("missing ), unterminated subpattern",
re.error: missing ), unterminated subpattern at position 8

2024-06-26 13:25:09 [listener_manage INFO] 结束--->向量化文档:323837a2-3360-11ef-aaed-0242ac120003
```

**期待的正确结果**
![image](https://github.com/1Panel-dev/MaxKB/assets/19249636/98e429a1-2ebd-49f1-9e48-0d9d7849b837)

**相关日志输出**
No response

**附加信息**
从错误信息来看，错误的原因是正则表达式模式在某个位置缺少一个右括号，使得子模式未完全结束。错误发生在 `ts_vecto_util.py` 文件的 `replace_word` 函数中：

```python
text = re.sub('(?<!#)' + word_dict[key] + '(?!#)', key, text)
```

这个正则表达式使用了一个非捕获断言 `(?<!#)` 和 `(?!#)`，但在 `word_dict[key]` 中的某个值可能包含未关闭的括号或其他不合法的正则表达式字符。

解决这个问题，通过以下方法：
**转义特殊字符**：
   使用 `re.escape` 来转义 `word_dict` 中的所有值，以确保它们在正则表达式中被视为字面量字符而不是正则表达式的元字符。

修改 `replace_word` 函数如下：

```python
def replace_word(word_dict, text):
    for key in word_dict:
        pattern = '(?<!#)' + re.escape(word_dict[key]) + '(?!#)'
        text = re.sub(pattern, key, text)
    return text
```

这样， `word_dict` 中的值会被转义，从而避免未闭合的括号或其他正则表达式元字符的问题。

# Summary of your change

# Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.