### PR TITLE
fix: When adding a new node, the default execution condition is' all ', which often results in errors. Adjust it to default to any

### DIFF
--- a/ui/src/components/workflow-dropdown-menu/knowledge-inner/index.vue
+++ b/ui/src/components/workflow-dropdown-menu/knowledge-inner/index.vue
@@ -177,6 +177,7 @@ function clickNodes(item: any, data?: any) {
       })),
     }
   }
+  item['properties']['condition'] = 'OR'
   props.workflowRef?.addNode(item)
 
   emit('clickNodes', item)
@@ -188,6 +189,7 @@ function onmousedown(item: any, data?: any) {
     if (data.tool_type == 'DATA_SOURCE') {
       item['properties'].kind = WorkflowKind.DataSource
     }
+
     item['properties']['node_data'] = {
       ...data,
       tool_lib_id: data.id,
@@ -197,6 +199,7 @@ function onmousedown(item: any, data?: any) {
       })),
     }
   }
+  item['properties']['condition'] = 'OR'
   props.workflowRef?.onmousedown(item)
   emit('onmousedown', item)
 }

--- a/ui/src/components/workflow-dropdown-menu/knowledge/index.vue
+++ b/ui/src/components/workflow-dropdown-menu/knowledge/index.vue
@@ -199,8 +199,8 @@ function clickNodes(item: any, data?: any) {
       })),
     }
   }
+  item['properties']['condition'] = 'OR'
   props.workflowRef?.addNode(item)
-
   emit('clickNodes', item)
 }
 
@@ -219,6 +219,7 @@ function onmousedown(item: any, data?: any) {
       })),
     }
   }
+  item['properties']['condition'] = 'OR'
   props.workflowRef?.onmousedown(item)
   emit('onmousedown', item)
 }


### PR DESCRIPTION
fix: When adding a new node, the default execution condition is' all ', which often results in errors. Adjust it to default to any 