### PR TITLE
fix: 添加模型时选择框里的模型按照名称排序

### DIFF
--- a/ui/src/views/template/component/SelectProviderDialog.vue
+++ b/ui/src/views/template/component/SelectProviderDialog.vue
@@ -64,6 +64,7 @@ const open = () => {
   dialogVisible.value = true
   ModelApi.getProvider(loading).then((ok) => {
     list_provider.value = ok.data
+    list_provider.value.sort((a, b) => a.provider.localeCompare(b.provider))
   })
 }
 
@@ -75,6 +76,7 @@ const checkModelType = (model_type: string) => {
   currentModelType.value = modelTypeOptions.value.filter((item) => item.value === model_type)[0].text
   ModelApi.getProviderByModelType(model_type, loading).then((ok) => {
     list_provider.value = ok.data
+    list_provider.value.sort((a, b) => a.provider.localeCompare(b.provider))
   })
 }
 


### PR DESCRIPTION
fix: 添加模型时选择框里的模型按照名称排序  --bug=1048208 --user=刘瑞斌 优化：【系统管理-模型设置】添加模型，显示的供应商里列表和左边的供应商列表排序不一致 https://www.tapd.cn/57709429/s/1599397 