### PR TITLE
fix: improve module tree query to use Q object for filtering by workspace_id

### DIFF
--- a/apps/modules/api/module.py
+++ b/apps/modules/api/module.py
@@ -105,5 +105,12 @@ class ModuleTreeReadAPI(APIMixin):
                 enum=["APPLICATION", "KNOWLEDGE", "TOOL"],
                 location='path',
                 required=True,
-            )
+            ),
+            OpenApiParameter(
+                name="name",
+                description="名称",
+                type=OpenApiTypes.STR,
+                location='query',
+                required=False,
+            ),
         ]

--- a/apps/modules/serializers/module.py
+++ b/apps/modules/serializers/module.py
@@ -95,9 +95,13 @@ class ModuleTreeSerializer(serializers.Serializer):
     workspace_id = serializers.CharField(required=True, allow_null=True, allow_blank=True, label=_('workspace id'))
     source = serializers.CharField(required=True, label=_('source'))
 
-    def get_module_tree(self):
+    def get_module_tree(self, name=None):
         self.is_valid(raise_exception=True)
         Module = get_module_type(self.data.get('source'))
-        nodes = Module.objects.filter(Q(workspace_id=self.data.get('workspace_id'))).get_cached_trees()
+        if name is not None:
+            nodes = Module.objects.filter(Q(workspace_id=self.data.get('workspace_id')) &
+                                          Q(name__contains=name)).get_cached_trees()
+        else:
+            nodes = Module.objects.filter(Q(workspace_id=self.data.get('workspace_id'))).get_cached_trees()
         serializer = ToolModuleTreeSerializer(nodes, many=True)
         return serializer.data  # 这是可序列化的字典

--- a/apps/modules/views/module.py
+++ b/apps/modules/views/module.py
@@ -88,4 +88,4 @@ class ModuleTreeView(APIView):
     def get(self, request: Request, workspace_id: str, source: str):
         return result.success(ModuleTreeSerializer(
             data={'workspace_id': workspace_id, 'source': source}
-        ).get_module_tree())
+        ).get_module_tree(request.query_params.get('name')))


### PR DESCRIPTION
fix: improve module tree query to use Q object for filtering by workspace_id 