### PR TITLE
fix: During the debugging process, the browser voice will automatically play after returning to other pages

### DIFF
--- a/ui/src/components/ai-chat/component/operation-button/ChatOperationButton.vue
+++ b/ui/src/components/ai-chat/component/operation-button/ChatOperationButton.vue
@@ -536,6 +536,8 @@ onMounted(() => {
   })
 })
 onBeforeUnmount(() => {
+  bus.off('change:answer')
+  bus.off('play:pause')
   if (audioManage.value) {
     audioManage.value.pause()
   }


### PR DESCRIPTION
fix: During the debugging process, the browser voice will automatically play after returning to other pages 