### PR TITLE
fix: When the label of the form tab is empty, the content is not supported

### DIFF
--- a/ui/src/components/dynamics-form/items/radio/RadioCard.vue
+++ b/ui/src/components/dynamics-form/items/radio/RadioCard.vue
@@ -13,7 +13,7 @@
               modelValue == item[valueField] ? 'active' : '',
             ]"
             @click="inputDisabled ? () => {} : selected(item[valueField])"
-            :innerHTML="item[textField]"
+            :innerHTML="item[textField] ? item[textField] : '\u200D'"
           >
           </el-card>
         </el-col>


### PR DESCRIPTION
fix: When the label of the form tab is empty, the content is not supported 