### PR TITLE
fix: After renaming the predecessor node, the variable list was not updated

### DIFF
--- a/ui/src/workflow/common/NodeContainer.vue
+++ b/ui/src/workflow/common/NodeContainer.vue
@@ -254,6 +254,7 @@ const editName = async (formEl: FormInstance | undefined) => {
           ?.some((node: any) => node.properties.stepName === form.value.title)
       ) {
         set(props.nodeModel.properties, 'stepName', form.value.title)
+        props.nodeModel.clear_next_node_field(true)
         nodeNameDialogVisible.value = false
         formEl.resetFields()
       } else {


### PR DESCRIPTION
fix: After renaming the predecessor node, the variable list was not updated 