### PR TITLE
fix: Adjust configuration file loading order.

### DIFF
--- a/apps/smartdoc/conf.py
+++ b/apps/smartdoc/conf.py
@@ -182,7 +182,7 @@ class ConfigManager:
         return True
 
     def load_from_yml(self):
-        for i in ['config_example.yml', 'config.yaml', 'config.yml']:
+        for i in ['config.yml', 'config.yaml', 'config_example.yml']:
             if not os.path.isfile(os.path.join(self.root_path, i)):
                 continue
             loaded = self.from_yaml(i)


### PR DESCRIPTION
prioritizing `config.yml` and `config.yaml` before `config_example.yml` to ensure proper configuration resolution.