### PR TITLE
fix: When executing the knowledge base workflow, the loop node reported an error and the workflow was not terminated

### DIFF
--- a/apps/application/flow/knowledge_workflow_manage.py
+++ b/apps/application/flow/knowledge_workflow_manage.py
@@ -89,6 +89,8 @@ class KnowledgeWorkflowManage(WorkflowManage):
             if result is not None:
                 # 阻塞获取结果
                 list(result)
+            if current_node.status == 500:
+                return None
             return current_result
         except Exception as e:
             traceback.print_exc()


### PR DESCRIPTION
fix: When executing the knowledge base workflow, the loop node reported an error and the workflow was not terminated 