### PR TITLE
fix(ui): markdown unordered list does not show correctly

### DIFF
--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -56,7 +56,7 @@ div:focus {
 }
 
 ul {
-  list-style: none;
+  list-style: circle;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
#### What this PR does / why we need it?

The markdown unordered list does not show correctly.

Before:
<img width="979" height="329" alt="image" src="https://github.com/user-attachments/assets/fa31457b-f38f-4812-a3ab-e4cbc1d8467b" />

After:
<img width="979" height="329" alt="image" src="https://github.com/user-attachments/assets/aed87870-db29-4958-a852-00a3388945be" />


#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.