### PR TITLE
fix: AI conversation nodes connected after parallel nodes have different contexts when they first arrive at AI conv

### DIFF
--- a/apps/application/flow/workflow_manage.py
+++ b/apps/application/flow/workflow_manage.py
@@ -665,15 +665,16 @@ class WorkflowManage:
                     if next_node.properties.get('condition', "AND") == 'AND':
                         if self.dependent_node_been_executed(edge.targetNodeId):
                             up_nodes = self.flow.get_up_nodes(edge.targetNodeId)
-                            up_node_id_list = current_node.up_node_id_list
+                            up_node_id_list = [*current_node.up_node_id_list, current_node.node.id]
                             if up_nodes and len(up_nodes) > 1:
                                 up_nodes.sort(key=lambda node: node.id)
                                 first = up_nodes[0]
                                 up_node_id_list = [n_c for n_c in self.node_context if n_c.node.id == first.id][
                                     0].up_node_id_list
+                                up_node_id_list = [*up_node_id_list, first.id]
                             node_list.append(
                                 self.get_node_cls_by_id(edge.targetNodeId,
-                                                        [*up_node_id_list, current_node.node.id]))
+                                                        up_node_id_list))
                     else:
                         node_list.append(
                             self.get_node_cls_by_id(edge.targetNodeId,
@@ -686,15 +687,16 @@ class WorkflowManage:
                     if next_node.properties.get('condition', "AND") == 'AND':
                         if self.dependent_node_been_executed(edge.targetNodeId):
                             up_nodes = self.flow.get_up_nodes(edge.targetNodeId)
-                            up_node_id_list = current_node.up_node_id_list
+                            up_node_id_list = [*current_node.up_node_id_list, current_node.node.id]
                             if up_nodes and len(up_nodes) > 1:
                                 up_nodes.sort(key=lambda node: node.id)
                                 first = up_nodes[0]
                                 up_node_id_list = [n_c for n_c in self.node_context if n_c.node.id == first.id][
                                     0].up_node_id_list
+                                up_node_id_list = [*up_node_id_list, first.id]
                             node_list.append(
                                 self.get_node_cls_by_id(edge.targetNodeId,
-                                                        [*up_node_id_list, current_node.node.id]))
+                                                        up_node_id_list))
                     else:
                         node_list.append(
                             self.get_node_cls_by_id(edge.targetNodeId,


### PR DESCRIPTION
fix: AI conversation nodes connected after parallel nodes have different contexts when they first arrive at AI conv ersation nodes in different branches #4778 (#4797) 