### PR TITLE
fix: In workflow applications, the display of custom icons for sub applications and tools in the box below the variable selection is incorrect

### DIFF
--- a/ui/src/workflow/common/NodeCascader.vue
+++ b/ui/src/workflow/common/NodeCascader.vue
@@ -10,9 +10,12 @@
   >
     <template #default="{ node, data }">
       <span class="flex align-center" @wheel="wheel">
-        <component :is="iconComponent(`${data.type}-icon`)" class="mr-8" :size="18" />{{
-          data.label
-        }}</span
+        <component
+          :is="iconComponent(`${data.type}-icon`)"
+          class="mr-8"
+          :size="18"
+          :item="data"
+        />{{ data.label }}</span
       >
     </template>
   </el-cascader>

--- a/ui/src/workflow/common/app-node.ts
+++ b/ui/src/workflow/common/app-node.ts
@@ -75,6 +75,7 @@ class AppNode extends HtmlResize.view {
     }
     result.push({
       value: this.props.model.id,
+      icon: this.props.model.properties.node_data?.icon,
       label: this.props.model.properties.stepName,
       type: this.props.model.type,
       children: this.props.model.properties?.config?.fields || [],


### PR DESCRIPTION
fix: In workflow applications, the display of custom icons for sub applications and tools in the box below the variable selection is incorrect 