### PR TITLE
fix: In the execution details, the execution time of the loop node is displayed incorrectly

### DIFF
--- a/apps/application/flow/step_node/loop_node/impl/base_loop_node.py
+++ b/apps/application/flow/step_node/loop_node/impl/base_loop_node.py
@@ -205,6 +205,7 @@ def loop(workflow_manage_new_instance, node: INode, generate_loop):
     node.context['loop_answer_data'] = loop_answer_data
     node.context["index"] = current_index
     node.context["item"] = current_index
+    node.context['run_time'] = time.time() - node.context.get("start_time")
 
 
 def get_write_context(loop_type, array, number, loop_body):

--- a/ui/src/workflow/nodes/loop-body-node/index.vue
+++ b/ui/src/workflow/nodes/loop-body-node/index.vue
@@ -12,7 +12,7 @@ import Dagre from '@/workflow/plugins/dagre'
 import { initDefaultShortcut } from '@/workflow/common/shortcut'
 import LoopBodyContainer from '@/workflow/nodes/loop-body-node/LoopBodyContainer.vue'
 import { WorkflowMode } from '@/enums/application'
-import { WorkFlowInstance } from '@/workflow/common/validate'
+import { WorkFlowInstance, KnowledgeWorkFlowInstance } from '@/workflow/common/validate'
 import { t } from '@/locales'
 import { disconnectByFlow } from '@/workflow/common/teleport'
 const loop_workflow_mode = inject('loopWorkflowMode') || WorkflowMode.ApplicationLoop
@@ -21,7 +21,10 @@ const props = defineProps<{ nodeModel: any }>()
 const containerRef = ref()
 const LoopBodyContainerRef = ref<InstanceType<typeof LoopBodyContainer>>()
 const validate = () => {
-  const workflow = new WorkFlowInstance(lf.value.getGraphData(), WorkflowMode.ApplicationLoop)
+  const workflow =
+    loop_workflow_mode == WorkflowMode.ApplicationLoop
+      ? new WorkFlowInstance(lf.value.getGraphData(), WorkflowMode.ApplicationLoop)
+      : new KnowledgeWorkFlowInstance(lf.value.getGraphData(), WorkflowMode.KnowledgeLoop)
   return Promise.all(lf.value.graphModel.nodes.map((element: any) => element?.validate?.()))
     .then(() => {
       const loop_node_id = props.nodeModel.properties.loop_node_id


### PR DESCRIPTION
fix: Set up a complete knowledge base workflow in the loop body, debug prompts that the knowledge base write node cannot be used as the end node<br>fix: In the execution details, the execution time of the loop node is displayed incorrectly 