### PR TITLE
refactor: move chat share endpoints to chat API routes and remove workspace_id from share-link flow

### DIFF
--- a/apps/application/api/application_chat_link.py
+++ b/apps/application/api/application_chat_link.py
@@ -27,13 +27,6 @@ class ChatRecordLinkAPI(APIMixin):
     def get_parameters():
         return [
             OpenApiParameter(
-                name="workspace_id",
-                description="工作空间id",
-                type=OpenApiTypes.STR,
-                location='path',
-                required=True,
-            ),
-            OpenApiParameter(
                 name="application_id",
                 description="Application ID",
                 type=OpenApiTypes.STR,

--- a/apps/application/serializers/application_chat_link.py
+++ b/apps/application/serializers/application_chat_link.py
@@ -35,7 +35,6 @@ class ChatRecordShareLinkRequestSerializer(serializers.Serializer):
 
 class ChatRecordShareLinkSerializer(serializers.Serializer):
     chat_id = serializers.UUIDField(required=True, label=_("Conversation ID"))
-    workspace_id = serializers.CharField(required=False, allow_null=True, allow_blank=True, label=_("Workspace ID"))
     application_id = serializers.UUIDField(required=True, label=_("Application ID"))
     user_id = serializers.UUIDField(required=False, label=_("User ID"))
 

--- a/apps/application/urls.py
+++ b/apps/application/urls.py
@@ -24,7 +24,6 @@ urlpatterns = [
     path('workspace/<str:workspace_id>/application/<str:application_id>/chat', views.ApplicationChat.as_view()),
     path('workspace/<str:workspace_id>/application/<str:application_id>/chat/export', views.ApplicationChat.Export.as_view()),
     path('workspace/<str:workspace_id>/application/<str:application_id>/chat/<int:current_page>/<int:page_size>', views.ApplicationChat.Page.as_view()),
-    path('workspace/<str:workspace_id>/application/<str:application_id>/chat/<str:chat_id>/share_chat', views.ChatRecordLinkView.as_view()),
     path('workspace/<str:workspace_id>/application/<str:application_id>/chat/<str:chat_id>/chat_record', views.ApplicationChatRecord.as_view()),
     path('workspace/<str:workspace_id>/application/<str:application_id>/chat/<str:chat_id>/chat_record/<str:chat_record_id>', views.ApplicationChatRecordOperateAPI.as_view()),
     path('workspace/<str:workspace_id>/application/<str:application_id>/chat/<str:chat_id>/chat_record/<int:current_page>/<int:page_size>', views.ApplicationChatRecord.Page.as_view()),
@@ -40,5 +39,4 @@ urlpatterns = [
     path('workspace/<str:workspace_id>/application/<str:application_id>/mcp_tools', views.McpServers.as_view()),
     path('workspace/<str:workspace_id>/application/<str:application_id>/model/<str:model_id>/prompt_generate', views.PromptGenerateView.as_view()),
     path('chat_message/<str:chat_id>', views.ChatView.as_view()),
-    path('chat/share/<str:link>', views.ChatRecordDetailView.as_view()),
 ]

--- a/apps/application/views/application_chat_link.py
+++ b/apps/application/views/application_chat_link.py
@@ -30,9 +30,8 @@ class ChatRecordLinkView(APIView):
         tags=[_("Chat record link")]  # type: ignore
     )
 
-    def post(self, request: Request, workspace_id: str, application_id: str, chat_id: str):
+    def post(self, request: Request, application_id: str, chat_id: str):
         return result.success(ChatRecordShareLinkSerializer(data={
-            "workspace_id": workspace_id,
             "application_id": application_id,
             "chat_id": chat_id,
             "user_id": request.auth.chat_user_id

--- a/apps/chat/urls.py
+++ b/apps/chat/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from application.views import ChatRecordDetailView, ChatRecordLinkView
 from chat.views.mcp import mcp_view
 from . import views
 
@@ -24,5 +25,7 @@ urlpatterns = [
     path('historical_conversation/clear',views.HistoricalConversationView.BatchDelete.as_view(), name='historical_conversation_clear'),
     path('historical_conversation/<str:chat_id>',views.HistoricalConversationView.Operate.as_view(), name='historical_conversation_operate'),
     path('historical_conversation_record/<str:chat_id>', views.HistoricalConversationRecordView.as_view(), name='historical_conversation_record'),
-    path('historical_conversation_record/<str:chat_id>/<int:current_page>/<int:page_size>', views.HistoricalConversationRecordView.PageView.as_view(), name='historical_conversation_record')
+    path('historical_conversation_record/<str:chat_id>/<int:current_page>/<int:page_size>', views.HistoricalConversationRecordView.PageView.as_view(), name='historical_conversation_record'),
+    path('share/<str:link>', ChatRecordDetailView.as_view()),
+    path('<str:application_id>/chat/<str:chat_id>/share_chat', ChatRecordLinkView.as_view()),
 ]


### PR DESCRIPTION
refactor: move chat share endpoints to chat API routes and remove workspace_id from share-link flow 