### PR TITLE
fix: 修复【应用编排】判断器点击右侧+添加组件后，连线有点长，建议调整一下组件距离

### DIFF
--- a/ui/src/workflow/common/NodeContainer.vue
+++ b/ui/src/workflow/common/NodeContainer.vue
@@ -182,10 +182,11 @@ const resizeStepContainer = (wh: any) => {
 }
 
 function clickNodes(item: any) {
+  const width = item.properties.width ? item.properties.width : 214
   const nodeModel = props.nodeModel.graphModel.addNode({
     type: item.type,
     properties: item.properties,
-    x: anchorData.value?.x + props.nodeModel.width + 100,
+    x: anchorData.value?.x + width / 2 + 200,
     y: anchorData.value?.y - item.height
   })
   props.nodeModel.graphModel.addEdge({


### PR DESCRIPTION
fix: 修复【应用编排】判断器点击右侧+添加组件后，连线有点长，建议调整一下组件距离 