### PR TITLE
fix: 修复模型card上没显示图片理解类型

### DIFF
--- a/ui/src/enums/model.ts
+++ b/ui/src/enums/model.ts
@@ -12,5 +12,6 @@ export enum modelType {
   LLM = '大语言模型',
   STT = '语音识别',
   TTS = '语音合成',
+  IMAGE = '图片理解',
   RERANKER = '重排模型'
 }


### PR DESCRIPTION
fix: 修复模型card上没显示图片理解类型  --bug=1049276 --user=刘瑞斌 [系统管理]模型设置-添加的OpenAI图片理解模型后，模型类型显示为空 https://www.tapd.cn/57709429/s/1614428 