### PR TITLE
workflow中增加变量更新节点

### DIFF
--- a/apps/application/flow/step_node/__init__.py
+++ b/apps/application/flow/step_node/__init__.py
@@ -15,9 +15,10 @@ from .direct_reply_node import *
 from .function_lib_node import *
 from .function_node import *
 from .reranker_node import *
+from .variable_update_node import *
 
 node_list = [BaseStartStepNode, BaseChatNode, BaseSearchDatasetNode, BaseQuestionNode, BaseConditionNode, BaseReplyNode,
-             BaseFunctionNodeNode, BaseFunctionLibNodeNode, BaseRerankerNode]
+             BaseFunctionNodeNode, BaseFunctionLibNodeNode, BaseRerankerNode, BaseVariableUpdateNode]
 
 
 def get_node(node_type):

--- a/apps/application/flow/step_node/variable_update_node/__init__.py
+++ b/apps/application/flow/step_node/variable_update_node/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+# @项目：
+# @文件：__init__.py.py
+# @时间：2024/11/5 上午9:39
+# @作者：li-qzh
+# @邮箱：evilstar2015@foxmail.com
+from .impl import *

--- a/apps/application/flow/step_node/variable_update_node/i_variable_update_node.py
+++ b/apps/application/flow/step_node/variable_update_node/i_variable_update_node.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+"""
+    @project: maxkb
+    @Author：虎
+    @file： i_reply_node.py
+    @date：2024/6/11 16:25
+    @desc:
+"""
+from typing import Type
+
+from rest_framework import serializers
+
+from application.flow.i_step_node import INode, NodeResult, chat_cache
+from common.exception.app_exception import AppApiException
+from common.util.field_message import ErrMessage
+
+
+class VariableUpdateNodeParamsSerializer(serializers.Serializer):
+    value_type = serializers.CharField(required=True, error_messages=ErrMessage.char("更新类型，引用变量值/自定义"))
+    fields = serializers.ListField(required=False, error_messages=ErrMessage.list("待变更的变量"))
+    content = serializers.CharField(required=False, allow_blank=True, allow_null=True,
+                                    error_messages=ErrMessage.char("自定义内容"))
+    target_value = serializers.ListField(required=False, error_messages=ErrMessage.char("引用的变量值"))
+
+    def is_valid(self, *, raise_exception=False):
+        super().is_valid(raise_exception=True)
+        if self.data.get('value_type') == 'referencing':
+            if 'fields' not in self.data:
+                raise AppApiException(500, "变量字段不能为空")
+            if len(self.data.get('fields')) < 2:
+                raise AppApiException(500, "变量字段错误")
+            if 'target_value' not in self.data:
+                raise AppApiException(500, "引用的参数不能为空")
+            if len(self.data.get('target_value')) < 2:
+                raise AppApiException(500, "引用的参数错误")
+        else:
+            if 'content' not in self.data or self.data.get('content') is None:
+                raise AppApiException(500, "内容不能为空")
+
+
+class IVariableUpdateNode(INode):
+    type = 'variable-update-node'
+
+    def get_node_params_serializer_class(self) -> Type[serializers.Serializer]:
+        return VariableUpdateNodeParamsSerializer
+
+    def _run(self):
+        return self.execute(**self.node_params_serializer.data, **self.flow_params_serializer.data)
+
+    def execute(self, value_type, stream, fields=None, content=None, target_value=None, **kwargs) -> NodeResult:
+        pass

--- a/apps/application/flow/step_node/variable_update_node/impl/__init__.py
+++ b/apps/application/flow/step_node/variable_update_node/impl/__init__.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+"""
+    @project: maxkb
+    @Author：虎
+    @file： __init__.py
+    @date：2024/6/11 17:49
+    @desc:
+"""
+from .base_variable_update_node import *

--- a/apps/application/flow/step_node/variable_update_node/impl/base_variable_update_node.py
+++ b/apps/application/flow/step_node/variable_update_node/impl/base_variable_update_node.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+"""
+    @project: maxkb
+    @Author：虎
+    @file： base_reply_node.py
+    @date：2024/6/11 17:25
+    @desc:
+"""
+from typing import List
+
+from application.flow.i_step_node import NodeResult
+from application.flow.step_node.variable_update_node.i_variable_update_node import IVariableUpdateNode
+
+
+class BaseVariableUpdateNode(IVariableUpdateNode):
+    def execute(self, value_type, stream, fields=None, content=None, target_value=None, **kwargs) -> NodeResult:
+        if value_type == 'referencing':
+            target_val = self.get_reference_content(target_value)
+        else:
+            target_val = self.generate_customized_content(content)
+
+        self.set_reference_content(fields, target_val)
+        return NodeResult({'result': f'{fields[1]} = {target_val}'}, {fields[1]: target_val})
+
+    def generate_customized_content(self, prompt):
+        return self.workflow_manage.generate_prompt(prompt)
+
+    # 获取参数的值
+    def get_reference_content(self, fields: List[str]):
+        return str(self.workflow_manage.get_reference_field(
+            fields[0],
+            fields[1:]))
+
+    def set_reference_content(self, fields: List[str], target_value: str):
+        self.workflow_manage.set_reference_field(fields[0], fields, target_value)
+        return
+
+    def get_details(self, index: int, **kwargs):
+        return {
+            'name': self.node.properties.get('stepName'),
+            "index": index,
+            'run_time': self.context.get('run_time'),
+            'result': self.context.get('result'),
+            'type': self.node.type,
+            'status': self.status,
+            'err_message': self.err_message
+        }

