### PR TITLE
fix: When extracting parameters, input parameters that are not strings result in the node being unable to execute

### DIFF
--- a/apps/application/flow/step_node/parameter_extraction_node/impl/base_parameter_extraction_node.py
+++ b/apps/application/flow/step_node/parameter_extraction_node/impl/base_parameter_extraction_node.py
@@ -91,6 +91,7 @@ class BaseParameterExtractionNode(IParameterExtractionNode):
         self.context['request'] = details.get('request')
 
     def execute(self, input_variable, variable_list, model_params_setting, model_id, **kwargs) -> NodeResult:
+        input_variable = str(input_variable)
         self.context['request'] = input_variable
         if model_params_setting is None:
             model_params_setting = get_default_model_params_setting(model_id)


### PR DESCRIPTION
fix: When extracting parameters, input parameters that are not strings result in the node being unable to execute 