### PR TITLE
fix: Remove vllm image cache

### DIFF
--- a/apps/setting/models_provider/impl/vllm_model_provider/model/image.py
+++ b/apps/setting/models_provider/impl/vllm_model_provider/model/image.py
@@ -18,3 +18,6 @@ class VllmImage(MaxKBBaseModel, BaseChatOpenAI):
             stream_usage=True,
             **optional_params,
         )
+
+    def is_cache_model(self):
+        return False


### PR DESCRIPTION
fix: Remove vllm image cache  --bug=1052365 --user=刘瑞斌 【github#2353】vllm视觉模型修改最大tokens不生效 https://www.tapd.cn/57709429/s/1657667 