### PR TITLE
feat: `Variable splitting` supports JSON strings.

### DIFF
--- a/apps/application/flow/step_node/variable_splitting_node/impl/base_variable_splitting_node.py
+++ b/apps/application/flow/step_node/variable_splitting_node/impl/base_variable_splitting_node.py
@@ -6,6 +6,7 @@
     @date：2025/10/13 15:02
     @desc:
 """
+import json
 from jsonpath_ng import parse
 
 from application.flow.i_step_node import NodeResult
@@ -40,6 +41,12 @@ class BaseVariableSplittingNode(IVariableSplittingNode):
         self.context['exception_message'] = details.get('err_message')
 
     def execute(self, input_variable, variable_list, **kwargs) -> NodeResult:
+        if type(input_variable).__name__ == "str":
+            try:
+                input_variable = json.loads(input_variable)
+            except Exception:
+                pass
+
         self.context['request'] = input_variable
         response = {v['field']: smart_jsonpath_search(input_variable, v['expression']) for v in variable_list}
         return NodeResult({'result': response, **response}, {})


### PR DESCRIPTION
#### What this PR does / why we need it?
feat: Variable splitting supports JSON strings.

#### Summary of your change
`变量拆分`：自动将 `str` 类型的变量转为 `obj` 类型，避免 JSON path 无法获取变量值。

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.