### PR TITLE
fix: In the variable aggregation strategy that returns the first non-null value of each group, empty strings, empty lists, and empty objects are not treated as null values

### DIFF
--- a/apps/application/flow/step_node/variable_aggregation_node/impl/base_variable_aggregation_node.py
+++ b/apps/application/flow/step_node/variable_aggregation_node/impl/base_variable_aggregation_node.py
@@ -25,7 +25,7 @@ class BaseVariableAggregationNode(IVariableAggregation):
             v = self.workflow_manage.get_reference_field(
                 variable.get('variable')[0],
                 variable.get('variable')[1:])
-            if v is not None:
+            if v is not None and not(isinstance(v, (str,list,dict)) and len(v) == 0) :
                 return v
         return None
 


### PR DESCRIPTION
fix: In the variable aggregation strategy that returns the first non-null value of each group, empty strings, empty lists, and empty objects are not treated as null values 