### PR TITLE
fix: AI conversation nodes connected after parallel nodes have different contexts when they first arrive at AI conversation nodes in different branches #4778

### DIFF
--- a/apps/application/flow/common.py
+++ b/apps/application/flow/common.py
@@ -170,7 +170,7 @@ class Workflow:
         @param node_id: 节点id
         @return: 节点列表
         """
-        return [en.node for en in self.up_node_map.get(node_id)]
+        return [en.node for en in (self.up_node_map.get(node_id) or [])]
 
     def get_next_nodes(self, node_id) -> List[Node]:
         """
@@ -243,7 +243,7 @@ class Workflow:
 
     def is_valid_model_params(self):
         node_list = [node for node in self.nodes if (
-                    node.type == 'ai-chat-node' or node.type == 'question-node' or node.type == 'parameter-extraction-node')]
+                node.type == 'ai-chat-node' or node.type == 'question-node' or node.type == 'parameter-extraction-node')]
         for node in node_list:
             model = QuerySet(Model).filter(id=node.properties.get('node_data', {}).get('model_id')).first()
             if model is None:

--- a/apps/application/flow/workflow_manage.py
+++ b/apps/application/flow/workflow_manage.py
@@ -664,9 +664,16 @@ class WorkflowManage:
                         f"{edge.sourceNodeId}_{current_node_result.node_variable.get('branch_id')}_right" == edge.sourceAnchorId):
                     if next_node.properties.get('condition', "AND") == 'AND':
                         if self.dependent_node_been_executed(edge.targetNodeId):
+                            up_nodes = self.flow.get_up_nodes(edge.targetNodeId)
+                            up_node_id_list = current_node.up_node_id_list
+                            if up_nodes and len(up_nodes) > 1:
+                                up_nodes.sort(key=lambda node: node.id)
+                                first = up_nodes[0]
+                                up_node_id_list = [n_c for n_c in self.node_context if n_c.node.id == first.id][
+                                    0].up_node_id_list
                             node_list.append(
                                 self.get_node_cls_by_id(edge.targetNodeId,
-                                                        [*current_node.up_node_id_list, current_node.node.id]))
+                                                        [*up_node_id_list, current_node.node.id]))
                     else:
                         node_list.append(
                             self.get_node_cls_by_id(edge.targetNodeId,
@@ -678,9 +685,16 @@ class WorkflowManage:
                     next_node = edge_node.node
                     if next_node.properties.get('condition', "AND") == 'AND':
                         if self.dependent_node_been_executed(edge.targetNodeId):
+                            up_nodes = self.flow.get_up_nodes(edge.targetNodeId)
+                            up_node_id_list = current_node.up_node_id_list
+                            if up_nodes and len(up_nodes) > 1:
+                                up_nodes.sort(key=lambda node: node.id)
+                                first = up_nodes[0]
+                                up_node_id_list = [n_c for n_c in self.node_context if n_c.node.id == first.id][
+                                    0].up_node_id_list
                             node_list.append(
                                 self.get_node_cls_by_id(edge.targetNodeId,
-                                                        [*current_node.up_node_id_list, current_node.node.id]))
+                                                        [*up_node_id_list, current_node.node.id]))
                     else:
                         node_list.append(
                             self.get_node_cls_by_id(edge.targetNodeId,


### PR DESCRIPTION
fix: AI conversation nodes connected after parallel nodes have different contexts when they first arrive at AI conversation nodes in different branches #4778 