### PR TITLE
fix: When adding interface parameters during application editing, go directly to the conversation after publishing. The URL of the conversation interface does not include interface parameters

### DIFF
--- a/ui/src/views/application-workflow/index.vue
+++ b/ui/src/views/application-workflow/index.vue
@@ -318,6 +318,27 @@ const publish = () => {
         })
         .then((ok: any) => {
           detail.value.name = ok.data.name
+          ok.data.work_flow?.nodes
+            ?.filter((v: any) => v.id === 'base-node')
+            .map((v: any) => {
+              apiInputParams.value = v.properties.api_input_field_list
+                ? v.properties.api_input_field_list.map((v: any) => {
+                    return {
+                      name: v.variable,
+                      value: v.default_value,
+                    }
+                  })
+                : v.properties.input_field_list
+                  ? v.properties.input_field_list
+                      .filter((v: any) => v.assignment_method === 'api_input')
+                      .map((v: any) => {
+                        return {
+                          name: v.variable,
+                          value: v.default_value,
+                        }
+                      })
+                  : []
+            })
           MsgSuccess(t('views.application.tip.publishSuccess'))
         })
         .catch((res: any) => {


### PR DESCRIPTION
fix: When adding interface parameters during application editing, go directly to the conversation after publishing. The URL of the conversation interface does not include interface parameters 