### PR TITLE
fix: When adding a large language model in Application-Settings-Add AI node, the Base Model is not listed

### DIFF
--- a/ui/src/views/template/component/CreateModelDialog.vue
+++ b/ui/src/views/template/component/CreateModelDialog.vue
@@ -377,6 +377,9 @@ const open = (provider: Provider, model_type?: string) => {
   dialogVisible.value = true
   base_form_data.value.model_type = model_type || ''
   activeName.value = 'base-info'
+  if (model_type) {
+    list_base_model(model_type)
+  }
 }
 
 const list_base_model = (model_type: any, change?: boolean) => {


### PR DESCRIPTION
fix: When adding a large language model in Application-Settings-Add AI node, the Base Model is not listed  --bug=1054358 --user=王孝刚 【应用】应用-设置-添加AI 节点时添加大语言模型，没有列出Base Model https://www.tapd.cn/57709429/s/1681102 