### PR TITLE
fix: 修复本地模型加载失败时,错误信息未输出

### DIFF
--- a/apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py
+++ b/apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py
@@ -91,6 +91,8 @@ def convert_value(name: str, value, _type, is_required, source, node):
 class BaseFunctionLibNodeNode(IFunctionLibNode):
     def execute(self, function_lib_id, input_field_list, **kwargs) -> NodeResult:
         function_lib = QuerySet(FunctionLib).filter(id=function_lib_id).first()
+        if not function_lib.is_active:
+            raise Exception(f'函数:{function_lib.name}  不可用')
         params = {field.get('name'): convert_value(field.get('name'), field.get('value'), field.get('type'),
                                                    field.get('is_required'),
                                                    field.get('source'), self)

--- a/apps/setting/models_provider/impl/local_model_provider/model/embedding.py
+++ b/apps/setting/models_provider/impl/local_model_provider/model/embedding.py
@@ -35,7 +35,7 @@ class WebLocalEmbedding(MaxKBBaseModel, BaseModel, Embeddings):
         result = res.json()
         if result.get('code', 500) == 200:
             return result.get('data')
-        raise Exception(result.get('msg'))
+        raise Exception(result.get('message'))
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         bind = f'{CONFIG.get("LOCAL_MODEL_HOST")}:{CONFIG.get("LOCAL_MODEL_PORT")}'
@@ -44,7 +44,7 @@ class WebLocalEmbedding(MaxKBBaseModel, BaseModel, Embeddings):
         result = res.json()
         if result.get('code', 500) == 200:
             return result.get('data')
-        raise Exception(result.get('msg'))
+        raise Exception(result.get('message'))
 
 
 class LocalEmbedding(MaxKBBaseModel, HuggingFaceEmbeddings):


### PR DESCRIPTION
fix: 修复【应用编排】应用编排中引用函数，函数被禁用后应用里还可以正常执行<br>fix: 修复本地模型加载失败时,错误信息未输出 