### PR TITLE
fix: Create application orchestration, select the knowledge base Q&A assistant template, and when publishing, the knowledge base retrieval node prompts to set parameters

### DIFF
--- a/ui/src/workflow/nodes/reranker-node/index.vue
+++ b/ui/src/workflow/nodes/reranker-node/index.vue
@@ -288,6 +288,9 @@ const validate = () => {
 
 onMounted(() => {
   getSelectModel()
+  form_data.value.show_knowledge = form_data.value.show_knowledge
+    ? form_data.value.show_knowledge
+    : false
   set(props.nodeModel, 'validate', validate)
 })
 </script>

--- a/ui/src/workflow/nodes/search-knowledge-node/index.vue
+++ b/ui/src/workflow/nodes/search-knowledge-node/index.vue
@@ -217,6 +217,9 @@ const validate = () => {
 onMounted(() => {
   // console.log(props.nodeModel.properties.node_data)
   knowledgeList.value = props.nodeModel.properties.node_data.knowledge_list
+  form_data.value.show_knowledge = form_data.value.show_knowledge
+    ? form_data.value.show_knowledge
+    : false
   set(props.nodeModel, 'validate', validate)
 })
 </script>


### PR DESCRIPTION
fix: Create application orchestration, select the knowledge base Q&A assistant template, and when publishing, the knowledge base retrieval node prompts to set parameters 