### PR TITLE
refactor: 添加参数时单选、多选、选项卡设置第一个条目

### DIFF
--- a/ui/src/components/dynamics-form/constructor/items/MultiSelectConstructor.vue
+++ b/ui/src/components/dynamics-form/constructor/items/MultiSelectConstructor.vue
@@ -116,6 +116,8 @@ defineExpose({ getData, rander })
 onMounted(() => {
   formValue.value.option_list = []
   formValue.value.default_value = ''
+
+  addOption()
 })
 </script>
 <style lang="scss" scoped>

--- a/ui/src/components/dynamics-form/constructor/items/RadioCardConstructor.vue
+++ b/ui/src/components/dynamics-form/constructor/items/RadioCardConstructor.vue
@@ -109,6 +109,8 @@ defineExpose({ getData, rander })
 onMounted(() => {
   formValue.value.option_list = []
   formValue.value.default_value = ''
+
+  addOption()
 })
 </script>
 <style lang="scss" scoped>

--- a/ui/src/components/dynamics-form/constructor/items/RadioRowConstructor.vue
+++ b/ui/src/components/dynamics-form/constructor/items/RadioRowConstructor.vue
@@ -110,6 +110,8 @@ defineExpose({ getData, rander })
 onMounted(() => {
   formValue.value.option_list = []
   formValue.value.default_value = ''
+
+  addOption()
 })
 </script>
 <style lang="scss" scoped>

--- a/ui/src/components/dynamics-form/constructor/items/SingleSelectConstructor.vue
+++ b/ui/src/components/dynamics-form/constructor/items/SingleSelectConstructor.vue
@@ -108,6 +108,8 @@ defineExpose({ getData, rander })
 onMounted(() => {
   formValue.value.option_list = []
   formValue.value.default_value = ''
+
+  addOption()
 })
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
refactor: 添加参数时单选、多选、选项卡设置第一个条目  --bug=1049778 --user=刘瑞斌 【表单收集】- 组件类型选择单选框、多选框、选项卡、单行选项卡后，默认显示一行选项值。 https://www.tapd.cn/57709429/s/1621602 