### PR TITLE
fix: Fix default_value not show when image model changed

### DIFF
--- a/ui/src/components/dynamics-form/index.vue
+++ b/ui/src/components/dynamics-form/index.vue
@@ -179,7 +179,12 @@ const render = (
     const value = formFieldList.value
       .map((item) => {
         if (form_data[item.field] !== undefined) {
-          return { [item.field]: form_data[item.field] }
+          const v: any = item.option_list?.filter(i => i.value_field === form_data[item.field])
+          if (v?.length > 0) {
+            return { [item.field]: form_data[item.field] };
+          } else {
+            return { [item.field]: item.default_value };
+          }
         }
         if (item.show_default_value === true || item.show_default_value === undefined) {
           return { [item.field]: item.default_value }


### PR DESCRIPTION
fix: Fix default_value not show when image model changed  --bug=1052695 --user=刘瑞斌 【应用】高级编排-设置-图片生成组件-切换模型后图片尺寸为空-未同步切换到当前模型的首个尺寸 https://www.tapd.cn/57709429/s/1661346 