### PR TITLE
fix: Clicking on the web Q&A of the knowledge source did not redirect to the corresponding link

### DIFF
--- a/ui/src/components/ai-chat/component/knowledge-source-component/index.vue
+++ b/ui/src/components/ai-chat/component/knowledge-source-component/index.vue
@@ -27,7 +27,7 @@
                   </div>
                   <div class="ml-8" v-else>
                     <a
-                      :href="getFileUrl(item?.meta?.source_file_id || item?.source_url)"
+                      :href="getFileUrl(item?.meta?.source_file_id) || item?.meta?.source_url"
                       target="_blank"
                       class="ellipsis-1"
                       :title="item?.document_name?.trim()"


### PR DESCRIPTION
fix: Clicking on the web Q&A of the knowledge source did not redirect to the corresponding link 