### PR TITLE
chore: refine UI text consistency and translation accuracy for Knowledge

### DIFF
--- a/ui/src/locales/lang/en-US/common.ts
+++ b/ui/src/locales/lang/en-US/common.ts
@@ -26,7 +26,7 @@ export default {
   professional: 'Purchase the Professional Edition',
   createDate: 'Create Date',
   createTime: 'Create Time',
-  operation: 'Operation',
+  operation: 'Action',
   character: 'characters',
   export: 'Export',
   exportSuccess: 'Successful',

--- a/ui/src/locales/lang/en-US/views/application.ts
+++ b/ui/src/locales/lang/en-US/views/application.ts
@@ -203,9 +203,9 @@ export default {
     copyUrl: 'Copy the link and fill it in'
   },
   hitTest: {
-    title: 'Retrieval Test',
-    text: 'Ensure effective response by matching segments to user inquiries.',
-    emptyMessage1: 'The matching segment is displayed here',
+    title: 'Retrieval Testing',
+    text: 'Test the hitting effect of the Knowledge based on the given query text.',
+    emptyMessage1: 'Retrieval Testing results will show here',
     emptyMessage2: 'No matching sections found'
   }
 }

--- a/ui/src/locales/lang/en-US/views/dataset.ts
+++ b/ui/src/locales/lang/en-US/views/dataset.ts
@@ -27,7 +27,7 @@ export default {
   },
   datasetForm: {
     title: {
-      info: 'Basic Information'
+      info: 'Knowledge settings'
     },
     form: {
       datasetName: {

--- a/ui/src/locales/lang/en-US/views/problem.ts
+++ b/ui/src/locales/lang/en-US/views/problem.ts
@@ -2,7 +2,7 @@ export default {
   title: 'Questions',
   createProblem: 'Create Question',
   detailProblem: 'Question Details',
-  quickCreateProblem: 'Quick Create Question',
+  quickCreateProblem: 'Quick Create',
   quickCreateName: 'question',
   tip: {
     placeholder: 'Enter the question, support multiple entries, one per line.',
@@ -12,14 +12,14 @@ export default {
   },
 
   setting: {
-    batchDelete: 'Batch Delete',
+    batchDelete: 'Bulk Delete',
     cancelRelated: 'Cancel Association'
   },
   searchBar: {
     placeholder: 'Search by name'
   },
   table: {
-    paragraph_count: 'Associated Segments',
+    paragraph_count: 'Linked Segments',
     updateTime: 'Update Time'
   },
   delete: {
@@ -28,10 +28,10 @@ export default {
     confirmMessage2: 'segments. Please proceed with caution.'
   },
   relateParagraph: {
-    title: 'Associate Segments',
-    selectDocument: 'Select Document',
-    placeholder: 'Search by document name',
-    selectParagraph: 'Select Segment',
+    title: 'Link to Segment',
+    selectDocument: 'Select a Document',
+    placeholder: 'Search document by name',
+    selectParagraph: 'Select Segments',
     selectedParagraph: 'Selected Segments',
     count: 'Count'
   }


### PR DESCRIPTION
#### What this PR does / why we need it?

This PR refines inconsistent and unnatural English translations in the UI. 
The focus was on improving clarity and fluency in areas where the original Chinese translations sounded unnatural in English. 
Only the Chinese-to-English translations were reviewed and adjusted, ensuring better readability and consistency across the interface.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.