### PR TITLE
fix: text to speech doc show request body

### DIFF
--- a/apps/application/swagger_api/application_api.py
+++ b/apps/application/swagger_api/application_api.py
@@ -401,3 +401,25 @@ Question:
                                       description=_('Application ID')),
 
                     ]
+
+    class TextToSpeech(ApiMixin):
+        @staticmethod
+        def get_request_params_api():
+            return [openapi.Parameter(name='application_id',
+                                      in_=openapi.IN_PATH,
+                                      type=openapi.TYPE_STRING,
+                                      required=True,
+                                      description=_('Application ID')),
+
+                    ]
+
+        @staticmethod
+        def get_request_body_api():
+            return openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                required=[],
+                properties={
+                    'text': openapi.Schema(type=openapi.TYPE_STRING, title=_("Text"),
+                                           description=_("Text")),
+                }
+            )

--- a/apps/application/views/application_views.py
+++ b/apps/application/views/application_views.py
@@ -629,6 +629,12 @@ class Application(APIView):
         authentication_classes = [TokenAuth]
 
         @action(methods=['POST'], detail=False)
+        @swagger_auto_schema(operation_summary=_("text to speech"),
+                             operation_id=_("text to speech"),
+                             manual_parameters=ApplicationApi.TextToSpeech.get_request_params_api(),
+                             request_body=ApplicationApi.TextToSpeech.get_request_body_api(),
+                             responses=result.get_default_response(),
+                             tags=[_('Application')])
         @has_permissions(
             ViewPermission([RoleConstants.ADMIN, RoleConstants.USER, RoleConstants.APPLICATION_ACCESS_TOKEN],
                            [lambda r, keywords: Permission(group=Group.APPLICATION,


### PR DESCRIPTION
fix: text to speech doc show request body  【【github#2032 】【swagger 文档】/api/application/application_id/text to_speech 接口缺少文件上传的入口参数】 https://www.tapd.cn/57709429/bugtrace/bugs/view/1157709429001051530 