### PR TITLE
fix: 上传文本文件去掉csv

### DIFF
--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -38,7 +38,7 @@ export function fileType(name: string) {
   获得文件对应图片
 */
 const typeList: any = {
-  txt: ['txt', 'pdf', 'docx', 'csv', 'md', 'html'],
+  txt: ['txt', 'pdf', 'docx', 'md', 'html'],
   table: ['xlsx', 'xls', 'csv'],
   QA: ['xlsx', 'csv', 'xls']
 }

--- a/ui/src/views/dataset/component/UploadComponent.vue
+++ b/ui/src/views/dataset/component/UploadComponent.vue
@@ -129,7 +129,7 @@
         action="#"
         :auto-upload="false"
         :show-file-list="false"
-        accept=".txt, .md, .csv, .log, .docx, .pdf, .html"
+        accept=".txt, .md, .log, .docx, .pdf, .html"
         :limit="50"
         :on-exceed="onExceed"
         :on-change="fileHandleChange"


### PR DESCRIPTION
fix: 上传文本文件去掉csv  --bug=1049721 --user=刘瑞斌 【知识库】上传文本文件夹，里面包含csv文件，csv文件也能上传成功 https://www.tapd.cn/57709429/s/1620432 