### PR TITLE
fix: 修复高级应用调试时接口传入的参数不能填充默认值的问题

### DIFF
--- a/ui/src/components/ai-chat/index.vue
+++ b/ui/src/components/ai-chat/index.vue
@@ -468,7 +468,7 @@ function handleInputFieldList() {
                   field: v.variable,
                   input_type: 'TextInput',
                   label: v.variable,
-                  default_value: default_value[v.variable],
+                  default_value: v.default_value || default_value[v.variable],
                   required: v.is_required
                 }
               case 'select':
@@ -476,7 +476,7 @@ function handleInputFieldList() {
                   field: v.variable,
                   input_type: 'SingleSelect',
                   label: v.variable,
-                  default_value: default_value[v.variable],
+                  default_value: v.default_value || default_value[v.variable],
                   required: v.is_required,
                   option_list: v.optionList.map((o: any) => {
                     return { key: o, value: o }
@@ -487,7 +487,7 @@ function handleInputFieldList() {
                   field: v.variable,
                   input_type: 'DatePicker',
                   label: v.variable,
-                  default_value: default_value[v.variable],
+                  default_value: v.default_value || default_value[v.variable],
                   required: v.is_required,
                   attrs: {
                     format: 'YYYY-MM-DD HH:mm:ss',


### PR DESCRIPTION
fix: 修复高级应用调试时接口传入的参数不能填充默认值的问题  --bug=1047927 --user=刘瑞斌 【应用编排】接口传参必填项默认值不显示 https://www.tapd.cn/57709429/s/1598598 