### PR TITLE
fix: Change the max_token of the Qianfan large model to max_output_token

### DIFF
--- a/apps/setting/models_provider/impl/wenxin_model_provider/credential/llm.py
+++ b/apps/setting/models_provider/impl/wenxin_model_provider/credential/llm.py
@@ -27,7 +27,7 @@ class WenxinLLMModelParams(BaseForm):
                                     _step=0.01,
                                     precision=2)
 
-    max_tokens = forms.SliderField(
+    max_output_tokens = forms.SliderField(
         TooltipLabel(_('Output the maximum Tokens'),
                      _('Specify the maximum number of tokens that the model can generate')),
         required=True, default_value=1024,


### PR DESCRIPTION
fix: Change the max_token of the Qianfan large model to max_output_token 