### PR TITLE
fix: refactor delete method in DocumentSerializers for improved clarity

### DIFF
--- a/apps/knowledge/serializers/document.py
+++ b/apps/knowledge/serializers/document.py
@@ -662,6 +662,7 @@ class DocumentSerializers(serializers.Serializer):
 
         @transaction.atomic
         def delete(self):
+            self.is_valid(raise_exception=True)
             document_id = self.data.get("document_id")
             source_file_ids = [
                 doc['meta'].get(


### PR DESCRIPTION
fix: refactor delete method in DocumentSerializers for improved clarity  --bug=1060005 --user=刘瑞斌 【资源管理】知识库-删除文档报错 https://www.tapd.cn/62980211/s/1749123 