### PR TITLE
build: sandbox权限限制，/opt/maxkb/app 目录下的文件只能操作自己的 /opt/maxkb/app/sandbox

### DIFF
--- a/installer/Dockerfile
+++ b/installer/Dockerfile
@@ -61,6 +61,7 @@ RUN chmod 755 /opt/maxkb/app/installer/run-maxkb.sh && \
     cp -f /opt/maxkb/app/installer/run-maxkb.sh /usr/bin/run-maxkb.sh && \
     cp -f /opt/maxkb/app/installer/init.sql /docker-entrypoint-initdb.d && \
     mkdir -p /opt/maxkb/app/sandbox/python-packages &&  \
+    find /opt/maxkb/app -mindepth 1 -not -name 'sandbox' -exec chmod 700 {} + && \
     useradd --no-create-home --home /opt/maxkb/app/sandbox --shell /bin/bash sandbox &&  \
     chown sandbox:sandbox /opt/maxkb/app/sandbox
 


### PR DESCRIPTION
build: sandbox权限限制，/opt/maxkb/app 目录下的文件只能操作自己的 /opt/maxkb/app/sandbox 