### PR TITLE
fix: In the newly created workflow tool canvas, the basic information and the start node overlap with each other

### DIFF
--- a/ui/src/workflow/common/data.ts
+++ b/ui/src/workflow/common/data.ts
@@ -99,8 +99,8 @@ export const toolBaseNode = {
 export const toolStartNode = {
   id: WorkflowType.ToolStartNode,
   type: WorkflowType.ToolStartNode,
-  x: 360,
-  y: 2761.3875,
+  x: 280,
+  y: 3301,
   text: '',
   properties: {
     height: 728.375,


### PR DESCRIPTION
fix: In the newly created workflow tool canvas, the basic information and the start node overlap with each other 