### PR TITLE
fix: 修复【系统管理】模型设置，模型名称省略显示的时候，模型图标会消失

### DIFF
--- a/ui/src/views/template/component/ModelCard.vue
+++ b/ui/src/views/template/component/ModelCard.vue
@@ -3,7 +3,7 @@
     <template #header>
       <div class="flex">
         <span style="height: 32px; width: 32px" :innerHTML="icon" class="mr-12"></span>
-        <div class="w-full">
+        <div style="width: calc(100% - 32px - 4px - var(--app-base-px))">
           <div class="flex" style="height: 22px">
             <auto-tooltip :content="model.name" style="max-width: 40%">
               {{ model.name }}


### PR DESCRIPTION
fix: 修复【系统管理】模型设置，模型名称省略显示的时候，模型图标会消失 