### PR TITLE
fix: Variable splitting node expression not validated

### DIFF
--- a/ui/src/workflow/nodes/variable-splitting/component/VariableFieldDialog.vue
+++ b/ui/src/workflow/nodes/variable-splitting/component/VariableFieldDialog.vue
@@ -50,8 +50,7 @@
       <el-form-item
         :label="$t('views.applicationWorkflow.nodes.variableSplittingNode.expression.label')"
         :required="true"
-        prop="label"
-        :rules="rules.label"
+        prop="expression"
       >
         <el-input
           v-model="form.expression"


### PR DESCRIPTION
fix: Variable splitting node expression not validated 