### PR TITLE
fix: Advanced Layout Canvas Editing - Special Editing Method will connect the exit of the current node to the exit of subsequent nodes when adding them

### DIFF
--- a/ui/src/workflow/common/NodeContainer.vue
+++ b/ui/src/workflow/common/NodeContainer.vue
@@ -297,11 +297,13 @@ function clickNodes(item: any) {
     x: anchorData.value?.x + width / 2 + 200,
     y: anchorData.value?.y - item.height
   })
+  console.log(nodeModel)
   props.nodeModel.graphModel.addEdge({
     type: 'app-edge',
     sourceNodeId: props.nodeModel.id,
     sourceAnchorId: anchorData.value?.id,
-    targetNodeId: nodeModel.id
+    targetNodeId: nodeModel.id,
+    targetAnchorId: nodeModel.id + '_left'
   })
 
   closeNodeMenu()


### PR DESCRIPTION
fix: Advanced Layout Canvas Editing - Special Editing Method will connect the exit of the current node to the exit of subsequent nodes when adding them 