### PR TITLE
chore(i18n): add missing translation for "edition" in about dialog

### DIFF
--- a/ui/src/layout/components/top-bar/avatar/AboutDialog.vue
+++ b/ui/src/layout/components/top-bar/avatar/AboutDialog.vue
@@ -23,7 +23,8 @@
         >
       </div>
       <div class="flex">
-        <span class="label">{{ $t('layout.about.edition') }}</span><span>{{ user.showXpack() ? '专业版' : '社区版' }}</span>
+        <span class="label">{{ $t('layout.about.edition.label') }}</span>
+        <span>{{ user.showXpack() ? $t('layout.about.edition.professional') : $t('layout.about.edition.community') }}</span>
       </div>
       <div class="flex">
         <span class="label">{{ $t('layout.about.version') }}</span><span>{{ user.version }}</span>

--- a/ui/src/locales/lang/en-US/layout.ts
+++ b/ui/src/locales/lang/en-US/layout.ts
@@ -10,12 +10,17 @@ export default {
   about: {
     title: 'About',
     expiredTime: 'Expiration Date',
-    edition: 'Edition',
+    edition: {
+      label: 'Edition',
+      community: 'Community Edition',
+      professional: 'Professional Edition'
+    },
     version: 'Version',
     serialNo: 'Serial No.',
     remark: 'Remarks',
     update: 'Update',
-    authorize: 'Authorized'
+    authorize: 'Authorized',
+    
   },
   time: {
     daysLater: 'days later',

--- a/ui/src/locales/lang/zh-CN/layout.ts
+++ b/ui/src/locales/lang/zh-CN/layout.ts
@@ -10,7 +10,11 @@ export default {
   about: {
     title: '关于',
     expiredTime: '到期时间',
-    edition: '版本',
+    edition: {
+      label: '版本',
+      community: '社区版',
+      professional: '专业版'
+    },
     version: '版本号',
     serialNo: '序列号',
     remark: '备注',

--- a/ui/src/locales/lang/zh-Hant/layout.ts
+++ b/ui/src/locales/lang/zh-Hant/layout.ts
@@ -11,7 +11,11 @@ export default {
   about: {
     title: '關於',
     expiredTime: '到期時間',
-    edition: '版本',
+    edition: {
+      label: '版本',
+      community: '社群版',
+      professional: '專業版'
+    },
     version: '版本號',
     serialNo: '序列號',
     remark: '備註',


### PR DESCRIPTION
#### What this PR does / why we need it?
Add missing translation for "edition" in about dialog

<img width="618" alt="image" src="https://github.com/user-attachments/assets/92c5f81e-7a03-4373-846d-2cc4d2314b30" />

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.