### PR TITLE
fix: Fix xinference cannot add deepseek-vl-chat model

### DIFF
--- a/apps/setting/models_provider/impl/base_chat_open_ai.py
+++ b/apps/setting/models_provider/impl/base_chat_open_ai.py
@@ -104,7 +104,7 @@ class BaseChatOpenAI(ChatOpenAI):
                 if generation_chunk.message.usage_metadata is not None:
                     self.usage_metadata = generation_chunk.message.usage_metadata
                 # custom code
-                if 'reasoning_content' in chunk['choices'][0]['delta']:
+                if len(chunk['choices']) > 0 and 'reasoning_content' in chunk['choices'][0]['delta']:
                     generation_chunk.message.additional_kwargs["reasoning_content"] = chunk['choices'][0]['delta'][
                         'reasoning_content']
 


### PR DESCRIPTION
fix: Fix xinference cannot add deepseek-vl-chat model  --bug=1052077 --user=刘瑞斌 【github#2051】【模型管理】xinference添加issue中提供的视觉模型失败 https://www.tapd.cn/57709429/s/1652171 