### PR TITLE
fix: 修复添加参数对话框的标题文字不对应的问题

### DIFF
--- a/ui/src/workflow/nodes/base-node/component/ApiFieldFormDialog.vue
+++ b/ui/src/workflow/nodes/base-node/component/ApiFieldFormDialog.vue
@@ -5,6 +5,7 @@
     :close-on-click-modal="false"
     :close-on-press-escape="false"
     :destroy-on-close="true"
+    :before-close="close"
     append-to-body
   >
     <el-form
@@ -110,6 +111,7 @@ const open = (row: any) => {
 
 const close = () => {
   dialogVisible.value = false
+  isEdit.value = false
 }
 
 const submit = async (formEl: FormInstance | undefined) => {

--- a/ui/src/workflow/nodes/base-node/component/UserFieldFormDialog.vue
+++ b/ui/src/workflow/nodes/base-node/component/UserFieldFormDialog.vue
@@ -5,6 +5,7 @@
     :close-on-click-modal="false"
     :close-on-press-escape="false"
     :destroy-on-close="true"
+    :before-close="close"
     append-to-body
   >
     <DynamicsFormConstructor
@@ -16,7 +17,7 @@
     ></DynamicsFormConstructor>
     <template #footer>
       <span class="dialog-footer">
-        <el-button @click.prevent="dialogVisible = false"> 取消 </el-button>
+        <el-button @click.prevent="close"> 取消 </el-button>
         <el-button type="primary" @click="submit()" :loading="loading">
           {{ isEdit ? '保存' : '添加' }}
         </el-button>


### PR DESCRIPTION
fix: 修复添加参数对话框的标题文字不对应的问题  --bug=1047778 --user=刘瑞斌 【应用编排】- 用户输入，点击编辑参数后，关闭对话框，再点击添加参数打开的还是编辑参数对话框 https://www.tapd.cn/57709429/s/1601532 