### PR TITLE
style: 设置文本自动换行

### DIFF
--- a/ui/src/views/dataset/component/SetRules.vue
+++ b/ui/src/views/dataset/component/SetRules.vue
@@ -82,7 +82,7 @@
             </div>
           </el-scrollbar>
           <div>
-            <el-checkbox v-model="checkedConnect" @change="changeHandle">
+            <el-checkbox v-model="checkedConnect" @change="changeHandle" style="white-space: normal;">
               导入时添加分段标题为关联问题（适用于标题为问题的问答对）
             </el-checkbox>
           </div>


### PR DESCRIPTION
#### What this PR does / why we need it?

上传文档后进行分段设置的页面中，页面宽度较小的情况下会发生checkbox文本被遮盖。

![image](https://github.com/user-attachments/assets/92361bad-65b1-49cb-a4ad-f8acb8d37206)


#### Summary of your change

修改style，文本自动换行。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.