### PR TITLE
fix: 开启文件上传开关时设置默认值

### DIFF
--- a/apps/application/flow/workflow_manage.py
+++ b/apps/application/flow/workflow_manage.py
@@ -52,7 +52,7 @@ class Node:
             self.__setattr__(keyword, kwargs.get(keyword))
 
 
-end_nodes = ['ai-chat-node', 'reply-node', 'function-node', 'function-lib-node', 'application-node']
+end_nodes = ['ai-chat-node', 'reply-node', 'function-node', 'function-lib-node', 'application-node', 'image-understand-node']
 
 
 class Flow:

--- a/ui/src/workflow/common/validate.ts
+++ b/ui/src/workflow/common/validate.ts
@@ -5,6 +5,7 @@ const end_nodes: Array<string> = [
   WorkflowType.Reply,
   WorkflowType.FunctionLib,
   WorkflowType.FunctionLibCustom,
+  WorkflowType.ImageUnderstandNode,
   WorkflowType.Application
 ]
 export class WorkFlowInstance {

--- a/ui/src/workflow/nodes/base-node/index.vue
+++ b/ui/src/workflow/nodes/base-node/index.vue
@@ -382,8 +382,17 @@ const refreshTTSForm = (data: any) => {
   form_data.value.tts_model_params_setting = data
 }
 
+const default_upload_setting = {
+  maxFiles: 3,
+  fileLimit: 50,
+  document: true,
+  image: false,
+  audio: false,
+  video: false
+}
+
 const openFileUploadSettingDialog = () => {
-  FileUploadSettingDialogRef.value?.open(form_data.value.file_upload_setting)
+  FileUploadSettingDialogRef.value?.open(form_data.value.file_upload_setting || default_upload_setting)
 }
 
 const refreshFileUploadForm = (data: any) => {


### PR DESCRIPTION
fix: 图片理解节点可以作为结束节点  --bug=1049088 --user=刘瑞斌 【应用编排】图片理解模型应该可以作为结束节点 https://www.tapd.cn/57709429/s/1612298<br>fix: 开启文件上传开关时设置默认值  --bug=1049087 --user=刘瑞斌 【应用编排】开启文件上传后，全局变量列表没有自动生成文件变量 https://www.tapd.cn/57709429/s/1612303 