### PR TITLE
fix: 修复知识库迁移报错的缺陷

### DIFF
--- a/apps/dataset/serializers/document_serializers.py
+++ b/apps/dataset/serializers/document_serializers.py
@@ -240,7 +240,7 @@ class DocumentSerializers(ApiMixin, serializers.Serializer):
                 document_list.update(dataset_id=target_dataset_id)
             model_id = None
             if dataset.embedding_mode_id != target_dataset.embedding_mode_id:
-                model_id = get_embedding_model_by_dataset_id(target_dataset_id)
+                model_id = get_embedding_model_id_by_dataset_id(target_dataset_id)
 
             pid_list = [paragraph.id for paragraph in paragraph_list]
             # 修改段落信息


### PR DESCRIPTION
fix: 修复知识库迁移报错的缺陷  --bug=1045659 --user=王孝刚 【知识库】通用知识库，文档迁移报错了 https://www.tapd.cn/57709429/s/1568795 