### PR TITLE
fix: 修复关闭文件上传开关后开始节点没有取消document和image

### DIFF
--- a/ui/src/workflow/nodes/base-node/index.vue
+++ b/ui/src/workflow/nodes/base-node/index.vue
@@ -395,8 +395,8 @@ const switchFileUpload = () => {
 
   if (form_data.value.file_upload_enable) {
     form_data.value.file_upload_setting = form_data.value.file_upload_setting || default_upload_setting
-    props.nodeModel.graphModel.eventCenter.emit('refreshFileUploadConfig')
   }
+  props.nodeModel.graphModel.eventCenter.emit('refreshFileUploadConfig')
 }
 const openFileUploadSettingDialog = () => {
   FileUploadSettingDialogRef.value?.open(form_data.value.file_upload_setting)

--- a/ui/src/workflow/nodes/start-node/index.vue
+++ b/ui/src/workflow/nodes/start-node/index.vue
@@ -65,12 +65,16 @@ const refreshFileUploadConfig = () => {
   let fields = cloneDeep(props.nodeModel.properties.config.fields)
   const form_data = props.nodeModel.graphModel.nodes
     .filter((v: any) => v.id === 'base-node')
+    .filter((v: any) => v.properties.node_data.file_upload_enable)
     .map((v: any) => cloneDeep(v.properties.node_data.file_upload_setting))
     .filter((v: any) => v)
+
+  fields = fields.filter((item: any) => item.value !== 'image' && item.value !== 'document')
+
   if (form_data.length === 0) {
+    set(props.nodeModel.properties.config, 'fields', fields)
     return
   }
-  fields = fields.filter((item: any) => item.value !== 'image' && item.value !== 'document')
   let fileUploadFields = []
   if (form_data[0].document) {
     fileUploadFields.push({ label: '文档', value: 'document' })


### PR DESCRIPTION
fix: 修复关闭文件上传开关后开始节点没有取消document和image  --bug=1049507 --user=刘瑞斌 【应用】应用设置-基本信息中开启文件上传 再关闭，开始节点的参数输出“文档”没有同步删除 https://www.tapd.cn/57709429/s/1617263 