### PR TITLE
fix: 修复被关联的语音模型可以直接删除的问题

### DIFF
--- a/apps/setting/serializers/provider_serializers.py
+++ b/apps/setting/serializers/provider_serializers.py
@@ -272,6 +272,14 @@ class ModelSerializer(serializers.Serializer):
                 dataset_count = DataSet.objects.filter(embedding_mode_id=model_id).count()
                 if dataset_count > 0:
                     raise AppApiException(500, f"该模型关联了{dataset_count} 个知识库，无法删除该模型。")
+            elif model.model_type == 'TTS':
+                dataset_count = Application.objects.filter(tts_model_id=model_id).count()
+                if dataset_count > 0:
+                    raise AppApiException(500, f"该模型关联了{dataset_count} 个应用，无法删除该模型。")
+            elif model.model_type == 'STT':
+                dataset_count = Application.objects.filter(stt_model_id=model_id).count()
+                if dataset_count > 0:
+                    raise AppApiException(500, f"该模型关联了{dataset_count} 个应用，无法删除该模型。")
             model.delete()
             return True
 


### PR DESCRIPTION
fix: 修复被关联的语音模型可以直接删除的问题  --bug=1046965 --user=刘瑞斌 【模型管理】OpenAI语音输入模型在简单应用中使用，模型管理中还可删除 https://www.tapd.cn/57709429/s/1583615 