### PR TITLE
fix: Fix user input table title not changed

### DIFF
--- a/ui/src/workflow/nodes/base-node/component/UserInputFieldTable.vue
+++ b/ui/src/workflow/nodes/base-node/component/UserInputFieldTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex-between mb-16">
-    <h5 class="lighter">{{ $t('chat.userInput') }}</h5>
+    <h5 class="lighter">{{ inputFieldConfig.title }}</h5>
     <div>
       <el-button type="primary" link @click="openChangeTitleDialog">
         <el-icon>


### PR DESCRIPTION
fix: Fix user input table title not changed  --bug=1052676 --user=刘瑞斌 【应用】高级编排-设置-基本信息-修改用户输入标题后保存-未更新-再次进入后仍展示用户输入 https://www.tapd.cn/57709429/s/1661083 