### PR TITLE
fix: i18n error

### DIFF
--- a/apps/locales/zh_CN/LC_MESSAGES/django.po
+++ b/apps/locales/zh_CN/LC_MESSAGES/django.po
@@ -4536,7 +4536,7 @@ msgstr "修改知识库信息"
 #: community/apps/dataset/views/document.py:463
 #: community/apps/dataset/views/document.py:464
 msgid "Get the knowledge base paginated list"
-msgstr "获取知识库分页列表"
+msgstr "获取知识库文档分页列表"
 
 #: community/apps/dataset/views/document.py:31
 #: community/apps/dataset/views/document.py:32

--- a/apps/locales/zh_Hant/LC_MESSAGES/django.po
+++ b/apps/locales/zh_Hant/LC_MESSAGES/django.po
@@ -4545,7 +4545,7 @@ msgstr "修改知識庫信息"
 #: community/apps/dataset/views/document.py:463
 #: community/apps/dataset/views/document.py:464
 msgid "Get the knowledge base paginated list"
-msgstr "獲取知識庫分頁列表"
+msgstr "獲取知識庫文档分頁列表"
 
 #: community/apps/dataset/views/document.py:31
 #: community/apps/dataset/views/document.py:32


### PR DESCRIPTION
fix: i18n error  --bug=1054853 --user=王孝刚 【API文档】-获取知识库文档分页列表接口的名称错误 https://www.tapd.cn/57709429/s/1688248 