### PR TITLE
chore: update tool_params handling in index.vue

### DIFF
--- a/ui/src/workflow/nodes/mcp-node/index.vue
+++ b/ui/src/workflow/nodes/mcp-node/index.vue
@@ -138,7 +138,7 @@
                   v-model="item.source"
                   size="small"
                   style="width: 85px"
-                  @change="form_data.tool_params[form_data.params_nested] = {}"
+                  @change="form_data.tool_params[form_data.params_nested] = {}; form_data.tool_params[form_data.params_nested][item.label.label]"
                 >
                   <el-option
                     :label="$t('views.applicationWorkflow.nodes.replyNode.replyContent.reference')"
@@ -207,6 +207,7 @@
                   v-model="item.source"
                   size="small"
                   style="width: 85px"
+                  @change="form_data.tool_params[item.label.label] = ''"
                 >
                   <el-option
                     :label="$t('views.applicationWorkflow.nodes.replyNode.replyContent.reference')"


### PR DESCRIPTION
chore: update tool_params handling in index.vue  --bug=1062339 --user=刘瑞斌 【MCP】MCP节点，从“引用变量” 切换到 “自定义” 没有清空 “引用变量” 的值 https://www.tapd.cn/62980211/s/1782327 