### PR TITLE
fix: Fix new chat cannot load document_image

### DIFF
--- a/ui/src/components/ai-chat/index.vue
+++ b/ui/src/components/ai-chat/index.vue
@@ -185,9 +185,9 @@ const openChatId: () => Promise<string> = () => {
 /**
  * 对话
  */
-function getChartOpenId(chat?: any) {
+function getChartOpenId(chat?: any, problem?: string, re_chat?: boolean, other_params_data?: any) {
   return openChatId().then(() => {
-    chatMessage(chat)
+    chatMessage(chat, problem, re_chat, other_params_data)
   })
 }
 
@@ -317,7 +317,7 @@ function chatMessage(chat?: any, problem?: string, re_chat?: boolean, other_para
     ChatManagement.write(chat.id)
   }
   if (!chartOpenId.value) {
-    getChartOpenId(chat).catch(() => {
+    getChartOpenId(chat, problem, re_chat, other_params_data).catch(() => {
       errorWrite(chat)
     })
   } else {


### PR DESCRIPTION
fix: Fix new chat cannot load document_image  --bug=1051402 --user=刘瑞斌 【github#2008】【应用编排】应用演示页面新建对话后再次上传文档，无法读取文档内容 https://www.tapd.cn/57709429/s/1648617 