### PR TITLE
fix: Tool workflow restricts the deletion of basic nodes and start nodes

### DIFF
--- a/ui/src/workflow/common/shortcut.ts
+++ b/ui/src/workflow/common/shortcut.ts
@@ -104,6 +104,8 @@ export function initDefaultShortcut(lf: LogicFlow, graph: GraphModel) {
     const nodes = elements.nodes.filter((node) =>
       [
         'start-node',
+        'tool-start-node',
+        'tool-base-node',
         'base-node',
         'loop-body-node',
         'loop-start-node',


### PR DESCRIPTION
fix: Tool workflow restricts the deletion of basic nodes and start nodes 