### PR TITLE
fix: simplify inputFieldConfig handling in UserInputFieldTable

### DIFF
--- a/ui/src/workflow/nodes/base-node/component/UserInputFieldTable.vue
+++ b/ui/src/workflow/nodes/base-node/component/UserInputFieldTable.vue
@@ -168,7 +168,7 @@ function refreshFieldTitle(data: any) {
   inputFieldConfig.value = data
   UserInputTitleDialogRef.value.close()
 
-  console.log('inputFieldConfig', inputFieldConfig.value)
+  // console.log('inputFieldConfig', inputFieldConfig.value)
 }
 
 const getDefaultValue = (row: any) => {
@@ -245,6 +245,9 @@ onMounted(() => {
     }
   })
   set(props.nodeModel.properties, 'user_input_field_list', inputFieldList)
+  if (props.nodeModel.properties.user_input_config) {
+    inputFieldConfig.value = props.nodeModel.properties.user_input_config
+  }
   set(props.nodeModel.properties, 'user_input_config', inputFieldConfig)
   onDragHandle()
 })


### PR DESCRIPTION
fix: simplify inputFieldConfig handling in UserInputFieldTable  --bug=1052676 --user=刘瑞斌 【应用】高级编排-设置-基本信息-修改用户输入标题后保存-未更新-再次进入后仍展示用户输入 https://www.tapd.cn/57709429/s/1662577 