### PR TITLE
fix: validate JSON object in form submission

### DIFF
--- a/ui/src/views/tool/McpToolFormDrawer.vue
+++ b/ui/src/views/tool/McpToolFormDrawer.vue
@@ -246,7 +246,10 @@ const submit = async (formEl: FormInstance | undefined) => {
   await formEl.validate((valid: any) => {
     if (valid) {
       try {
-        JSON.parse(form.value.code as string)
+        const parsed = JSON.parse(form.value.code as string)
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+          throw new Error('Code must be a valid JSON object')
+        }
       } catch (e) {
         MsgError(t('views.applicationWorkflow.nodes.mcpNode.mcpServerTip'))
         return

--- a/ui/src/views/tool/toolStore/ToolStoreDialog.vue
+++ b/ui/src/views/tool/toolStore/ToolStoreDialog.vue
@@ -179,11 +179,9 @@ function open(id: string) {
   folderId.value = id
   filterList.value = null
   dialogVisible.value = true
-}
 
-onBeforeMount(() => {
   getList()
-})
+}
 
 async function getList() {
   if (toolType.value === 'INTERNAL') {

--- a/ui/src/views/tool/toolStore/ToolStoreDialog.vue
+++ b/ui/src/views/tool/toolStore/ToolStoreDialog.vue
@@ -222,11 +222,6 @@ async function getStoreToolList() {
       tool.desc = tool.description
     })
 
-    if (storeTools.length === 0) {
-      filterList.value = []
-      return
-    }
-
     categories.value = tags.map((tag: any) => ({
       id: tag.key,
       title: tag.name, // 国际化


### PR DESCRIPTION
chore: refactor ToolStoreDialog.vue to streamline onBeforeMount usage<br>chore: remove unnecessary check for empty storeTools in ToolStoreDialog<br>fix: validate JSON object in form submission 