### PR TITLE
fix: 修复文件配置全没勾选的情况下还能上传文件的问题

### DIFF
--- a/ui/src/components/ai-chat/component/chat-input-operate/index.vue
+++ b/ui/src/components/ai-chat/component/chat-input-operate/index.vue
@@ -217,6 +217,9 @@ const getAcceptList = () => {
     accepts = [...accepts, ...videoExtensions]
   }
   // console.log(accepts)
+  if (accepts.length === 0) {
+    return '.请在文件上传配置中选择文件类型'
+  }
   return accepts.map((ext: any) => '.' + ext).join(',')
 }
 


### PR DESCRIPTION
fix: 修复文件配置全没勾选的情况下还能上传文件的问题  --bug=1049620 --user=刘瑞斌 【应用编排】文件上传设置没勾选文档也没勾选图片，发布后对话还是能上传文档和图片 https://www.tapd.cn/57709429/s/1618519 