### PR TITLE
refactor: add LANGCHAIN_GRAPH_RECURSION_LIMIT env to avoid the error …

### DIFF
--- a/apps/application/flow/tools.py
+++ b/apps/application/flow/tools.py
@@ -12,7 +12,7 @@ import queue
 import re
 import threading
 from typing import Iterator
-
+from maxkb.const import CONFIG
 from django.http import StreamingHttpResponse
 from langchain_core.messages import BaseMessageChunk, BaseMessage, ToolMessage, AIMessageChunk
 from langchain_mcp_adapters.client import MultiServerMCPClient
@@ -313,7 +313,7 @@ async def _yield_mcp_response(chat_model, message_list, mcp_servers, mcp_output_
     try:
         client = MultiServerMCPClient(json.loads(mcp_servers))
         tools = await client.get_tools()
-        agent = create_react_agent(chat_model, tools)
+        agent = create_react_agent(chat_model, tools).configure(recursion_limit=(int(CONFIG.get("LANGCHAIN_GRAPH_RECURSION_LIMIT", '25'))))
         response = agent.astream({"messages": message_list}, stream_mode='messages')
 
         # 用于存储工具调用信息（按 tool_id）以及按 index 聚合分片


### PR DESCRIPTION
…"GraphRecursionError: Recursion limit of 25 reached without hitting a stop condition. You can increase the limit by setting the recursion_limit config key. For troubleshooting, visit: https://python.langchain.com/docs/troubleshooting/errors/GRAPH_RECURSION_LIMIT "

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.