### PR TITLE
fix: handle tooltip display for labels in index.vue

### DIFF
--- a/ui/src/workflow/nodes/mcp-node/index.vue
+++ b/ui/src/workflow/nodes/mcp-node/index.vue
@@ -130,7 +130,8 @@
             <template #label>
               <div class="flex-between">
                 <div>
-                  <TooltipLabel :label="item.label.label" :tooltip="item.label.attrs.tooltip" />
+                  <TooltipLabel v-if="item.label.attrs.tooltip" :label="item.label.label" :tooltip="item.label.attrs.tooltip" />
+                  <span v-else>{{ item.label.label }}</span>
                   <span v-if="item.required" class="color-danger">*</span>
                 </div>
                 <el-select
@@ -199,7 +200,8 @@
             <template #label>
               <div class="flex-between">
                 <div>
-                  <TooltipLabel :label="item.label.label" :tooltip="item.label.attrs.tooltip" />
+                  <TooltipLabel v-if="item.label.attrs.tooltip" :label="item.label.label" :tooltip="item.label.attrs.tooltip" />
+                  <span v-else>{{ item.label.label }}</span>
                   <span v-if="item.required" class="color-danger">*</span>
                 </div>
                 <el-select


### PR DESCRIPTION
fix: handle tooltip display for labels in index.vue  --bug=1062579 --user=刘瑞斌 【应用】MCP节点中，工具参数没有提示信息，依然显示提示图标，提示信息为空 https://www.tapd.cn/62980211/s/1783808 