### PR TITLE
【不是BUG】fix: Fix not determined to be supported the trigger by the handler when undeploy trigger

### DIFF
--- a/apps/trigger/handler/simple_tools.py
+++ b/apps/trigger/handler/simple_tools.py
@@ -53,5 +53,6 @@ def undeploy(trigger, **kwargs):
     @return:
     """
     for simple_trigger_handler in simple_trigger_handlers:
-        return simple_trigger_handler.undeploy(trigger, **kwargs)
+        if simple_trigger_handler.support(trigger, **kwargs):
+            return simple_trigger_handler.undeploy(trigger, **kwargs)
     raise Exception("不支持的触发器类型")


### PR DESCRIPTION
#### What this PR does / why we need it?
fix; Fix not determined to be supported the trigger by the handler when undeploy trigger

#### Summary of your change
修复取消部署触发器时，未判断处理器是否支持该触发器的问题。

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.