### PR TITLE
fix: Add sync_type parameter to Web knowledge base sync API documentation

### DIFF
--- a/apps/knowledge/api/knowledge.py
+++ b/apps/knowledge/api/knowledge.py
@@ -221,6 +221,13 @@ class SyncWebAPI(APIMixin):
                 location='path',
                 required=True,
             ),
+            OpenApiParameter(
+                name="sync_type",
+                description="同步类型 (replace: 替换同步, complete: 完整同步)",
+                type=OpenApiTypes.STR,
+                location='query',
+                required=True,
+            ),
         ]
 
     @staticmethod


### PR DESCRIPTION
Fix Issue #5081: The Web knowledge base synchronization API documentation is missing the sync_type parameter, which leaves users unaware that this parameter must be provided. Add sync_type as a required query parameter, with supported values replace (replacement sync) or complete (full 


