### PR TITLE
fix: 修复批量导入网页地址swagger上没有填写请求体的地方的缺陷

### DIFF
--- a/apps/dataset/serializers/document_serializers.py
+++ b/apps/dataset/serializers/document_serializers.py
@@ -143,6 +143,18 @@ class DocumentWebInstanceSerializer(ApiMixin, serializers.Serializer):
                                   required=True,
                                   description='知识库id'),
                 ]
+    @staticmethod
+    def get_request_body_api():
+        return openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            required=['source_url_list'],
+            properties={
+                'source_url_list': openapi.Schema(type=openapi.TYPE_ARRAY, title="文档地址列表", description="文档地址列表",
+                                                  items=openapi.Schema(type=openapi.TYPE_STRING)),
+                'selector': openapi.Schema(type=openapi.TYPE_STRING, title="选择器", description="选择器")
+            }
+        )
+
 
 
 class DocumentInstanceSerializer(ApiMixin, serializers.Serializer):


### PR DESCRIPTION
fix: 修复批量导入网页地址swagger上没有填写请求体的地方的缺陷  --bug=1050206 --user=王孝刚 【github#1809】【知识库】web知识库，批量导入网页地址时，抓到的接口有请求体，但是swagger上没有填写请求体的地方。 https://www.tapd.cn/57709429/s/1628286 