### PR TITLE
fix: Unable to select loop node parameters after page refresh

### DIFF
--- a/ui/src/workflow/nodes/loop-node/index.ts
+++ b/ui/src/workflow/nodes/loop-node/index.ts
@@ -1,9 +1,12 @@
 import LoopNode from './index.vue'
 import { AppNode, AppNodeModel } from '@/workflow/common/app-node'
 import { WorkflowType } from '@/enums/application'
+
 class LoopNodeView extends AppNode {
   constructor(props: any) {
+    const config = props.model.properties.config
     super(props, LoopNode)
+    props.model.properties.config = config
   }
 }
 class LoopModel extends AppNodeModel {


### PR DESCRIPTION
fix: Unable to select loop node parameters after page refresh 