### PR TITLE
fix: The parameters for advanced orchestration in trigger task execution have been changed from custom to reference mode, and the parameters have disappeared

### DIFF
--- a/ui/src/views/trigger/component/ApplicationParameter.vue
+++ b/ui/src/views/trigger/component/ApplicationParameter.vue
@@ -142,7 +142,7 @@
 
         <el-cascader
           v-if="modelValue['api_input_field_list'][f.field].source === 'reference'"
-          v-model="modelValue[f.field].value"
+          v-model="modelValue['api_input_field_list'][f.field].value"
           :options="options"
           :placeholder="$t('common.selectPlaceholder')"
           :props="props"


### PR DESCRIPTION
fix: The parameters for advanced orchestration in trigger task execution have been changed from custom to reference mode, and the parameters have disappeared 