### PR TITLE
fix: When asker is empty, do not pass the current parameter

### DIFF
--- a/ui/src/components/ai-chat/component/user-form/index.vue
+++ b/ui/src/components/ai-chat/component/user-form/index.vue
@@ -323,7 +323,10 @@ const checkInputParam = () => {
     }
   }
   if (!api_form_data_context.value['asker']) {
-    api_form_data_context.value['asker'] = getRouteQueryValue('asker')
+    const asker = getRouteQueryValue('asker')
+    if (asker) {
+      api_form_data_context.value['asker'] = getRouteQueryValue('asker')
+    }
   }
 
   if (msg.length > 0) {

--- a/ui/src/views/application/component/ReasoningParamSettingDialog.vue
+++ b/ui/src/views/application/component/ReasoningParamSettingDialog.vue
@@ -19,6 +19,7 @@
             :label="$t('views.application.applicationForm.form.reasoningContent.start')"
           >
             <el-input
+              type="textarea"
               v-model="form.reasoning_content_start"
               :rows="6"
               maxlength="50"
@@ -29,6 +30,7 @@
         <el-col :span="12">
           <el-form-item :label="$t('views.application.applicationForm.form.reasoningContent.end')">
             <el-input
+              type="textarea"
               v-model="form.reasoning_content_end"
               :rows="6"
               maxlength="50"


### PR DESCRIPTION
fix: When asker is empty, do not pass the current parameter 