### PR TITLE
fix: Split permission in document import dialogue

### DIFF
--- a/apps/knowledge/views/document.py
+++ b/apps/knowledge/views/document.py
@@ -175,8 +175,8 @@ class DocumentView(APIView):
             tags=[_('Knowledge Base/Documentation')]  # type: ignore
         )
         @has_permissions(
-            PermissionConstants.KNOWLEDGE_DOCUMENT_CREATE.get_workspace_knowledge_permission(),
-            PermissionConstants.KNOWLEDGE_DOCUMENT_EDIT.get_workspace_knowledge_permission(),
+            PermissionConstants.KNOWLEDGE_DOCUMENT_READ.get_workspace_knowledge_permission(),
+            PermissionConstants.KNOWLEDGE_DOCUMENT_READ.get_workspace_permission_workspace_manage_role(),
             RoleConstants.WORKSPACE_MANAGE.get_workspace_role(),
             ViewPermission([RoleConstants.USER.get_workspace_role()],
                            [PermissionConstants.KNOWLEDGE.get_workspace_knowledge_permission()], CompareConstants.AND),


### PR DESCRIPTION
fix: Split permission in document import dialogue 