### PR TITLE
fix: Child application node, input parameters too long, error reported during Q&A

### DIFF
--- a/apps/application/flow/step_node/application_node/impl/base_application_node.py
+++ b/apps/application/flow/step_node/application_node/impl/base_application_node.py
@@ -174,7 +174,7 @@ class BaseApplicationNode(IApplicationNode):
         current_chat_id = string_to_uuid(chat_id + application_id)
         Chat.objects.get_or_create(id=current_chat_id, defaults={
             'application_id': application_id,
-            'abstract': message
+            'abstract': message[0:1024]
         })
         if app_document_list is None:
             app_document_list = []


### PR DESCRIPTION
fix: Child application node, input parameters too long, error reported during Q&A 