### PR TITLE
fix: handle line breaks in cell content for markdown table formatting

### DIFF
--- a/apps/common/handle/impl/table/xls_parse_table_handle.py
+++ b/apps/common/handle/impl/table/xls_parse_table_handle.py
@@ -82,7 +82,10 @@ class XlsSplitHandle(BaseParseTableHandle):
                 for row in data:
                     # 将每个单元格中的内容替换换行符为 <br> 以保留原始格式
                     md_table += '| ' + ' | '.join(
-                        [str(cell).replace('\n', '<br>') if cell else '' for cell in row]) + ' |\n'
+                        [str(cell)
+                         .replace('\r\n', '<br>')
+                         .replace('\n', '<br>')
+                         if cell else '' for cell in row]) + ' |\n'
                 md_tables += md_table + '\n\n'
 
             return md_tables


### PR DESCRIPTION
fix: handle line breaks in cell content for markdown table formatting  --bug=1054683 --user=刘瑞斌 【github#2831】知识库上传excel、应用编排文档内容提取节点中上传excel，单元格中有换行，导入后没有在一个单元格里显示 https://www.tapd.cn/57709429/s/1685274 