### PR TITLE
fix: Fix the issue of image loading failure in the execution details of the `Image Understanding` node

### DIFF
--- a/apps/application/flow/step_node/image_understand_step_node/impl/base_image_understand_node.py
+++ b/apps/application/flow/step_node/image_understand_step_node/impl/base_image_understand_node.py
@@ -18,7 +18,7 @@ from models_provider.tools import get_model_instance_by_model_workspace_id
 def _write_context(node_variable: Dict, workflow_variable: Dict, node: INode, workflow, answer: str,
                    reasoning_content: str):
     chat_model = node_variable.get('chat_model')
-    message_tokens = node_variable['usage_metadata']['output_tokens'] if 'usage_metadata' in node_variable else 0
+    message_tokens = chat_model.get_num_tokens_from_messages(node_variable.get('message_list'))
     answer_tokens = chat_model.get_num_tokens(answer)
     node.context['message_tokens'] = message_tokens
     node.context['answer_tokens'] = answer_tokens
@@ -256,7 +256,7 @@ class BaseImageUnderstandNode(IImageUnderstandNode):
                         *[{'type': 'image_url',
                            'image_url': {'url': f'data:image/{base64_image[1]};base64,{base64_image[0]}'}} for
                           base64_image in image_base64_list],
-                        *[{'type': 'image_url', 'image_url': url} for url in url_list]
+                        *[{'type': 'image_url', 'image_url': {'url': url}} for url in url_list]
                     ])
         return HumanMessage(content=chat_record.problem_text)
 

--- a/apps/users/serializers/user.py
+++ b/apps/users/serializers/user.py
@@ -31,7 +31,6 @@ from common.exception.app_exception import AppApiException
 from common.utils.common import valid_license, password_encrypt, password_verify, get_random_chars
 from common.utils.rsa_util import decrypt
 from maxkb import settings
-from maxkb.const import CONFIG
 from maxkb.conf import PROJECT_DIR
 from maxkb.const import CONFIG
 from system_manage.models import SystemSetting, SettingType, AuthTargetType, WorkspaceUserResourcePermission

--- a/ui/src/components/execution-detail-card/index.vue
+++ b/ui/src/components/execution-detail-card/index.vue
@@ -595,7 +595,7 @@
                   <el-space wrap>
                     <template v-for="(f, i) in data.image_list" :key="i">
                       <el-image
-                        :src="f.url || f.file_id ? `./oss/file/${f.file_id}` : ''"
+                        :src="f.url || (f.file_id ? `./oss/file/${f.file_id}` : '')"
                         alt=""
                         fit="cover"
                         style="width: 40px; height: 40px; display: block"


### PR DESCRIPTION
#### What this PR does / why we need it?
fix: Fix the issue of image loading failure in the execution details of the `Image Understanding` node

fixes #5270 （顺便修复一下图片理解节点未成功计算输入tokens的问题）

#### Summary of your change
1. 修正 `图片理解` 节点的执行记录中，图片加载失败的问题。
<img width="964" height="701" alt="图片" src="https://github.com/user-attachments/assets/9e421d7e-36f3-46a1-9aeb-efa8284a3aef" />
