### PR TITLE
fix: After selecting the knowledge base for the knowledge base retrieval node, copy the node, but the new node does not have the control for selecting the knowledge base

### DIFF
--- a/ui/src/workflow/common/shortcut.ts
+++ b/ui/src/workflow/common/shortcut.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash'
 import type LogicFlow from '@logicflow/core'
 import { type GraphModel } from '@logicflow/core'
 import { MsgSuccess, MsgError, MsgConfirm } from '@/utils/message'
@@ -63,7 +64,7 @@ export function initDefaultShortcut(lf: LogicFlow, graph: GraphModel) {
       MsgError(base_nodes[0]?.properties?.stepName + t('views.applicationWorkflow.tip.cannotCopy'))
       return
     }
-    selected = elements
+    selected = cloneDeep(elements)
     selected.nodes.forEach((node: any) => translationNodeData(node, TRANSLATION_DISTANCE))
     selected.edges.forEach((edge: any) => translationEdgeData(edge, TRANSLATION_DISTANCE))
     MsgSuccess(t('views.applicationWorkflow.tip.copyError'))

--- a/ui/src/workflow/nodes/search-knowledge-node/index.vue
+++ b/ui/src/workflow/nodes/search-knowledge-node/index.vue
@@ -196,6 +196,7 @@ function addKnowledge(val: Array<any>) {
     'knowledge_id_list',
     val.map((item) => item.id),
   )
+  set(props.nodeModel.properties.node_data, 'knowledge_list', val)
   knowledgeList.value = val
 }
 


### PR DESCRIPTION
fix: After selecting the knowledge base for the knowledge base retrieval node, copy the node, but the new node does not have the control for selecting the knowledge base 