### PR TITLE
fix: [Trigger] The parameters for advanced orchestration in the trigger task execution have been changed from custom to reference, causing the parameters to disappear.

### DIFF
--- a/ui/src/views/trigger/component/ApplicationParameter.vue
+++ b/ui/src/views/trigger/component/ApplicationParameter.vue
@@ -93,7 +93,7 @@
 
         <el-cascader
           v-if="modelValue['user_input_field_list'][f.field].source === 'reference'"
-          v-model="modelValue[f.field].value"
+          v-model="modelValue['user_input_field_list'][f.field].value"
           :options="options"
           :placeholder="$t('common.selectPlaceholder')"
           :props="props"


### PR DESCRIPTION
fix: [Trigger] The parameters for advanced orchestration in the trigger task execution have been changed from custom to reference, causing the parameters to disappear. 