### PR TITLE
fix: When the slider type step size is set to 0, the verification is triggered, and when it is changed to 1, the verification disappears

### DIFF
--- a/ui/src/components/dynamics-form/constructor/items/SliderConstructor.vue
+++ b/ui/src/components/dynamics-form/constructor/items/SliderConstructor.vue
@@ -142,14 +142,15 @@ const step_rules = [
   {
     required: true,
     validator: (rule: any, value: any, callback: any) => {
-      if (!value) {
-        callback(new Error(t('dynamicsForm.Slider.step.requiredMessage1')))
-        return false
-      }
       if (value === 0) {
         callback(new Error(t('dynamicsForm.Slider.step.requiredMessage2')))
         return false
       }
+      if (!value) {
+        callback(new Error(t('dynamicsForm.Slider.step.requiredMessage1')))
+        return false
+      }
+
       return true
     },
     trigger: 'blur',


### PR DESCRIPTION
fix: When the slider type step size is set to 0, the verification is triggered, and when it is changed to 1, the verification disappears 