### PR TITLE
fix: 修复 XInference 供应商加载模型时的未认证导致 API 域名无效的问题

### DIFF
--- a/apps/setting/models_provider/impl/xinference_model_provider/credential/llm.py
+++ b/apps/setting/models_provider/impl/xinference_model_provider/credential/llm.py
@@ -34,7 +34,7 @@ class XinferenceLLMModelCredential(BaseForm, BaseModelCredential):
         if not any(list(filter(lambda mt: mt.get('value') == model_type, model_type_list))):
             raise AppApiException(ValidCode.valid_error.value, f'{model_type} 模型类型不支持')
         try:
-            model_list = provider.get_base_model_list(model_credential.get('api_base'), model_type)
+            model_list = provider.get_base_model_list(model_credential.get('api_base'), model_credential.get('api_key'), model_type)
         except Exception as e:
             raise AppApiException(ValidCode.valid_error.value, "API 域名无效")
         exist = provider.get_model_info_by_name(model_list, model_name)

--- a/apps/setting/models_provider/impl/xinference_model_provider/xinference_model_provider.py
+++ b/apps/setting/models_provider/impl/xinference_model_provider/xinference_model_provider.py
@@ -371,10 +371,13 @@ class XinferenceModelProvider(IModelProvider):
                          'xinference_icon_svg')))
 
     @staticmethod
-    def get_base_model_list(api_base, model_type):
+    def get_base_model_list(api_base, api_key, model_type):
         base_url = get_base_url(api_base)
         base_url = base_url if base_url.endswith('/v1') else (base_url + '/v1')
-        r = requests.request(method="GET", url=f"{base_url}/models", timeout=5)
+        headers = {}
+        if api_key:
+            headers['Authorization'] = f"Bearer {api_key}"
+        r = requests.request(method="GET", url=f"{base_url}/models", headers=headers, timeout=5)
         r.raise_for_status()
         model_list = r.json().get('data')
         return [model for model in model_list if model.get('model_type') == model_type]


### PR DESCRIPTION
#### What this PR does / why we need it?
当XInference供应商模型开启认证后，添加模型时的获取模型列表接口未传递 Authorization 导致模型添加失败。页面报 “API 域名无效” 错误。该 PR 修复该问题。
#### Summary of your change
如果添加模型时设置了API KEY，在调用 XInference 接口时传递该参数。
#### Please indicate you've done the following:
不涉及。
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.