### PR TITLE
fix: 修复配置TTS模型参数时必填项没有拦截的问题

### DIFF
--- a/ui/src/views/application/component/TTSModeParamSettingDialog.vue
+++ b/ui/src/views/application/component/TTSModeParamSettingDialog.vue
@@ -100,8 +100,12 @@ const reset_default = (model_id: string, application_id?: string) => {
 }
 
 const submit = async () => {
-  emit('refresh', form_data.value)
-  dialogVisible.value = false
+  dynamicsFormRef.value?.validate().then((ok) => {
+    if (ok) {
+      emit('refresh', form_data.value)
+      dialogVisible.value = false
+    }
+  })
 }
 
 


### PR DESCRIPTION
fix: 修复配置TTS模型参数时必填项没有拦截的问题  --bug=1048068 --user=刘瑞斌 【应用】语音合成模型参数设置了必填，没有填写的参数的时候点确认没有提示 https://www.tapd.cn/57709429/s/1598728 