### PR TITLE
refactor: convert getList and getUserList functions to async for improved handling of asynchronous operations

### DIFF
--- a/ui/src/views/function-lib/index.vue
+++ b/ui/src/views/function-lib/index.vue
@@ -184,6 +184,7 @@
                             {{ $t('common.copy') }}
                           </el-dropdown-item>
                           <el-dropdown-item
+                            v-if="item.init_field_list?.length > 0"
                             :disabled="item.permission_type === 'PUBLIC' && !canEdit(item)"
                             @click.stop="configInitParams(item)"
                           >

--- a/ui/src/views/function-lib/index.vue
+++ b/ui/src/views/function-lib/index.vue
@@ -509,7 +509,10 @@ function importFunctionLib(file: any) {
     })
 }
 
-function getList() {
+async function getList() {
+  if (userOptions.value?.length === 0) {
+    await getUserList()
+  }
   const params = {
     ...(searchValue.value && { name: searchValue.value }),
     ...(functionType.value && { function_type: functionType.value }),
@@ -545,28 +548,26 @@ function refresh(data: any) {
   getList()
 }
 
-function getUserList() {
-  applicationApi.getUserList('FUNCTION', loading).then((res) => {
-    if (res.data) {
-      userOptions.value = res.data.map((item: any) => {
-        return {
-          label: item.username,
-          value: item.id
-        }
-      })
-      if (user.userInfo) {
-        const selectUserIdValue = localStorage.getItem(user.userInfo.id + 'function')
-        if (selectUserIdValue && userOptions.value.find((v) => v.value === selectUserIdValue)) {
-          selectUserId.value = selectUserIdValue
-        }
+async function getUserList() {
+  const res = await applicationApi.getUserList('FUNCTION', loading)
+  if (res.data) {
+    userOptions.value = res.data.map((item: any) => {
+      return {
+        label: item.username,
+        value: item.id
       }
-      // getList()
+    })
+    if (user.userInfo) {
+      const selectUserIdValue = localStorage.getItem(user.userInfo.id + 'function')
+      if (selectUserIdValue && userOptions.value.find((v) => v.value === selectUserIdValue)) {
+        selectUserId.value = selectUserIdValue
+      }
     }
-  })
+  }
 }
 
 onMounted(() => {
-  getUserList()
+
 })
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
refactor: conditionally render dropdown item based on init_field_list length  --bug=1054160 --user=刘瑞斌 【函数库】没有启用参数的函数，不展示启动参数按钮 https://www.tapd.cn/57709429/s/1678874<br>refactor: convert getList and getUserList functions to async for improved handling of asynchronous operations  --bug=1054152 --user=刘瑞斌 【函数库】筛选“我的”函数后刷新页面，还是显示的全部函数 https://www.tapd.cn/57709429/s/1678876 