### PR TITLE
fix: When referencing workflow fields, if the node is not executed, return None data

### DIFF
--- a/apps/application/flow/workflow_manage.py
+++ b/apps/application/flow/workflow_manage.py
@@ -755,7 +755,10 @@ class WorkflowManage:
         if node_id == 'global':
             return INode.get_field(self.context, fields)
         else:
-            return self.get_node_by_id(node_id).get_reference_field(fields)
+            node = self.get_node_by_id(node_id)
+            if node:
+                return node.get_reference_field(fields)
+            return None
 
     def get_workflow_content(self):
         context = {


### PR DESCRIPTION
fix: When referencing workflow fields, if the node is not executed, return None data 