--- a/apps/application/serializers/chat_message_serializers.py
+++ b/apps/application/serializers/chat_message_serializers.py
@@ -46,12 +46,14 @@ class ChatInfo:
                  dataset_id_list: List[str],
                  exclude_document_id_list: list[str],
                  application: Application,
-                 work_flow_version: WorkFlowVersion = None):
+                 work_flow_version: WorkFlowVersion = None,
+                 form_data: Dict = None):
         """
         :param chat_id:                     对话id
         :param dataset_id_list:             数据集列表
         :param exclude_document_id_list:    排除的文档
         :param application:                 应用信息
+        :param form_data:                   flow中全局变量
         """
         self.chat_id = chat_id
         self.application = application
@@ -59,6 +61,7 @@ class ChatInfo:
         self.exclude_document_id_list = exclude_document_id_list
         self.chat_record_list: List[ChatRecord] = []
         self.work_flow_version = work_flow_version
+        self.form_data = form_data
 
     @staticmethod
     def get_no_references_setting(dataset_setting, model_setting):

--- a/ui/src/components/ai-chat/ExecutionDetailDialog.vue
+++ b/ui/src/components/ai-chat/ExecutionDetailDialog.vue
@@ -233,6 +233,24 @@
                       </div>
                     </div>
                   </template>
+                  <!-- 变量更新 -->
+                  <template v-if="item.type === WorkflowType.VariableUpdate">
+                    <div class="card-never border-r-4">
+                      <h5 class="p-8-12">变量更新</h5>
+                      <div class="p-8-12 border-t-dashed lighter">
+                        <el-scrollbar height="150">
+                          <MdPreview
+                            v-if="item.result"
+                            ref="editorRef"
+                            editorId="preview-only"
+                            :modelValue="item.result"
+                            style="background: none"
+                          />
+                          <template v-else> - </template>
+                        </el-scrollbar>
+                      </div>
+                    </div>
+                  </template>
                 </template>
                 <template v-else>
                   <div class="card-never border-r-4">

--- a/ui/src/enums/workflow.ts
+++ b/ui/src/enums/workflow.ts
@@ -8,5 +8,6 @@ export enum WorkflowType {
   Reply = 'reply-node',
   FunctionLib = 'function-lib-node',
   FunctionLibCustom = 'function-node',
-  RrerankerNode = 'reranker-node'
+  RrerankerNode = 'reranker-node',
+  VariableUpdate = 'variable-update-node'
 }

--- a/ui/src/workflow/common/data.ts
+++ b/ui/src/workflow/common/data.ts
@@ -168,13 +168,33 @@ export const rerankerNode = {
     }
   }
 }
