### PR TITLE
fix: In the execution details, the display order of the child nodes of the loop body is incorrect

### DIFF
--- a/ui/src/components/ai-chat/component/knowledge-source-component/ExecutionDetailCard.vue
+++ b/ui/src/components/ai-chat/component/knowledge-source-component/ExecutionDetailCard.vue
@@ -1001,7 +1001,7 @@
                 <template
                   v-for="(cLoop, cIndex) in Object.values(
                     data.loop_node_data?.[currentLoopNode] || [],
-                  )"
+                  ).sort((x: any, y: any) => (x.index || 0) - (y.index || 0))"
                   :key="cIndex"
                 >
                   <ExecutionDetailCard :data="cLoop"></ExecutionDetailCard>


### PR DESCRIPTION
fix: In the execution details, the display order of the child nodes of the loop body is incorrect 