### PR TITLE
fix: 修复引用分段详情弹框和执行详情里的文档名称不能点的缺陷

### DIFF
--- a/ui/src/components/ai-chat/KnowledgeSource.vue
+++ b/ui/src/components/ai-chat/KnowledgeSource.vue
@@ -20,7 +20,12 @@
                 </div>
                 <div class="ml-8" v-else>
                   <a
-                    @click="openLink(item.source_url)"
+                    :href="
+                      item.source_url && !item.source_url.endsWith('/')
+                        ? item.source_url + '/'
+                        : item.source_url
+                    "
+                    target="_blank"
                     class="ellipsis"
                     :title="item?.document_name?.trim()"
                   >
@@ -98,14 +103,6 @@ const uniqueParagraphList = computed(() => {
     }) || []
   )
 })
-
-function openLink(url: string) {
-  // 如果url不是以/结尾，加上/
-  if (url && !url.endsWith('/')) {
-    url += '/'
-  }
-  window.open(url, '_blank')
-}
 </script>
 <style lang="scss" scoped>
 .source_dataset-button {

--- a/ui/src/components/ai-chat/component/ParagraphCard.vue
+++ b/ui/src/components/ai-chat/component/ParagraphCard.vue
@@ -20,9 +20,25 @@
         <el-text class="flex align-center" style="width: 70%">
           <img :src="getImgUrl(data?.document_name?.trim())" alt="" width="20" class="mr-4" />
 
-          <span class="ellipsis" :title="data?.document_name?.trim()">
-            {{ data?.document_name.trim() }}</span
-          >
+          <template v-if="meta?.source_url">
+            <a
+              :href="
+                meta?.source_url && !meta?.source_url.endsWith('/')
+                  ? meta?.source_url + '/'
+                  : meta?.source_url
+              "
+              target="_blank"
+              class="ellipsis"
+              :title="data?.document_name?.trim()"
+            >
+              {{ data?.document_name?.trim() }}
+            </a>
+          </template>
+          <template v-else>
+            <span class="ellipsis" :title="data?.document_name?.trim()">
+              {{ data?.document_name?.trim() }}
+            </span>
+          </template>
         </el-text>
         <div class="flex align-center" style="line-height: 32px">
           <AppAvatar class="mr-8 avatar-blue" shape="square" :size="18">
@@ -37,6 +53,8 @@
 </template>
 <script setup lang="ts">
 import { getImgUrl } from '@/utils/utils'
+import { computed } from 'vue'
+
 const props = defineProps({
   data: {
     type: Object,
@@ -47,11 +65,22 @@ const props = defineProps({
     default: 0
   }
 })
+const isMetaObject = computed(() => typeof props.data.meta === 'object')
+const parsedMeta = computed(() => {
+  try {
+    return JSON.parse(props.data.meta)
+  } catch (e) {
+    return {}
+  }
+})
+
+const meta = computed(() => (isMetaObject.value ? props.data.meta : parsedMeta.value))
 </script>
 <style lang="scss" scoped>
 .paragraph-source-card-height {
   height: 260px;
 }
+
 @media only screen and (max-width: 768px) {
   .paragraph-source-card-height {
     height: 285px;


### PR DESCRIPTION
fix: 修复引用分段详情弹框和执行详情里的文档名称不能点的缺陷  --bug=1049682 --user=王孝刚 【应用】引用分段详情弹框和执行详情里的文档名称不能点 https://www.tapd.cn/57709429/s/1619877 