### PR TITLE
fix: 修复文档表格按照状态过滤没有生成问题中的缺陷

### DIFF
--- a/.github/workflows/typos_check.yml
+++ b/.github/workflows/typos_check.yml
@@ -1,5 +1,10 @@
 name: Typos Check
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   run:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,4 @@
+[files]
+extend-exclude = [
+    'apps/setting/models_provider/impl/*/icon/*'
+]

--- a/ui/src/views/document/index.vue
+++ b/ui/src/views/document/index.vue
@@ -123,6 +123,12 @@
                         :command="beforeCommand('status', '3')"
                         >排队中</el-dropdown-item
                       >
+                      <el-dropdown-item
+                        :class="filterMethod['status'] === '4' ? 'is-active' : ''"
+                        class="justify-center"
+                        :command="beforeCommand('status', '4')"
+                        >生成问题中</el-dropdown-item
+                      >
                     </el-dropdown-menu>
                   </template>
                 </el-dropdown>


### PR DESCRIPTION
fix: 修复文档表格按照状态过滤没有生成问题中的缺陷  --bug=1048200 --user=刘瑞斌 【知识库】文档列表按文件状态排序，少了一个「生成问题中」的选项 https://www.tapd.cn/57709429/s/1601157 