### PR TITLE
fix: Thinking about process labels during simple application debugging does not take effect

### DIFF
--- a/apps/application/serializers/application_serializers.py
+++ b/apps/application/serializers/application_serializers.py
@@ -148,10 +148,12 @@ class ModelSettingSerializer(serializers.Serializer):
                                                         error_messages=ErrMessage.char(_("Thinking process switch")))
     reasoning_content_start = serializers.CharField(required=False, allow_null=True, default="<think>",
                                                     allow_blank=True, max_length=256,
+                                                    trim_whitespace=False,
                                                     error_messages=ErrMessage.char(
                                                         _("The thinking process begins to mark")))
     reasoning_content_end = serializers.CharField(required=False, allow_null=True, allow_blank=True, default="</think>",
                                                   max_length=256,
+                                                  trim_whitespace=False,
                                                   error_messages=ErrMessage.char(_("End of thinking process marker")))
 
 


### PR DESCRIPTION
fix: Thinking about process labels during simple application debugging does not take effect 