### PR TITLE
fix: Return the link to the connection pool after the node execution is completed

### DIFF
--- a/apps/application/flow/workflow_manage.py
+++ b/apps/application/flow/workflow_manage.py
@@ -14,7 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import reduce
 from typing import List, Dict
 
-from django.db import close_old_connections
+from django.db import close_old_connections, connection
 from django.db.models import QuerySet
 from django.utils import translation
 from django.utils.translation import get_language
@@ -569,6 +569,8 @@ class WorkflowManage:
             return None
         finally:
             current_node.node_chunk.end()
+            # 归还链接
+            connection.close()
 
     def run_node_async(self, node):
         future = executor.submit(self.run_node, node)


### PR DESCRIPTION
fix: Return the link to the connection pool after the node execution is completed 