### PR TITLE
Update tool_code.py

### DIFF
--- a/apps/common/utils/tool_code.py
+++ b/apps/common/utils/tool_code.py
@@ -10,7 +10,7 @@ import uuid_utils.compat as uuid
 
 from maxkb.const import BASE_DIR, CONFIG
 from maxkb.const import PROJECT_DIR
-
+import tempfile
 python_directory = sys.executable
 
 
@@ -212,4 +212,15 @@ exec({dedent(code)!a})
 
     @staticmethod
     def _exec(_code):
-        return subprocess.run([python_directory, '-c', _code], text=True, capture_output=True)
+         @staticmethod
+    def _exec(_code):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as temp_file:
+            temp_file.write(_code)
+            temp_file_path = temp_file.name
+        try:
+            return subprocess.run([python_directory, temp_file_path], text=True, capture_output=True)
+        finally:
+            try:
+                os.unlink(temp_file_path)
+            except:
+                pass 


### PR DESCRIPTION
#### What this PR does / why we need it?
When the retrieved segments are too many or the historical information is too long, the function will throw an error：
"
[Errno 7] Argument list too long: '~/miniconda3/envs/maxkb/bin/python'
"

#### Summary of your change
Resolve the issue of function execution where the _code parameter input exceeds the maximum length.

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.