### PR TITLE
fix: After enabling application access authentication, closing the public access connection will still display the application login page

### DIFF
--- a/apps/chat/serializers/chat_authentication.py
+++ b/apps/chat/serializers/chat_authentication.py
@@ -59,6 +59,8 @@ class AuthProfileSerializer(serializers.Serializer):
         application_access_token = QuerySet(ApplicationAccessToken).filter(access_token=access_token).first()
         if application_access_token is None:
             raise NotFound404(404, _("Invalid access_token"))
+        if not application_access_token.is_active:
+            raise NotFound404(404, _("Invalid access_token"))
         application_id = application_access_token.application_id
         profile = {
             'authentication': False


### PR DESCRIPTION
fix: After enabling application access authentication, closing the public access connection will still display the application login page 