### PR TITLE
fix: 修复接口传入类型的参数校验必填项的问题

### DIFF
--- a/ui/src/components/ai-chat/index.vue
+++ b/ui/src/components/ai-chat/index.vue
@@ -512,7 +512,7 @@ function checkInputParam() {
     if (!api_form_data.value[f.field]) {
       api_form_data.value[f.field] = route.query[f.field]
     }
-    if (!api_form_data.value[f.field]) {
+    if (f.required && !api_form_data.value[f.field]) {
       msg.push(f.field)
     }
   }


### PR DESCRIPTION
fix: 修复接口传入类型的参数校验必填项的问题  --bug=1046919 --user=刘瑞斌 【应用编排】接口传参类型的全局变量，设置了非必填后提问还是会提示需要填写 https://www.tapd.cn/57709429/s/1583325 