### PR TITLE
fix: tts node add a prompt with empty text

### DIFF
--- a/apps/common/util/common.py
+++ b/apps/common/util/common.py
@@ -214,6 +214,8 @@ def split_and_transcribe(file_path, model, max_segment_length_ms=59000, audio_fo
 
 
 def _remove_empty_lines(text):
+    if not text:
+        raise AppApiException(500, '文本转语音节点，文本内容不能为空')
     result = '\n'.join(line for line in text.split('\n') if line.strip())
     return markdown_to_plain_text(result)
 


### PR DESCRIPTION
fix: tts node add a prompt with empty text  --bug=1050887 --user=王孝刚 【应用编排】知识库检索节点为空，走到文本转语音节点会报错 https://www.tapd.cn/57709429/s/1637596 