### PR TITLE
fix: When the reference variable in the workflow is empty, take the value of None

### DIFF
--- a/apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py
+++ b/apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py
@@ -73,15 +73,19 @@ def valid_reference_value(_type, value, name):
 
 
 def convert_value(name: str, value, _type, is_required, source, node):
-    if not is_required and (value is None or (isinstance(value, str) and len(value) == 0)):
-        return None
-    if not is_required and source == 'reference' and (value is None or len(value) == 0):
+    if not is_required and (value is None or ((isinstance(value, str) or isinstance(value, list)) and len(value) == 0)):
         return None
     if source == 'reference':
         value = node.workflow_manage.get_reference_field(
             value[0],
             value[1:])
-
+        if value is None:
+            if not is_required:
+                return None
+            else:
+                raise Exception(_(
+                    'Field: {name} Type: {_type} is required'
+                ).format(name=name, _type=_type))
         value = valid_reference_value(_type, value, name)
         if _type == 'int':
             return int(value)

--- a/apps/application/flow/step_node/tool_node/impl/base_tool_node.py
+++ b/apps/application/flow/step_node/tool_node/impl/base_tool_node.py
@@ -59,13 +59,19 @@ def valid_reference_value(_type, value, name):
 
 
 def convert_value(name: str, value, _type, is_required, source, node):
-    if not is_required and (value is None or (isinstance(value, str) and len(value) == 0)):
+    if not is_required and (value is None or ((isinstance(value, str) or isinstance(value, list)) and len(value) == 0)):
         return None
     if source == 'reference':
         value = node.workflow_manage.get_reference_field(
             value[0],
             value[1:])
-
+        if value is None:
+            if not is_required:
+                return None
+            else:
+                raise Exception(_(
+                    'Field: {name} Type: {_type} is required'
+                ).format(name=name, _type=_type))
         value = valid_reference_value(_type, value, name)
         if _type == 'int':
             return int(value)
@@ -81,15 +87,17 @@ def convert_value(name: str, value, _type, is_required, source, node):
             v = json.loads(value)
             if isinstance(v, dict):
                 return v
-            raise Exception("类型错误")
+            raise Exception(_('type error'))
         if _type == 'array':
             v = json.loads(value)
             if isinstance(v, list):
                 return v
-            raise Exception("类型错误")
+            raise Exception(_('type error'))
         return value
     except Exception as e:
-        raise Exception(f'字段:{name}类型:{_type}值:{value}类型错误')
+        raise Exception(
+            _('Field: {name} Type: {_type} Value: {value} Type error').format(name=name, _type=_type,
+                                                                              value=value))
 
 
 class BaseToolNodeNode(IToolNode):

--- a/apps/application/flow/workflow_manage.py
+++ b/apps/application/flow/workflow_manage.py
@@ -602,7 +602,10 @@ class WorkflowManage:
         elif node_id == 'chat':
             return INode.get_field(self.chat_context, fields)
         else:
-            return self.get_node_by_id(node_id).get_reference_field(fields)
+            node = self.get_node_by_id(node_id)
+            if node:
+                return node.get_reference_field(fields)
+            return None
 
     def get_workflow_content(self):
         context = {

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,6 +37,7 @@
     "md-editor-v3": "^5.8.2",
     "mermaid": "^10.9.0",
     "moment": "^2.30.1",
+    "nanoid": "^5.1.5",
     "nprogress": "^0.2.0",
     "pinia": "^3.0.1",
     "recorder-core": "^1.3.25011100",

--- a/ui/src/utils/common.ts
+++ b/ui/src/utils/common.ts
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid'
 /**
  * 数字处理
  */
@@ -36,7 +37,7 @@ export function isFunction(fn: any) {
   随机id
 */
 export const randomId = function () {
-  return Math.floor(Math.random() * 10000) + ''
+  return nanoid()
 }
 
 /*


### PR DESCRIPTION
fix: When the reference variable in the workflow is empty, take the value of None 