### PR TITLE
fix: 保留上次选择的模型和提示词

### DIFF
--- a/ui/src/views/document/component/GenerateRelatedDialog.vue
+++ b/ui/src/views/document/component/GenerateRelatedDialog.vue
@@ -162,11 +162,6 @@ const rules = reactive({
   prompt: [{ required: true, message: '请输入提示词', trigger: 'blur' }]
 })
 
-watch(dialogVisible, (bool) => {
-  if (!bool) {
-    form.value.model_id = ''
-  }
-})
 
 const open = (document_ids: string[]) => {
   getProvider()

--- a/ui/src/views/paragraph/component/GenerateRelatedDialog.vue
+++ b/ui/src/views/paragraph/component/GenerateRelatedDialog.vue
@@ -163,12 +163,6 @@ const rules = reactive({
   prompt: [{ required: true, message: '请输入提示词', trigger: 'blur' }]
 })
 
-watch(dialogVisible, (bool) => {
-  if (!bool) {
-    form.value.model_id = ''
-  }
-})
-
 const open = (paragraph_ids: string[]) => {
   getProvider()
   getModel()


### PR DESCRIPTION
fix: 保留上次选择的模型和提示词  --bug=1047752 --user=刘瑞斌 【应用】-生成关联问题设置模型和提示词后，再次点击生成关联问题，默认显示用户上次设置的模型和提示词。 https://www.tapd.cn/57709429/s/1596140 