### PR TITLE
ci: add pip package ecosystem support to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
       timezone: "Asia/Shanghai"
       day: "friday"
     target-branch: "v2"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Asia/Shanghai"
+      day: "friday"
+    target-branch: "main"


### PR DESCRIPTION
ci: add pip package ecosystem support to dependabot configuration 