### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/apps/application/views/application_views.py
+++ b/apps/application/views/application_views.py
@@ -196,8 +196,7 @@ class Application(APIView):
                 return result.success(ApplicationSerializer.Operate(
                     data={'application_id': request.auth.keywords.get('application_id'),
                           'user_id': request.user.id}).profile())
-            else:
-                raise AppAuthenticationFailed(401, "身份异常")
+            raise AppAuthenticationFailed(401, "身份异常")
 
     class ApplicationKey(APIView):
         authentication_classes = [TokenAuth]

--- a/apps/common/auth/authentication.py
+++ b/apps/common/auth/authentication.py
@@ -59,11 +59,11 @@ def exist_permissions(user_role: List[RoleConstants], user_permission: List[Perm
                       **kwargs):
     if isinstance(permission, ViewPermission):
         return exist_permissions_by_view_permission(user_role, user_permission, permission, request, **kwargs)
-    elif isinstance(permission, RoleConstants):
+    if isinstance(permission, RoleConstants):
         return exist_role_by_role_constants(user_role, [permission])
-    elif isinstance(permission, PermissionConstants):
+    if isinstance(permission, PermissionConstants):
         return exist_permissions_by_permission_constants(user_permission, [permission])
-    elif isinstance(permission, Permission):
+    if isinstance(permission, Permission):
         return user_permission.__contains__(permission)
     return False
 
@@ -72,8 +72,7 @@ def exist(user_role: List[RoleConstants], user_permission: List[PermissionConsta
     if callable(permission):
         p = permission(request, kwargs)
         return exist_permissions(user_role, user_permission, p, request)
-    else:
-        return exist_permissions(user_role, user_permission, permission, request, **kwargs)
+    return exist_permissions(user_role, user_permission, permission, request, **kwargs)
 
 
 def has_permissions(*permission, compare=CompareConstants.OR):
@@ -92,8 +91,7 @@ def has_permissions(*permission, compare=CompareConstants.OR):
             # 判断是否有权限
             if any(exit_list) if compare == CompareConstants.OR else all(exit_list):
                 return func(view, request, **kwargs)
-            else:
-                raise AppUnauthorizedFailed(403, "没有权限访问")
+            raise AppUnauthorizedFailed(403, "没有权限访问")
 
         return run
 

--- a/apps/common/handle/handle_exception.py
+++ b/apps/common/handle/handle_exception.py
@@ -63,9 +63,9 @@ def find_err_detail(exc_detail):
             _value = exc_detail[key]
             if isinstance(_value, list):
                 return find_err_detail(_value)
-            elif isinstance(_value, ErrorDetail):
+            if isinstance(_value, ErrorDetail):
                 return _value
-            elif isinstance(_value, dict) and len(_value.keys()) > 0:
+            if isinstance(_value, dict) and len(_value.keys()) > 0:
                 return find_err_detail(_value)
     if isinstance(exc_detail, list):
         for v in exc_detail:

--- a/apps/smartdoc/urls.py
+++ b/apps/smartdoc/urls.py
@@ -57,16 +57,15 @@ def page_not_found(request, exception):
     """
     if request.path.startswith("/api/"):
         return Result(response_status=status.HTTP_404_NOT_FOUND, code=404, message="找不到接口")
-    else:
-        index_path = os.path.join(PROJECT_DIR, 'apps', "static", 'ui', 'index.html')
-        if not os.path.exists(index_path):
-            return HttpResponse("页面不存在", status=404)
-        file = open(index_path, "r", encoding='utf-8')
-        content = file.read()
-        file.close()
-        if request.path.startswith('/ui/chat/'):
-            return HttpResponse(content, status=200)
-        return HttpResponse(content, status=200, headers={'X-Frame-Options': 'DENY'})
+    index_path = os.path.join(PROJECT_DIR, 'apps', "static", 'ui', 'index.html')
+    if not os.path.exists(index_path):
+        return HttpResponse("页面不存在", status=404)
+    file = open(index_path, "r", encoding='utf-8')
+    content = file.read()
+    file.close()
+    if request.path.startswith('/ui/chat/'):
+        return HttpResponse(content, status=200)
+    return HttpResponse(content, status=200, headers={'X-Frame-Options': 'DENY'})
 
 
 handler404 = page_not_found


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.