### PR TITLE
fix: 修复fork抓取不全 #1563

### DIFF
--- a/apps/common/util/fork.py
+++ b/apps/common/util/fork.py
@@ -84,17 +84,19 @@ class Fork:
         self.root_url = root_url
 
     def get_child_link_list(self, bf: BeautifulSoup):
-        pattern = "^((?!(http:|https:|tel:/|#|mailto:|javascript:))|" + self.base_fork_url + "|/).*"
+        pattern = "^((?!(http:|https:|tel:/|#|mailto:|javascript:))|" + self.root_url + "|/).*"
         link_list = bf.find_all(name='a', href=re.compile(pattern))
         result = []
         for link in link_list:
             if link.get('href').startswith("/"):
-                result.append(ChildLink(urljoin(self.base_url, link.get('href')), link))
+                urlparsed = urlparse(self.root_url)
+                parsed_root_url = ParseResult(scheme=urlparsed.scheme, netloc=urlparsed.netloc, path='', params='', query='',
+                                             fragment='').geturl()
+                result.append(ChildLink(urljoin(parsed_root_url, link.get('href')), link))
             elif link.get('href').startswith(self.root_url):
                 result.append(ChildLink(link.get('href'), link))
             else:
-                result.append(ChildLink(self.root_url + link.get('href'), link))
-        result = [row for row in result if row.url.startswith(self.base_fork_url)]
+                result.append(ChildLink(self.base_url + link.get('href'), link))
         return result
 
     def get_content_html(self, bf: BeautifulSoup):


### PR DESCRIPTION
#### What this PR does / why we need it?

这个 PR 修复了 #1563 关于 fork 抓取的问题

#### Summary of your change

- 在 fork_child 和 Fork 的构造函数中添加了一个 `root_url` 表示真正的抓取根目录
- 更新 get_child_link_list 的逻辑为：
   - 若链接以 `/` 开头则用 `root_url` 拼接
   - 否则如果链接本身包含 `root_url`，直接添加
   - 否则使用 `base_url` 拼接

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.