### PR TITLE
refactor: 文档提取details保存content长度限制为500

### DIFF
--- a/apps/application/flow/step_node/document_extract_node/impl/base_document_extract_node.py
+++ b/apps/application/flow/step_node/document_extract_node/impl/base_document_extract_node.py
@@ -40,7 +40,7 @@ class BaseDocumentExtractNode(IDocumentExtractNode):
             "index": index,
             'run_time': self.context.get('run_time'),
             'type': self.node.type,
-            # 'content': self.context.get('content'), # 不保存content内容，因为content内容可能会很大
+            'content': self.context.get('content')[:500] + '...', # 不保存content全部内容，因为content内容可能会很大
             'status': self.status,
             'err_message': self.err_message,
             'document_list': self.context.get('document_list')

--- a/ui/src/components/ai-chat/ExecutionDetailDialog.vue
+++ b/ui/src/components/ai-chat/ExecutionDetailDialog.vue
@@ -218,7 +218,16 @@
                   <!-- 文档内容提取 -->
                   <template v-if="item.type === WorkflowType.DocumentExtractNode">
                     <div class="card-never border-r-4">
-                      <h5 class="p-8-12">参数输出</h5>
+                      <h5 class="p-8-12">
+                        参数输出
+                        <el-tooltip
+                            effect="dark"
+                            content="每个文档仅支持预览500字"
+                            placement="right"
+                        >
+                          <AppIcon iconName="app-warning" class="app-warning-icon"></AppIcon>
+                        </el-tooltip>
+                      </h5>
                       <div class="p-8-12 border-t-dashed lighter">
                         <el-scrollbar height="150">
                           <MdPreview


### PR DESCRIPTION
refactor: 文档提取details保存content长度限制为500 