### PR TITLE
fix: Information regarding role permissions management has not been internationalised.

### DIFF
--- a/apps/common/constants/permission_constants.py
+++ b/apps/common/constants/permission_constants.py
@@ -10,7 +10,7 @@ from functools import reduce
 from typing import List
 
 from django.db import models
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from maxkb import settings
 


### PR DESCRIPTION
fix: Information regarding role permissions management has not been internationalised.  --bug=1061417 --user=张展玮 【国际化BUG】2.10版本，角色权限管理的信息没有国际化 https://www.tapd.cn/62980211/s/1768834 