### PR TITLE
fix: [Trigger] When the request parameters triggered by an event are not mandatory, failing to pass the event parameters results in validation errors and request failure.

### DIFF
--- a/apps/trigger/handler/impl/trigger/event_trigger.py
+++ b/apps/trigger/handler/impl/trigger/event_trigger.py
@@ -56,8 +56,12 @@ def get_parameters(body_setting, request: Request):
     parameters = {}
     for body in body_setting:
         value = request.data.get(body.get('field'))
-        if value is None and body.get('required'):
+        required = body.get('required')
+        if value is None and required:
             raise AppApiException(500, f'{body.get("desc")} is required')
+        if value is None and not required:
+            parameters[body.get('field')] = None
+            continue
         _type = body.get('type')
         valid_parameter_type(value, _type, body.get("desc"))
         parameters[body.get('field')] = value


### PR DESCRIPTION
fix: [Trigger] When the request parameters triggered by an event are not mandatory, failing to pass the event parameters results in validation errors and request failure. 