### PR TITLE
fix: The workflow jumps out of the loop node and is judged as empty, resulting in an error message

### DIFF
--- a/apps/application/flow/step_node/loop_break_node/i_loop_break_node.py
+++ b/apps/application/flow/step_node/loop_break_node/i_loop_break_node.py
@@ -18,7 +18,7 @@ from application.flow.i_step_node import NodeResult
 
 class ConditionSerializer(serializers.Serializer):
     compare = serializers.CharField(required=True, label=_("Comparator"))
-    value = serializers.CharField(required=True, label=_("value"))
+    value = serializers.CharField(required=False, allow_null=True, allow_blank=True, label=_("value"))
     field = serializers.ListField(required=True, label=_("Fields"))
 
 


### PR DESCRIPTION
fix: The workflow jumps out of the loop node and is judged as empty, resulting in an error message 