### PR TITLE
fix: The default suffix for workflow file upload nodes is set to uppercase DOC and PPT

### DIFF
--- a/ui/src/workflow/nodes/base-node/index.vue
+++ b/ui/src/workflow/nodes/base-node/index.vue
@@ -316,7 +316,7 @@ const switchFileUpload = () => {
     audio: false,
     video: false,
     other: false,
-    otherExtensions: ['ppt', 'doc']
+    otherExtensions: ['PPT', 'DOC']
   }
 
   if (form_data.value.file_upload_enable) {


### PR DESCRIPTION
fix: The default suffix for workflow file upload nodes is set to uppercase DOC and PPT 