### PR TITLE
fix: ensure only active tools are processed in base_chat_node.py

### DIFF
--- a/apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py
+++ b/apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py
@@ -279,7 +279,7 @@ class BaseChatNode(IChatNode):
                 mcp_servers_config = json.loads(mcp_servers)
             elif mcp_tool_id:
                 mcp_tool = QuerySet(Tool).filter(id=mcp_tool_id).first()
-                if mcp_tool:
+                if mcp_tool and mcp_tool.is_active:
                     mcp_servers_config = json.loads(mcp_tool.code)
 
         if tool_enable:
@@ -288,6 +288,8 @@ class BaseChatNode(IChatNode):
                 self.context['execute_ids'] = []
                 for tool_id in tool_ids:
                     tool = QuerySet(Tool).filter(id=tool_id).first()
+                    if not tool.is_active:
+                        continue
                     executor = ToolExecutor(CONFIG.get('SANDBOX'))
                     if tool.init_params is not None:
                         params = json.loads(rsa_long_decrypt(tool.init_params))

--- a/apps/application/serializers/common.py
+++ b/apps/application/serializers/common.py
@@ -12,6 +12,7 @@ from typing import List
 from django.core.cache import cache
 from django.db.models import QuerySet
 from django.utils.translation import gettext_lazy as _
+from django.utils import timezone
 
 from application.chat_pipeline.step.chat_step.i_chat_step import PostResponseHandler
 from application.models import Application, ChatRecord, Chat, ApplicationVersion, ChatUserType, ApplicationTypeChoices, \
@@ -213,7 +214,7 @@ class ChatInfo:
                      chat_user_id=self.chat_user_id, chat_user_type=self.chat_user_type,
                      asker=self.get_chat_user()).save()
             else:
-                QuerySet(Chat).filter(id=self.chat_id).update(update_time=datetime.now())
+                QuerySet(Chat).filter(id=self.chat_id).update(update_time=timezone.now())
             # 插入会话记录
             chat_record.save()
             ChatCountSerializer(data={'chat_id': self.chat_id}).update_chat()


### PR DESCRIPTION
fix: ensure only active tools are processed in base_chat_node.py  --bug=1061252 --user=刘瑞斌 【工具】MCP被禁用后，依然可以在应用中调用 https://www.tapd.cn/62980211/s/1765960 