### PR TITLE
fix: Fix the `Parameter Extraction` node responded with incorrect attribute names when parameters were not extracted

### DIFF
--- a/apps/application/flow/step_node/parameter_extraction_node/impl/base_parameter_extraction_node.py
+++ b/apps/application/flow/step_node/parameter_extraction_node/impl/base_parameter_extraction_node.py
@@ -62,9 +62,9 @@ def generate_content(input_variable, variable_list):
     return value
 
 
-def json_loads(response, expected_fields):
+def json_loads(response, variable_list):
     if not response or not isinstance(response, str):
-        return {field: None for field in expected_fields}
+        return generate_example(variable_list)
 
     cleaned = response.strip()
 
@@ -79,7 +79,7 @@ def json_loads(response, expected_fields):
             return result
         except:
             continue
-    return generate_example(expected_fields)
+    return generate_example(variable_list)
 
 
 class BaseParameterExtractionNode(IParameterExtractionNode):


### PR DESCRIPTION
#### What this PR does / why we need it?
fix: Fix the `Parameter Extraction` node responded with incorrect attribute names when parameters were not extracted

#### Summary of your change
修复 `参数提取` 节点未提取到参数时，输出了错误的参数名的问题

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.