### PR TITLE
chore(i18n): simplify tab group titles by removing redundant Settings

### DIFF
--- a/ui/src/locales/lang/zh-CN/views/system.ts
+++ b/ui/src/locales/lang/zh-CN/views/system.ts
@@ -7,7 +7,7 @@ export default {
   authentication: {
     title: '登录认证',
     ldap: {
-      title: 'LDAP 设置',
+      title: 'LDAP',
       address: 'LDAP 地址',
       serverPlaceholder: '请输入LDAP 地址',
       bindDN: '绑定DN',
@@ -21,7 +21,7 @@ export default {
       enableAuthentication: '启用 LDAP 认证'
     },
     cas: {
-      title: 'CAS 设置',
+      title: 'CAS',
       ldpUri: 'ldpUri',
       ldpUriPlaceholder: '请输入ldpUri',
       validateUrl: '验证地址',
@@ -31,7 +31,7 @@ export default {
       enableAuthentication: '启用 CAS 认证'
     },
     oidc: {
-      title: 'OIDC 设置',
+      title: 'OIDC',
       authEndpoint: '授权端地址',
       authEndpointPlaceholder: '请输入授权端地址',
       tokenEndpoint: 'Token端地址',
@@ -50,7 +50,7 @@ export default {
     },
 
     oauth2: {
-      title: 'OAuth2 设置',
+      title: 'OAuth2',
       authEndpoint: '授权端地址',
       authEndpointPlaceholder: '请输入授权端地址',
       tokenEndpoint: 'Token 端地址',

--- a/ui/src/locales/lang/zh-Hant/views/system.ts
+++ b/ui/src/locales/lang/zh-Hant/views/system.ts
@@ -7,7 +7,7 @@ export default {
   authentication: {
     title: '登入認證',
     ldap: {
-      title: 'LDAP 設定',
+      title: 'LDAP',
       address: 'LDAP 位址',
       serverPlaceholder: '請輸入LDAP 位址',
       bindDN: '綁定DN',
@@ -22,7 +22,7 @@ export default {
       enableAuthentication: '啟用 LDAP 認證'
     },
     cas: {
-      title: 'CAS 設定',
+      title: 'CAS',
       ldpUri: 'ldpUri',
       ldpUriPlaceholder: '請輸入ldpUri',
       validateUrl: '驗證位址',
@@ -32,7 +32,7 @@ export default {
       enableAuthentication: '啟用 CAS 認證'
     },
     oidc: {
-      title: 'OIDC 設定',
+      title: 'OIDC',
       authEndpoint: '授權端位址',
       authEndpointPlaceholder: '請輸入授權端位址',
       tokenEndpoint: 'Token端位址',
@@ -51,7 +51,7 @@ export default {
     },
 
     oauth2: {
-      title: 'OAuth2 設定',
+      title: 'OAuth2',
       authEndpoint: '授權端位址',
       authEndpointPlaceholder: '請輸入授權端位址',
       tokenEndpoint: 'Token 端位址',


### PR DESCRIPTION
#### What this PR does / why we need it?
simplify tab group titles by removing redundant "设置”

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.