### PR TITLE
fix: Modify the parameter name and display name of the loop variable in the loop node, but the variable name is not updated in the nodes outside the loop

### DIFF
--- a/ui/src/workflow/nodes/loop-body-node/index.vue
+++ b/ui/src/workflow/nodes/loop-body-node/index.vue
@@ -69,6 +69,7 @@ const refresh_loop_fields = (fields: Array<any>) => {
   const loop_node = props.nodeModel.graphModel.getNodeModelById(loop_node_id)
   if (loop_node) {
     loop_node.properties.config.fields = fields
+    loop_node.clear_next_node_field(true)
   }
 }
 


### PR DESCRIPTION
fix: Modify the parameter name and display name of the loop variable in the loop node, but the variable name is not updated in the nodes outside the loop 