### PR TITLE
perf: optimize embed mode

### DIFF
--- a/ui/src/views/chat/embed/index.vue
+++ b/ui/src/views/chat/embed/index.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="chat-embed layout-bg"
+    :class="{ 'chat-embed--popup': isPopup }"
     v-loading="loading"
     :style="{
       '--el-color-primary': applicationDetail?.custom_theme?.theme_color,
@@ -116,11 +117,16 @@
 </template>
 <script setup lang="ts">
 import { ref, onMounted, reactive, nextTick, computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { isAppIcon } from '@/utils/application'
 import { hexToRgba } from '@/utils/theme'
 import useStore from '@/stores'
 const { user, log } = useStore()
+const route = useRoute()
 
+const isPopup = computed(() => {
+  return route.query.popup !== 'no'
+})
 const AiChatRef = ref()
 const loading = ref(false)
 const left_loading = ref(false)
@@ -303,8 +309,13 @@ onMounted(() => {
     z-index: 2009;
     position: absolute;
     top: 16px;
-    right: 85px;
+    right: 16px;
     font-size: 22px;
+  }
+  &.chat-embed--popup{
+    .chat-popover-button {
+      right: 85px;
+    }
   }
   .chat-popover-mask {
     background-color: var(--el-overlay-color-lighter);


### PR DESCRIPTION
#### What this PR does / why we need it?

When embedding with `http://localhost:3000/ui/chat/{token}?mode=embed` into a third party, there should be no space left in the top right corner. The position of the history button is incorrect. I expect the display to be optimized for standalone embedding.

#### Summary of your change
I've added a route parameter `?mode=embed&popup=no` to determine whether the content is displayed in a popup. There is no impact on the Floating Mode.

![1739964046754](https://github.com/user-attachments/assets/2f8a7415-7ba1-4570-a088-c4bf37ce42e6)

```plain
<!-- before -->
http://localhost:3000/ui/chat/{token}?mode=embed
<!-- after -->
http://localhost:3000/ui/chat/{token}?mode=embed&popup=no
```

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.