### PR TITLE
fix: The MCP calling node in the workflow knowledge base references MCP, but the workflow knowledge base is not displayed in the associated resources of the referenced MCP

### DIFF
--- a/apps/application/flow/tools.py
+++ b/apps/application/flow/tools.py
@@ -434,7 +434,9 @@ async def anext_async(agen):
 
 
 target_source_node_mapping = {
-    'TOOL': {'tool-lib-node': lambda n: [n.get('properties').get('node_data').get('tool_lib_id')]},
+    'TOOL': {'tool-lib-node': lambda n: [n.get('properties').get('node_data').get('tool_lib_id')],
+             'ai-chat-node': lambda n: [...([n.get('properties').get('node_data').get('mcp_tool_ids')] or []),
+                                        ...([n.get('properties').get('node_data').get('tool_ids')] or [])]},
     'MODEL': {'ai-chat-node': lambda n: [n.get('properties').get('node_data').get('model_id')],
               'question-node': lambda n: [n.get('properties').get('node_data').get('model_id')],
               'speech-to-text-node': lambda n: [n.get('properties').get('node_data').get('stt_model_id')],
@@ -444,7 +446,7 @@ target_source_node_mapping = {
               'intent-node': lambda n: [n.get('properties').get('node_data').get('model_id')],
               'image-understand-node': lambda n: [n.get('properties').get('node_data').get('model_id')],
               'parameter-extraction-node': lambda n: [n.get('properties').get('node_data').get('model_id')],
-              'video-understand-node': lambda n: [n.get('properties').get('node_data').get('model_id')]
+              'video-understand-node': lambda n: [n.get('properties').get('node_data').get('model_id')],
               },
     'KNOWLEDGE': {'search-knowledge-node': lambda n: n.get('properties').get('node_data').get('knowledge_id_list')},
     'APPLICATION': {


### PR DESCRIPTION
fix: The MCP calling node in the workflow knowledge base references MCP, but the workflow knowledge base is not displayed in the associated resources of the referenced MCP 