### PR TITLE
fix: Manually adding file types to the workflow knowledge base cannot upload files after adding them in lowercase letters

### DIFF
--- a/apps/application/flow/knowledge_workflow_manage.py
+++ b/apps/application/flow/knowledge_workflow_manage.py
@@ -95,9 +95,7 @@ class KnowledgeWorkflowManage(WorkflowManage):
             self.status = 500
             current_node.get_write_error_context(e)
             self.answer += str(e)
-            QuerySet(KnowledgeAction).filter(id=self.params.get('knowledge_action_id')).update(
-                details=self.get_runtime_details(),
-                state=State.FAILURE)
+            QuerySet(KnowledgeAction).filter(id=self.params.get('knowledge_action_id')).update(state=State.FAILURE)
         finally:
             current_node.node_chunk.end()
             QuerySet(KnowledgeAction).filter(id=self.params.get('knowledge_action_id')).update(

--- a/apps/common/encoder/encoder.py
+++ b/apps/common/encoder/encoder.py
@@ -15,6 +15,13 @@ from django.core.files.uploadedfile import InMemoryUploadedFile, TemporaryUpload
 
 
 class SystemEncoder(json.JSONEncoder):
+    def encode(self, obj):
+        # 先序列化为字符串
+        json_str = super().encode(obj)
+        # 移除所有空字符
+        json_str = json_str.replace('\\u0000', '')
+        return json_str
+
     def default(self, obj):
         if isinstance(obj, uuid.UUID):
             return str(obj)


### PR DESCRIPTION
fix: Manually adding file types to the workflow knowledge base cannot upload files after adding them in lowercase letters 