### PR TITLE
fix: When answering a question - click to stop answering - wait until the question is approximately answered, then click to continue - it will remain in a stopped answering state

### DIFF
--- a/ui/src/api/type/application.ts
+++ b/ui/src/api/type/application.ts
@@ -249,7 +249,10 @@ export class ChatRecordManage {
   write() {
     this.chat.is_stop = false
     this.is_stop = false
-    this.is_close = false
+    if (!this.is_close) {
+      this.is_close = false
+    }
+
     this.write_ed = false
     this.chat.write_ed = false
     if (this.loading) {


### PR DESCRIPTION
fix: When answering a question - click to stop answering - wait until the question is approximately answered, then click to continue - it will remain in a stopped answering state 