### PR TITLE
fix: 修复返回为空的文本不能播放默认提示的问题

### DIFF
--- a/ui/src/components/ai-chat/LogOperationButton.vue
+++ b/ui/src/components/ai-chat/LogOperationButton.vue
@@ -102,7 +102,9 @@ function editMark(data: any) {
 const audioPlayerStatus = ref(false)
 
 const playAnswerText = (text: string) => {
-  console.log(props.data)
+  if (!text) {
+    text = '抱歉，没有查找到相关内容，请重新描述您的问题或提供更多信息。'
+  }
   if (props.tts_type === 'BROWSER') {
     // 创建一个新的 SpeechSynthesisUtterance 实例
     const utterance = new SpeechSynthesisUtterance(text)

--- a/ui/src/components/ai-chat/OperationButton.vue
+++ b/ui/src/components/ai-chat/OperationButton.vue
@@ -160,6 +160,9 @@ function markdownToPlainText(md: string) {
 }
 
 const playAnswerText = (text: string) => {
+  if (!text) {
+    text = '抱歉，没有查找到相关内容，请重新描述您的问题或提供更多信息。'
+  }
   // text 处理成纯文本
   text = markdownToPlainText(text)
   if (props.tts_type === 'BROWSER') {


### PR DESCRIPTION
fix: 修复返回为空的文本不能播放默认提示的问题  --bug=1047018 --user=刘瑞斌 【应用】应用对话没有输出内容时，点击播放按钮console有报错 https://www.tapd.cn/57709429/s/1584399 