### PR TITLE
fix: Application menu displays conversation users and conversation logs

### DIFF
--- a/apps/common/constants/permission_constants.py
+++ b/apps/common/constants/permission_constants.py
@@ -895,7 +895,7 @@ class PermissionConstants(Enum):
     APPLICATION_CHAT_USER_READ = Permission(group=Group.APPLICATION_CHAT_USER, operate=Operate.READ,
                                             role_list=[RoleConstants.ADMIN, RoleConstants.USER],
                                             parent_group=[WorkspaceGroup.APPLICATION, UserGroup.APPLICATION],
-                                            resource_permission_group_list=[ResourcePermissionConst.APPLICATION_MANGE],
+                                            resource_permission_group_list=[ResourcePermissionConst.APPLICATION_VIEW],
                                             )
     APPLICATION_CHAT_USER_EDIT = Permission(group=Group.APPLICATION_CHAT_USER, operate=Operate.EDIT,
                                             role_list=[RoleConstants.ADMIN, RoleConstants.USER],
@@ -917,7 +917,7 @@ class PermissionConstants(Enum):
     APPLICATION_CHAT_LOG_READ = Permission(group=Group.APPLICATION_CHAT_LOG, operate=Operate.READ,
                                            role_list=[RoleConstants.ADMIN, RoleConstants.USER],
                                            parent_group=[WorkspaceGroup.APPLICATION, UserGroup.APPLICATION],
-                                           resource_permission_group_list=[ResourcePermissionConst.APPLICATION_MANGE],
+                                           resource_permission_group_list=[ResourcePermissionConst.APPLICATION_VIEW],
                                            )
 
     APPLICATION_CHAT_LOG_ANNOTATION = Permission(group=Group.APPLICATION_CHAT_LOG, operate=Operate.ANNOTATION,


### PR DESCRIPTION
fix: Application menu displays conversation users and conversation logs  --bug=1060818 --user=张展玮 【应用】应用只授权用户查看权限，详情页，没有展示对话用户、对话日志菜单 https://www.tapd.cn/62980211/s/1760973 