### PR TITLE
fix: No error message prompted after QR code failure

### DIFF
--- a/ui/src/views/login/components/dingtalkQrCode.vue
+++ b/ui/src/views/login/components/dingtalkQrCode.vue
@@ -80,6 +80,7 @@ const errorShown = ref(false)
 const initActive = async () => {
   try {
     await load(true)
+    errorShown.value = false
     if (!isConfigReady.value) {
       return
     }
@@ -116,7 +117,7 @@ const initActive = async () => {
       (errorMsg: string) => {
         if (!errorShown.value) {
           MsgError(errorMsg)
-          errorShown.value = true // 设置标志位为 true，表示错误已经显示过
+          errorShown.value = true
         }
       }
     )


### PR DESCRIPTION
fix: No error message prompted after QR code failure  --bug=1052150 --user=王孝刚 【系统设置】钉钉二维码失效后，点击刷新，使用非当前组织的用户扫码登录，没有弹错误提示 https://www.tapd.cn/57709429/s/1653901 