+
+export const variableUpdateNode = {
+  type: WorkflowType.VariableUpdate,
+  text: '可以更新指定节点的输出值或更新全局变量',
+  label: '变量更新',
+  height: 210,
+  properties: {
+    stepName: '变量更新',
+    config: {
+      fields: [
+        {
+          label: '赋值结果',
+          value: 'result'
+        }
+      ]
+    }
+  }
+}
+
 export const menuNodes = [
   aiChatNode,
   searchDatasetNode,
   questionNode,
   conditionNode,
   replyNode,
-  rerankerNode
+  rerankerNode,
+  variableUpdateNode
 ]
 
 /**
@@ -242,7 +262,8 @@ export const nodeDict: any = {
   [WorkflowType.Reply]: replyNode,
   [WorkflowType.FunctionLib]: functionLibNode,
   [WorkflowType.FunctionLibCustom]: functionNode,
-  [WorkflowType.RrerankerNode]: rerankerNode
+  [WorkflowType.RrerankerNode]: rerankerNode,
+  [WorkflowType.VariableUpdate]: variableUpdateNode
 }
 export function isWorkFlow(type: string | undefined) {
   return type === 'WORK_FLOW'

--- a/ui/src/workflow/common/validate.ts
+++ b/ui/src/workflow/common/validate.ts
@@ -4,7 +4,8 @@ const end_nodes: Array<string> = [
   WorkflowType.AiChat,
   WorkflowType.Reply,
   WorkflowType.FunctionLib,
-  WorkflowType.FunctionLibCustom
+  WorkflowType.FunctionLibCustom,
+  WorkflowType.VariableUpdate
 ]
 export class WorkFlowInstance {
   nodes

--- a/ui/src/workflow/icons/variable-update-node-icon.vue
+++ b/ui/src/workflow/icons/variable-update-node-icon.vue
@@ -1,0 +1,4 @@
+<template>
+  <img src="@/assets/icon_globe_color.svg" style="width: 11%" alt="" />
+</template>
+<script setup lang="ts"></script>

--- a/ui/src/workflow/nodes/variable-update-node/index.ts
+++ b/ui/src/workflow/nodes/variable-update-node/index.ts
@@ -1,0 +1,13 @@
+import VariableUpdateNodeVue from './index.vue'
+import { AppNode, AppNodeModel } from '@/workflow/common/app-node'
+
+class VariableUpdateNode extends AppNode {
+  constructor(props: any) {
+    super(props, VariableUpdateNodeVue)
+  }
+}
+export default {
+  type: 'variable-update-node',
+  model: AppNodeModel,
+  view: VariableUpdateNode
+}

--- a/ui/src/workflow/nodes/variable-update-node/index.vue
+++ b/ui/src/workflow/nodes/variable-update-node/index.vue
@@ -1,0 +1,115 @@
+<template>
+  <NodeContainer :nodeModel="nodeModel">
+    <el-card shadow="never" class="card-never" style="--el-card-padding: 12px">
+      <el-form
+        @submit.prevent
+        :model="form_data"
+        label-position="top"
+        require-asterisk-position="right"
+        label-width="auto"
+        ref="variableUpdateNodeFormRef"
+      >
+        <el-form-item label="变量">
+          <NodeCascader
+            ref="nodeCascaderRef"
+            :nodeModel="nodeModel"
+            class="w-full"
+            placeholder="请选择变量"
+            v-model="form_data.fields"
+          />
+        </el-form-item>
+        <el-form-item label="值">
+          <template #label>
+            <div class="flex-between">
+              <span>值</span>
+              <el-select
+                :teleported="false"
+                v-model="form_data.value_type"
+                size="small"
+                style="width: 85px"
+              >
+                <el-option label="引用变量" value="referencing" />
+                <el-option label="自定义" value="content" />
+              </el-select>
+            </div>
+          </template>
+
+          <MdEditorMagnify
+            v-if="form_data.value_type === 'content'"
+            @wheel="wheel"
+            title="变量值"
+            v-model="form_data.content"
+            style="height: 150px"
+            @submitDialog="submitDialog"
+          />
+          <NodeCascader
+            v-else
+            ref="nodeCascaderRef"
+            :nodeModel="nodeModel"
+            class="w-full"
+            placeholder="请选择引用变量"
+            v-model="form_data.target_value"
+          />
+        </el-form-item>
+      </el-form>
+    </el-card>
+  </NodeContainer>
+</template>
+<script setup lang="ts">
+import { set } from 'lodash'
+import NodeContainer from '@/workflow/common/NodeContainer.vue'
+import NodeCascader from '@/workflow/common/NodeCascader.vue'
+import { ref, computed, onMounted } from 'vue'
+
+const props = defineProps<{ nodeModel: any }>()
+
+const wheel = (e: any) => {
+  if (e.ctrlKey === true) {
+    e.preventDefault()
+    return true
+  } else {
+    e.stopPropagation()
+    return true
+  }
+}
+const form = {
+  value_type: 'content',
+  content: '',
+  fields: [],
+  target_value: []
+}
+
+const form_data = computed({
+  get: () => {
+    if (props.nodeModel.properties.node_data) {
+      return props.nodeModel.properties.node_data
+    } else {
+      set(props.nodeModel.properties, 'node_data', form)
+    }
+    return props.nodeModel.properties.node_data
+  },
+  set: (value) => {
+    set(props.nodeModel.properties, 'node_data', value)
+  }
+})
+
+function submitDialog(val: string) {
+  set(props.nodeModel.properties.node_data, 'content', val)
+}
+
+const variableUpdateNodeFormRef = ref()
+const nodeCascaderRef = ref()
+const validate = () => {
+  return Promise.all([
+    nodeCascaderRef.value ? nodeCascaderRef.value.validate() : Promise.resolve(''),
+    variableUpdateNodeFormRef.value?.validate()
+  ]).catch((err: any) => {
+    return Promise.reject({ node: props.nodeModel, errMessage: err })
+  })
+}
+
+onMounted(() => {
+  set(props.nodeModel, 'validate', validate)
+})
+</script>
+<style lang="scss" scoped></style>


### PR DESCRIPTION
# workflow中增加变量更新节点

## 功能说明
1.全局变量存储在chat_cache中
2.flow中使用了变量更新node，会更新全局变量，包括chat_cache、flow上下文
3.star-node启动时，优先读取共享内存中已有的变量 

## 遗留问题
1.当前无默认值的全局变量（form_data）无法传输给后端，因此 使用 “变量更新” 节点的全局变量 必须在入口处设置默认值。
2.前端图片是复用的，需要切一下