### PR TITLE
chore(i18n): unify "Relate" as the standard term for knowledge

### DIFF
--- a/ui/src/locales/lang/en-US/views/document.ts
+++ b/ui/src/locales/lang/en-US/views/document.ts
@@ -168,7 +168,7 @@ export default {
     successMessage: 'Successful',
     tip1: 'The {data} in the prompt is a placeholder for segmented content, which is replaced by the segmented content when executed and sent to the AI model;',
     tip2: 'The AI model generates relevant questions based on the segmented content. Please place the generated questions within the',
-    tip3: 'tags, and the system will automatically associate the questions within these tags;',
+    tip3: 'tags, and the system will automatically relate the questions within these tags;',
     tip4: 'The generation effect depends on the selected model and prompt. Users can adjust to achieve the best effect.',
     prompt1:
       'Content: {data}\n \n Please summarize the above content and generate a summary based on the content 5 a question. \nAnswer requirements: \n - Please output only questions; \n - Please place each question in',

--- a/ui/src/locales/lang/en-US/views/problem.ts
+++ b/ui/src/locales/lang/en-US/views/problem.ts
@@ -19,7 +19,7 @@ export default {
     placeholder: 'Search by name'
   },
   table: {
-    paragraph_count: 'Linked Segments',
+    paragraph_count: 'Related Segments',
     updateTime: 'Update Time'
   },
   delete: {
@@ -28,7 +28,7 @@ export default {
     confirmMessage2: 'segments. Please proceed with caution.'
   },
   relateParagraph: {
-    title: 'Link to Segment',
+    title: 'Relate to Segment',
     selectDocument: 'Select a Document',
     placeholder: 'Search document by name',
     selectParagraph: 'Select Segments',


### PR DESCRIPTION
#### What this PR does / why we need it?

When questions or segments are semantically or logically related, using 'Relate' is more appropriate than 'Link' or 'Associate,' as it better conveys the intended relationship

- Replaced "Link to Segment" → "Relate to Segment" for better clarity.
- Updated "Linked Segments" → "Related Segments" to ensure consistent terminology.

/release-note-none

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.