### PR TITLE
fix: [Tool] Trigger triggered execution tool, the execution details record the startup parameters

### DIFF
--- a/apps/application/flow/common.py
+++ b/apps/application/flow/common.py
@@ -242,7 +242,8 @@ class Workflow:
             raise AppApiException(500, _('There can only be one starting node'))
 
     def is_valid_model_params(self):
-        node_list = [node for node in self.nodes if (node.type == 'ai-chat-node' or node.type == 'question-node')]
+        node_list = [node for node in self.nodes if (
+                    node.type == 'ai-chat-node' or node.type == 'question-node' or node.type == 'parameter-extraction-node')]
         for node in node_list:
             model = QuerySet(Model).filter(id=node.properties.get('node_data', {}).get('model_id')).first()
             if model is None:

--- a/apps/trigger/handler/impl/task/tool_task.py
+++ b/apps/trigger/handler/impl/task/tool_task.py
@@ -147,10 +147,8 @@ class ToolTask(BaseTriggerTask):
             init_params_default_value = {i["field"]: i.get('default_value') for i in tool.init_field_list}
 
             if tool.init_params is not None:
-                all_params = init_params_default_value | json.loads(rsa_long_decrypt(tool.init_params)) | parameters
-            else:
-                all_params = init_params_default_value | parameters
-
+                parameters = json.loads(rsa_long_decrypt(tool.init_params)) | parameters
+            all_params = init_params_default_value | parameters
             result = executor.exec_code(tool.code, all_params)
 
             result_dict = _get_result_detail(result)
@@ -165,7 +163,7 @@ class ToolTask(BaseTriggerTask):
             QuerySet(ToolRecord).filter(id=task_record_id).update(
                 state=State.SUCCESS,
                 run_time=time.time() - start_time,
-                meta={'input': all_params, 'output': result_dict}
+                meta={'input': parameters, 'output': result_dict}
             )
         except Exception as e:
             maxkb_logger.error(f"Tool execution error: {traceback.format_exc()}")


### PR DESCRIPTION
fix: There is no prompt when the model in the parameter extraction node of the [Agent] does not exist.<br>fix: [Tool] Trigger triggered execution tool, the execution details record the startup parameters 