### PR TITLE
fix: update MCP server configuration text to include STREAMABLE_HTTP support

### DIFF
--- a/ui/src/locales/lang/en-US/views/application-workflow.ts
+++ b/ui/src/locales/lang/en-US/views/application-workflow.ts
@@ -223,14 +223,14 @@ export default {
     },
     mcpNode: {
       label: 'MCP Server',
-      text: 'Call MCP Tools through SSE',
+      text: 'Call MCP Tools through SSE/STREAMABLE_HTTP',
       getToolsSuccess: 'Get Tools Successfully',
       getTool: 'Get Tools',
       tool: 'Tool',
       toolParam: 'Tool Params',
       mcpServerTip: 'Please enter the JSON format of the MCP server config',
       mcpToolTip: 'Please select a tool',
-      configLabel: 'MCP Server Config (Only supports SSE call method)'
+      configLabel: 'MCP Server Config (Only supports SSE/STREAMABLE_HTTP call method)'
     },
     imageGenerateNode: {
       label: 'Image Generation',

--- a/ui/src/locales/lang/zh-CN/views/application-workflow.ts
+++ b/ui/src/locales/lang/zh-CN/views/application-workflow.ts
@@ -224,14 +224,14 @@ export default {
     },
     mcpNode: {
       label: 'MCP 调用',
-      text: '通过SSE方式执行MCP服务中的工具',
+      text: '通过SSE/STREAMABLE_HTTP方式执行MCP服务中的工具',
       getToolsSuccess: '获取工具成功',
       getTool: '获取工具',
       tool: '工具',
       toolParam: '工具参数',
       mcpServerTip: '请输入JSON格式的MCP服务器配置',
       mcpToolTip: '请选择工具',
-      configLabel: 'MCP Server Config (仅支持SSE调用方式)'
+      configLabel: 'MCP Server Config (仅支持SSE/STREAMABLE_HTTP调用方式)'
     },
     imageGenerateNode: {
       label: '图片生成',

--- a/ui/src/locales/lang/zh-Hant/views/application-workflow.ts
+++ b/ui/src/locales/lang/zh-Hant/views/application-workflow.ts
@@ -223,14 +223,14 @@ export default {
     },
     mcpNode: {
       label: 'MCP 調用',
-      text: '透過SSE方式執行MCP服務中的工具',
+      text: '透過SSE/STREAMABLE_HTTP方式執行MCP服務中的工具',
       getToolsSuccess: '獲取工具成功',
       getTool: '獲取工具',
       tool: '工具',
       toolParam: '工具變數',
       mcpServerTip: '請輸入JSON格式的MCP服務器配置',
       mcpToolTip: '請選擇工具',
-      configLabel: 'MCP Server Config (僅支持SSE調用方式)'
+      configLabel: 'MCP Server Config (僅支持SSE/STREAMABLE_HTTP調用方式)'
     },
     imageGenerateNode: {
       label: '圖片生成',

--- a/ui/src/workflow/nodes/mcp-node/index.vue
+++ b/ui/src/workflow/nodes/mcp-node/index.vue
@@ -266,6 +266,10 @@ function getTools() {
     .then((res: any) => {
       form_data.value.mcp_tools = res.data
       MsgSuccess(t('views.applicationWorkflow.nodes.mcpNode.getToolsSuccess'))
+      // 修改了json，刷新mcp_server
+      form_data.value.mcp_server = form_data.value.mcp_tools.filter(
+        (item: any) => item.name === form_data.value.mcp_tool
+      )[0].server
     })
 }
 


### PR DESCRIPTION
fix: update MCP server configuration text to include STREAMABLE_HTTP support  --bug=1056115 --user=刘瑞斌 【应用编排】编辑mcp节点的config后，提问会报错 https://www.tapd.cn/57709429/s/1699333 --bug=1056092 --user=刘瑞斌 【应用编排】MCP的支持文案要加上支持 Streamable HTTP https://www.tapd.cn/57709429/s/1699357 