### PR TITLE
fix: Advanced orchestration defines global variables and assigns them through assignment nodes. If there is a form collection node before the reference node, the assignment node becomes invalid and the initial variable value is still referenced

### DIFF
--- a/apps/application/flow/step_node/start_node/impl/base_start_node.py
+++ b/apps/application/flow/step_node/start_node/impl/base_start_node.py
@@ -45,6 +45,8 @@ class BaseStartStepNode(IStarNode):
         self.err_message = details.get('err_message')
         for key, value in workflow_variable.items():
             workflow_manage.context[key] = value
+        for item in details.get('global_fields', []):
+            workflow_manage.context[item.get('key')] = item.get('value')
 
     def get_node_params_serializer_class(self) -> Type[serializers.Serializer]:
         pass


### PR DESCRIPTION
fix: Advanced orchestration defines global variables and assigns them through assignment nodes. If there is a form collection node before the reference node, the assignment node becomes invalid and the initial variable value is still referenced 