### PR TITLE
fix: Canvas icon cannot be dragged or dropped

### DIFF
--- a/ui/src/workflow/common/NodeContainer.vue
+++ b/ui/src/workflow/common/NodeContainer.vue
@@ -7,7 +7,14 @@
     >
       <div v-resize="resizeStepContainer">
         <div class="flex-between">
-          <div class="flex align-center" style="width: 70%">
+          <div
+            class="flex align-center"
+            @dragstart.prevent
+            @drag.prevent
+            @dragover.prevent
+            @dragend.prevent
+            style="width: 70%"
+          >
             <component
               :is="iconComponent(`${nodeModel.type}-icon`)"
               class="mr-8"


### PR DESCRIPTION
fix: Canvas icon cannot be dragged or dropped 