### PR TITLE
fix: 修复【应用编排】添加不是自己创建的公用函数失败

### DIFF
--- a/apps/function_lib/serializers/function_lib_serializer.py
+++ b/apps/function_lib/serializers/function_lib_serializer.py
@@ -215,6 +215,9 @@ class FunctionLibSerializer(serializers.Serializer):
 
         def one(self, with_valid=True):
             if with_valid:
-                self.is_valid(raise_exception=True)
+                super().is_valid(raise_exception=True)
+                if not QuerySet(FunctionLib).filter(id=self.data.get('id')).filter(
+                        Q(user_id=self.data.get('user_id')) | Q(permission_type='PUBLIC')).exists():
+                    raise AppApiException(500, '函数不存在')
             function_lib = QuerySet(FunctionLib).filter(id=self.data.get('id')).first()
             return FunctionLibModelSerializer(function_lib).data


### PR DESCRIPTION
fix: 修复【应用编排】添加不是自己创建的公用函数失败 