### PR TITLE
fix: When the function parameter is of non string type, if the parameter is empty, the function will run with an error #3053

### DIFF
--- a/apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py
+++ b/apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py
@@ -65,7 +65,7 @@ def valid_reference_value(_type, value, name):
 
 
 def convert_value(name: str, value, _type, is_required, source, node):
-    if not is_required and value is None:
+    if not is_required and (value is None or (isinstance(value, str) and len(value) == 0)):
         return None
     if not is_required and source == 'reference' and (value is None or len(value) == 0):
         return None

--- a/apps/application/flow/step_node/function_node/impl/base_function_node.py
+++ b/apps/application/flow/step_node/function_node/impl/base_function_node.py
@@ -49,7 +49,7 @@ def valid_reference_value(_type, value, name):
 
 
 def convert_value(name: str, value, _type, is_required, source, node):
-    if not is_required and value is None:
+    if not is_required and (value is None or (isinstance(value, str) and len(value) == 0)):
         return None
     if source == 'reference':
         value = node.workflow_manage.get_reference_field(


### PR DESCRIPTION
fix: When the function parameter is of non string type, if the parameter is empty, the function will run with an error #3053 