### PR TITLE
fix: 关闭语音开关后清除模型id

### DIFF
--- a/ui/src/views/application/ApplicationSetting.vue
+++ b/ui/src/views/application/ApplicationSetting.vue
@@ -326,7 +326,7 @@
                         <AppIcon iconName="app-warning" class="app-warning-icon"></AppIcon>
                       </el-tooltip> -->
                     </div>
-                    <el-switch size="small" v-model="applicationForm.stt_model_enable" />
+                    <el-switch size="small" v-model="applicationForm.stt_model_enable" @change="sttModelEnableChange"/>
                   </div>
                 </template>
                 <el-select
@@ -406,7 +406,7 @@
                         <el-icon class="mr-4"><Setting /></el-icon>
                         设置
                       </el-button>
-                      <el-switch size="small" v-model="applicationForm.tts_model_enable" />
+                      <el-switch size="small" v-model="applicationForm.tts_model_enable" @change="ttsModelEnableChange"/>
                     </div>
                   </div>
                 </template>
@@ -817,6 +817,19 @@ function ttsModelChange() {
     TTSModeParamSettingDialogRef.value?.reset_default(applicationForm.value.tts_model_id, id)
   } else {
     refreshTTSForm({})
+  }
+}
+
+function ttsModelEnableChange() {
+  if (!applicationForm.value.tts_model_enable) {
+    applicationForm.value.tts_model_id = ''
+    applicationForm.value.tts_type = 'BROWSER'
+  }
+}
+
+function sttModelEnableChange() {
+  if (!applicationForm.value.stt_model_enable) {
+    applicationForm.value.stt_model_id = ''
   }
 }
 

--- a/ui/src/workflow/nodes/base-node/index.vue
+++ b/ui/src/workflow/nodes/base-node/index.vue
@@ -60,7 +60,7 @@
                 <AppIcon iconName="app-warning" class="app-warning-icon"></AppIcon>
               </el-tooltip> -->
             </div>
-            <el-switch size="small" v-model="form_data.stt_model_enable" />
+            <el-switch size="small" v-model="form_data.stt_model_enable" @change="sttModelEnableChange"/>
           </div>
         </template>
 
@@ -141,7 +141,7 @@
                 </el-icon>
                 设置
               </el-button>
-              <el-switch size="small" v-model="form_data.tts_model_enable" />
+              <el-switch size="small" v-model="form_data.tts_model_enable" @change="ttsModelEnableChange"/>
             </div>
           </div>
         </template>
@@ -322,6 +322,20 @@ function ttsModelChange() {
     refreshTTSForm({})
   }
 }
+
+function ttsModelEnableChange() {
+  if (!form_data.value.tts_model_enable) {
+    form_data.value.tts_model_id = ''
+    form_data.value.tts_type = 'BROWSER'
+  }
+}
+
+function sttModelEnableChange() {
+  if (!form_data.value.stt_model_enable) {
+    form_data.value.stt_model_id = ''
+  }
+}
+
 
 const openTTSParamSettingDialog = () => {
   const model_id = form_data.value.tts_model_id


### PR DESCRIPTION
fix: 关闭语音开关后清除模型id  --bug=1047571 --user=刘瑞斌 【github#1376】【应用】在应用处关闭语音模型开关，去模型处删除模型，提示关联了一个应用，无法删除该模型。 https://www.tapd.cn/57709429/s/1601917 