### PR TITLE
fix: When collecting data from the multiple-choice box of the form collection node, it is recommended to support pressing enter to select the option

### DIFF
--- a/ui/src/components/dynamics-form/items/select/MultiSelect.vue
+++ b/ui/src/components/dynamics-form/items/select/MultiSelect.vue
@@ -5,6 +5,7 @@
     filterable
     allow-create
     clearable
+    default-first-option
     :reserve-keyword="false"
     v-bind="$attrs"
     v-model="_modelValue"


### PR DESCRIPTION
fix: When collecting data from the multiple-choice box of the form collection node, it is recommended to support pressing enter to select the option 