### PR TITLE
fix: In the permission settings, the knowledge base list does not distinguish between knowledge base types, and all are marked with the icon of the general knowledge base.

### DIFF
--- a/apps/setting/sql/get_member_permission.sql
+++ b/apps/setting/sql/get_member_permission.sql
@@ -8,7 +8,8 @@ FROM
 		"id",
 		"name",
 		'DATASET' AS "type",
-		user_id
+		user_id,
+		"type" AS "icon"
 	FROM
 		dataset
 	WHERE
@@ -17,7 +18,8 @@ FROM
 		"id",
 		"name",
 		'APPLICATION' AS "type",
-		user_id
+		user_id,
+	    "icon" AS "icon"
 	FROM
 		application
 	WHERE

--- a/ui/src/views/team/component/PermissionSetting.vue
+++ b/ui/src/views/team/component/PermissionSetting.vue
@@ -19,14 +19,41 @@
         <template #default="{ row }">
           <div class="flex align-center">
             <AppAvatar
-              v-if="isApplication"
-              :name="row.name"
-              pinyinColor
+              v-if="isApplication && isAppIcon(row?.icon)"
+              style="background: none"
               class="mr-12"
               shape="square"
               :size="24"
+            >
+              <img :src="row?.icon" alt="" />
+            </AppAvatar>
+
+            <AppAvatar
+              v-else-if="row?.name && isApplication"
+              :name="row?.name"
+              pinyinColor
+              shape="square"
+              :size="24"
+              class="mr-12"
             />
-            <AppAvatar v-else-if="isDataset" class="mr-12 avatar-blue" shape="square" :size="24">
+            <AppAvatar
+              v-if="row.icon === '1' && isDataset"
+              class="mr-8 avatar-purple"
+              shape="square"
+              :size="24"
+            >
+              <img src="@/assets/icon_web.svg" style="width: 58%" alt="" />
+            </AppAvatar>
+            <AppAvatar
+              v-else-if="row.icon === '2' && isDataset"
+              class="mr-8 avatar-purple"
+              shape="square"
+              :size="24"
+              style="background: none"
+            >
+              <img src="@/assets/logo_lark.svg" style="width: 100%" alt="" />
+            </AppAvatar>
+            <AppAvatar v-else-if="isDataset" class="mr-8 avatar-blue" shape="square" :size="24">
               <img src="@/assets/icon_document.svg" style="width: 58%" alt="" />
             </AppAvatar>
             <auto-tooltip :content="row?.name">
@@ -85,6 +112,7 @@
 <script setup lang="ts">
 import { ref, onMounted, watch, computed } from 'vue'
 import { TeamEnum } from '@/enums/team'
+import { isAppIcon } from '@/utils/application'
 
 const props = defineProps({
   data: {


### PR DESCRIPTION
fix: In the permission settings, the knowledge base list does not distinguish between knowledge base types, and all are marked with the icon of the general knowledge base.  --bug=1054142 --user=王孝刚 【团队成员】权限设置中，知识库列表没有区分知识库类型，都用通用知识库的图标标识 https://www.tapd.cn/57709429/s/1681104 