### PR TITLE
fix: replace bare except clauses with specific exception types

### DIFF
--- a/apps/application/flow/step_node/tool_node/impl/base_tool_node.py
+++ b/apps/application/flow/step_node/tool_node/impl/base_tool_node.py
@@ -51,7 +51,7 @@ def valid_reference_value(_type, value, name):
             raise Exception(_(
                 'Field: {name} Type: {_type} Value: {value} Unsupported types'
             ).format(name=name, _type=_type))
-    except:
+    except (json.JSONDecodeError, TypeError, ValueError):
         return value
     if not isinstance(value, instance_type):
         raise Exception(_(

--- a/apps/ops/celery/utils.py
+++ b/apps/ops/celery/utils.py
@@ -42,7 +42,7 @@ def get_task_log_path(base_path, task_id, level=2):
     task_id = str(task_id)
     try:
         uuid.UUID(task_id)
-    except:
+    except (ValueError, AttributeError):
         return os.path.join(PROJECT_DIR, 'data', 'caution.txt')
 
     rel_path = os.path.join(*task_id[:level], task_id + '.log')


### PR DESCRIPTION
## Summary

Fixes #5065

Replace bare `except:` clauses with specific exception types to prevent catching `KeyboardInterrupt` and `SystemExit`, which can prevent proper Celery worker shutdown and cause processes to hang.

## Changes

- **`apps/ops/celery/utils.py`**: Changed `except:` to `except (ValueError, AttributeError):` in UUID validation (`uuid.UUID()` raises `ValueError` on invalid input)
- **`apps/application/flow/step_node/tool_node/impl/base_tool_node.py`**: Changed `except:` to `except (json.JSONDecodeError, TypeError, ValueError):` in type validation (`json.loads()` raises `JSONDecodeError` on invalid JSON)

## Test plan

- [ ] Verify UUID validation still correctly rejects invalid task IDs
- [ ] Verify tool node type validation still correctly handles invalid JSON input
- [ ] Verify Celery worker can be cleanly shut down with SIGINT