### PR TITLE
fix: Application List - Hold down Ctrl+to set the new window opened to still be the application list page

### DIFF
--- a/ui/src/views/application/index.vue
+++ b/ui/src/views/application/index.vue
@@ -568,7 +568,10 @@ function settingApplication(event: any, row: any) {
     if (event?.ctrlKey) {
       event?.preventDefault()
       event.stopPropagation()
-      window.open(`/application/workspace/${row.id}/workflow`, '_blank')
+      const newUrl = router.resolve({
+        path: `/application/workspace/${row.id}/workflow`,
+      }).href
+      window.open(newUrl)
     } else {
       router.push({ path: `/application/workspace/${row.id}/workflow` })
     }


### PR DESCRIPTION
fix: Application List - Hold down Ctrl+to set the new window opened to still be the application list page 