### PR TITLE
fix: Open add model dialog show base-info always

### DIFF
--- a/ui/src/views/template/component/CreateModelDialog.vue
+++ b/ui/src/views/template/component/CreateModelDialog.vue
@@ -317,6 +317,7 @@ const open = (provider: Provider) => {
   })
   providerValue.value = provider
   dialogVisible.value = true
+  activeName.value = 'base-info'
 }
 
 const list_base_model = (model_type: any, change?: boolean) => {


### PR DESCRIPTION
fix: Open add model dialog show base-info always  --bug=1050670 --user=刘瑞斌 【系统管理】模型设置-添加模型-默认显示了“高级设置”标签页 https://www.tapd.cn/57709429/s/1635004 