### PR TITLE
fix: The validation prompt for the JSON input box is incorrect

### DIFF
--- a/ui/src/components/dynamics-form/items/JsonInput.vue
+++ b/ui/src/components/dynamics-form/items/JsonInput.vue
@@ -117,7 +117,7 @@ const validate_rules = (rule: any, value: any, callback: any) => {
     try {
       JSON.parse(model_value.value)
     } catch (e) {
-      callback(new Error(t('dynamicsForm.tip.requiredMessage')))
+      callback(new Error(t('dynamicsForm.tip.jsonMessage')))
       return false
     }
   }


### PR DESCRIPTION
fix: The validation prompt for the JSON input box is incorrect 