### PR TITLE
fix: KeyError '_type' in convert_value exception message

### DIFF
--- a/apps/tools/serializers/tool.py
+++ b/apps/tools/serializers/tool.py
@@ -552,7 +552,7 @@ class ToolSerializer(serializers.Serializer):
                     raise Exception(_('type error'))
                 return value
             except Exception as e:
-                raise AppApiException(500, _('Field: {name} Type: {_type} Value: {value} Type conversion error').format(
+                raise AppApiException(500, _('Field: {name} Type: {type} Value: {value} Type conversion error').format(
                     name=name, type=_type, value=value
                 ))
 


### PR DESCRIPTION
#### What this PR does / why we need it?
Fixes a KeyError '_type' bug when executing tool debug with type conversion errors in MaxKB.

#### Summary of your change
When debugging a tool in MaxKB, if type conversion fails, the exception handler attempts to format an error message using '.format()' but the template key '{_type}' did not match the parameter name 'type', causing a KeyError.

Fixed in apps/tools/serializers/tool.py by changing the template key from '{_type}' to '{type}' to match the actual parameter name passed to format().

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.