### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "MaxKB",
+  "version": "0.1.0",
+  "description": "\ud83d\udd25 MaxKB is an open-source platform for building enterprise-grade agents.  \u5f3a\u5927\u6613\u7528\u7684\u5f00\u6e90\u4f01\u4e1a\u7ea7\u667a\u80fd\u4f53\u5e73\u53f0\u3002",
+  "author": {
+    "name": "1Panel-dev",
+    "url": "https://github.com/1Panel-dev"
+  },
+  "homepage": "https://github.com/1Panel-dev/MaxKB",
+  "repository": "https://github.com/1Panel-dev/MaxKB",
+  "keywords": [
+    "mcp",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,26 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@e83708a91ae4812872aa2905b99ad559a55c74ab
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "MaxKB": {
+      "command": "npx",
+      "args": [
+        "1Panel-dev-MaxKB"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I opened this as a small metadata pass for the Codex plugin surface in the repo.

A couple of repo-specific details I checked first:
- Model-Agnostic: Supports various large models, including private models (such as DeepSeek, Llama, Qwen, etc.) and public models (like OpenAI, Claude, Gemini, etc.)

This PR adds the Codex plugin metadata, an `.mcp.json` starting point, and the scanner workflow.
If you want different command wiring or manifest metadata, I can adjust the branch.