### PR TITLE
chore: 解析错误是输出错误原因

### DIFF
--- a/apps/common/handle/impl/pdf_split_handle.py
+++ b/apps/common/handle/impl/pdf_split_handle.py
@@ -75,6 +75,7 @@ class PdfSplitHandle(BaseSplitHandle):
 
 
         except BaseException as e:
+            max_kb.error(f"File: {file.name}, error: {e}")
             return {'name': file.name,
                     'content': []}
         finally:


### PR DESCRIPTION
chore: 解析错误是输出错误原因 