### PR TITLE
fix: fix hunyuan-functioncall edit faild

### DIFF
--- a/apps/setting/models_provider/impl/tencent_model_provider/tencent_model_provider.py
+++ b/apps/setting/models_provider/impl/tencent_model_provider/tencent_model_provider.py
@@ -59,7 +59,7 @@ def _initialize_model_info():
             TencentLLMModelCredential,
             TencentModel),
         _create_model_info(
-            'hunyuan-functioncall ',
+            'hunyuan-functioncall',
             '混元最新 MOE 架构 FunctionCall 模型，经过高质量的 FunctionCall 数据训练，上下文窗口达 32K，在多个维度的评测指标上处于领先。',
             ModelTypeConst.LLM,
             TencentLLMModelCredential,


### PR DESCRIPTION
fix: fix hunyuan-functioncall edit faild  --bug=1051010 --user=刘瑞斌 【模型设置】修改腾讯混元的大语言模型为 hunyuan-functioncall 模型失败，提示模型不存在 https://www.tapd.cn/57709429/s/1639072 