### PR TITLE
fix: Application The parent application embeds the child application …

### DIFF
--- a/apps/application/flow/step_node/application_node/impl/base_application_node.py
+++ b/apps/application/flow/step_node/application_node/impl/base_application_node.py
@@ -171,6 +171,14 @@ class BaseApplicationNode(IApplicationNode):
         if self.node_params.get('is_result', False):
             self.answer_text = details.get('answer')
 
+    def get_chat_asker(self, kwargs):
+        asker = kwargs.get('asker')
+        if asker:
+            if isinstance(asker, dict):
+                return asker
+            return {'username': asker}
+        return self.workflow_manage.work_flow_post_handler.chat_info.get_chat_user()
+
     def execute(self, application_id, message, chat_id, chat_record_id, stream, re_chat,
                 chat_user_id,
                 chat_user_type,
@@ -185,7 +193,8 @@ class BaseApplicationNode(IApplicationNode):
             'application_id': application_id,
             'abstract': message[0:1024],
             'chat_user_id': chat_user_id,
-            'chat_user_type': chat_user_type
+            'chat_user_type': chat_user_type,
+            'asker': self.get_chat_asker(kwargs)
         })
         if app_document_list is None:
             app_document_list = []

--- a/apps/application/models/application_chat.py
+++ b/apps/application/models/application_chat.py
@@ -26,7 +26,7 @@ class ChatUserType(models.TextChoices):
 
 
 def default_asker():
-    return {'user_name': '游客'}
+    return {'username': '游客'}
 
 
 class Chat(AppModelMixin):


### PR DESCRIPTION
…and sets the variable by passing the parameter "akser" through the interface. The sub application is not displayed in the conversation log

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.