### PR TITLE
fix: When there are user input parameters in the workflow, the data source setting information is cleared after returning to the previous step from the user input page

### DIFF
--- a/ui/src/views/knowledge-workflow/component/DebugDrawer.vue
+++ b/ui/src/views/knowledge-workflow/component/DebugDrawer.vue
@@ -10,7 +10,7 @@
     :close-on-press-escape="false"
   >
     <div style="height: calc(100% - 57px)" v-loading="loading">
-      <keep-alive :key="key" :include="['data_source', 'knowledge_base']">
+      <keep-alive :key="key" :include="['DataSource', 'KnowledgeBase']">
         <component
           ref="ActionRef"
           :is="ak[active]"


### PR DESCRIPTION
fix: When there are user input parameters in the workflow, the data source setting information is cleared after returning to the previous step from the user input page 