### PR TITLE
fix: MD editor table cannot have too many columns and cannot scroll horizontally

### DIFF
--- a/ui/src/styles/md-editor.scss
+++ b/ui/src/styles/md-editor.scss
@@ -1,10 +1,14 @@
 .md-editor {
   font-weight: 400;
 }
+
 .md-editor-preview {
   padding: 0;
   margin: 0;
   font-size: inherit;
+  table{
+    display: block;
+  }
   p {
     padding: 0 !important;
   }


### PR DESCRIPTION
fix: MD editor table cannot have too many columns and cannot scroll horizontally 