### PR TITLE
fix: 修复前端obj为null的时候导致页面卡顿的问题

### DIFF
--- a/ui/src/workflow/nodes/base-node/index.vue
+++ b/ui/src/workflow/nodes/base-node/index.vue
@@ -52,7 +52,7 @@
         </el-button>
       </div>
       <el-table
-        v-if="props.nodeModel.properties.input_field_list.length > 0"
+        v-if="props.nodeModel.properties.input_field_list?.length > 0"
         :data="props.nodeModel.properties.input_field_list"
         class="mb-16"
       >


### PR DESCRIPTION
fix: 修复前端obj为null的时候导致页面卡顿的问题 