### PR TITLE
fix: When automatic sending is not selected, the text conversion should be displayed in the position of the question input box

### DIFF
--- a/ui/src/components/ai-chat/component/chat-input-operate/index.vue
+++ b/ui/src/components/ai-chat/component/chat-input-operate/index.vue
@@ -688,7 +688,9 @@ const uploadRecording = async (audioBlob: Blob) => {
     recorderStatus.value = 'TRANSCRIBING'
     const formData = new FormData()
     formData.append('file', audioBlob, 'recording.mp3')
-    bus.emit('on:transcribing', true)
+    if (props.applicationDetails.stt_autosend) {
+      bus.emit('on:transcribing', true)
+    }
     applicationApi
       .postSpeechToText(props.applicationDetails.id as string, formData, localLoading)
       .then((response) => {
@@ -767,7 +769,7 @@ function autoSendMessage() {
         document_list: uploadDocumentList.value,
         audio_list: uploadAudioList.value,
         video_list: uploadVideoList.value,
-        other_list: uploadOtherList.value,
+        other_list: uploadOtherList.value
       })
       inputValue.value = ''
       uploadImageList.value = []


### PR DESCRIPTION
fix: When automatic sending is not selected, the text conversion should be displayed in the position of the question input box 