### PR TITLE
fix: 修复接口传入类型参数没有输入时，历史会话重新生成没有拦截的问题

### DIFF
--- a/ui/src/components/ai-chat/index.vue
+++ b/ui/src/components/ai-chat/index.vue
@@ -768,6 +768,9 @@ function chatMessage(chat?: any, problem?: string, re_chat?: boolean) {
 }
 
 function regenerationChart(item: chatType) {
+  if (!checkInputParam()) {
+    return
+  }
   inputValue.value = item.problem_text
   if (!loading.value) {
     chatMessage(null, '', true)


### PR DESCRIPTION
fix: 修复接口传入类型参数没有输入时，历史会话重新生成没有拦截的问题 