### PR TITLE
fix(系统设置): 修复添加已存在的成员失败后，删除该成员，仍不能继续添加的缺陷

### DIFF
--- a/ui/src/views/team/component/CreateMemberDialog.vue
+++ b/ui/src/views/team/component/CreateMemberDialog.vue
@@ -81,12 +81,16 @@ const submitMember = async (formEl: FormInstance | undefined) => {
     if (valid) {
       loading.value = true
       let idsArray = memberForm.value.users.map((obj: any) => obj.id)
-      TeamApi.postCreatTeamMember(idsArray).then((res) => {
-        MsgSuccess('提交成功')
-        emit('refresh', idsArray)
-        dialogVisible.value = false
-        loading.value = false
-      })
+      TeamApi.postCreatTeamMember(idsArray)
+        .then((res) => {
+          MsgSuccess('提交成功')
+          emit('refresh', idsArray)
+          dialogVisible.value = false
+          loading.value = false
+        })
+        .finally(() => {
+          loading.value = false
+        })
     }
   })
 }


### PR DESCRIPTION
fix(系统设置): 修复添加已存在的成员失败后，删除该成员，仍不能继续添加的缺陷  --bug=1049026 --user=王孝刚 【系统设置】团队成员-添加成员时，选中已存在的成员之后再删除，仍不能继续添加 https://www.tapd.cn/57709429/s/1611718 