### PR TITLE
fix: When the workflow does not respond, there is an error in the historical chat record data

### DIFF
--- a/apps/application/models/application_chat.py
+++ b/apps/application/models/application_chat.py
@@ -9,7 +9,7 @@
 import uuid_utils.compat as uuid
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 from langchain_core.messages import HumanMessage, AIMessage
 
 from application.models import Application


### PR DESCRIPTION
fix: When the workflow does not respond, there is an error in the historical chat record data 