### PR TITLE
fix(security): replace unsalted MD5 password hashing with PBKDF2 (CWE-327/CWE-916)

### DIFF
--- a/apps/common/utils/common.py
+++ b/apps/common/utils/common.py
@@ -17,6 +17,7 @@ import uuid
 from functools import reduce
 from typing import List, Dict
 
+from django.contrib.auth.hashers import check_password, make_password
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db.models import QuerySet
 from django.utils.translation import gettext as _
@@ -26,16 +27,62 @@ from ..database_model_manage.database_model_manage import DatabaseModelManage
 from ..exception.app_exception import AppApiException
 
 
+def _legacy_md5_hash(row_password):
+    """
+    Legacy MD5 hashing — used only to detect old hashes during migration.
+    Do NOT use for new passwords.
+    """
+    md5 = hashlib.md5()
+    md5.update(row_password.encode())
+    return md5.hexdigest()
+
+
 def password_encrypt(row_password):
     """
-    密码 md5加密
+    密码加密（使用 Django PBKDF2）
     :param row_password: 密码
     :return:  加密后密码
     """
-    md5 = hashlib.md5()  # 2，实例化md5() 方法
-    md5.update(row_password.encode())  # 3，对字符串的字节类型加密
-    result = md5.hexdigest()  # 4，加密
-    return result
+    return make_password(row_password)
+
+
+def password_verify(row_password, hashed_password):
+    """
+    验证密码是否匹配已存储的哈希值。
+    支持透明升级：如果存储的是旧版 MD5 哈希，也能正确验证。
+    :param row_password: 明文密码
+    :param hashed_password: 数据库中存储的密码哈希
+    :return: 是否匹配
+    """
+    # First try Django's built-in check (PBKDF2, bcrypt, argon2, etc.)
+    if check_password(row_password, hashed_password):
+        return True
+    # Fall back to legacy MD5 comparison for not-yet-migrated hashes
+    if _is_legacy_md5_hash(hashed_password):
+        return _legacy_md5_hash(row_password) == hashed_password
+    return False
+
+
+def _is_legacy_md5_hash(hashed_password):
+    """
+    Detect legacy unsalted MD5 hex-digest hashes (exactly 32 hex chars).
+    Django password hashes always contain '$' separators.
+    """
+    if hashed_password and len(hashed_password) == 32:
+        try:
+            int(hashed_password, 16)
+            return True
+        except ValueError:
+            pass
+    return False
+
+
+def needs_password_upgrade(hashed_password):
+    """
+    Check if a stored password hash should be upgraded to PBKDF2.
+    Returns True for legacy MD5 hashes.
+    """
+    return _is_legacy_md5_hash(hashed_password)
 
 
 def group_by(list_source: List, key):

--- a/apps/users/serializers/login.py
+++ b/apps/users/serializers/login.py
@@ -22,7 +22,7 @@ from common.constants.authentication_type import AuthenticationType
 from common.constants.cache_version import Cache_Version
 from common.database_model_manage.database_model_manage import DatabaseModelManage
 from common.exception.app_exception import AppApiException
-from common.utils.common import password_encrypt, get_random_chars
+from common.utils.common import password_encrypt, password_verify, needs_password_upgrade, get_random_chars
 from common.utils.rsa_util import decrypt
 from maxkb.const import CONFIG
 from users.models import User
@@ -65,7 +65,7 @@ def record_login_fail(username: str, expire: int = 600):
 def record_login_fail_lock(username: str, expire: int = 10):
     """
     使用 cache.incr 保证原子递增，并在不存在时初始化计数器并返回当前值。
-    这里的计数器用于判断是否应当进入“锁定”分支，避免依赖非原子 get -> set 的组合。
+    这里的计数器用于判断是否应当进入"锁定"分支，避免依赖非原子 get -> set 的组合。
     """
     if not username:
         return 0
@@ -144,15 +144,17 @@ class LoginSerializer(serializers.Serializer):
             if LoginSerializer._need_captcha(username, max_attempts):
                 LoginSerializer._validate_captcha(username, captcha)
 
-        # 验证用户凭据
-        user = User.objects.filter(
-            username=username,
-            password=password_encrypt(password)
-        ).first()
+        # 验证用户凭据：先按用户名查找，再用 password_verify 验证密码
+        user = User.objects.filter(username=username).first()
 
-        if not user:
+        if not user or not password_verify(password, user.password):
             LoginSerializer._handle_failed_login(username, is_license_valid, failed_attempts, lock_time)
             raise AppApiException(500, _('The username or password is incorrect'))
+
+        # Transparently upgrade legacy MD5 hash to PBKDF2
+        if needs_password_upgrade(user.password):
+            user.password = password_encrypt(password)
+            user.save(update_fields=['password'])
 
         if not user.is_active:
             raise AppApiException(1005, _("The user has been disabled, please contact the administrator!"))
@@ -213,7 +215,7 @@ class LoginSerializer(serializers.Serializer):
         - 使用 record_login_fail / record_login_fail_lock 两个原子 incr 来记录失败；
         - 不再依赖精确等于 0 的比较来触发锁，而是基于原子计数 >= 阈值来决定进入锁定分支；
         - 使用 cache.add 原子创建锁键，cache.add 保证只有第一个成功创建者可写入该键；
-          其他并发到达的请求若发现计数已到达阈值也应当返回“已锁定”响应，避免出现绕过。
+          其他并发到达的请求若发现计数已到达阈值也应当返回"已锁定"响应，避免出现绕过。
         """
         # 记录普通失败计数（供验证码触发使用）
         try:

--- a/apps/users/serializers/user.py
+++ b/apps/users/serializers/user.py
@@ -26,9 +26,10 @@ from common.constants.permission_constants import RoleConstants, Auth, ResourceA
 from common.database_model_manage.database_model_manage import DatabaseModelManage
 from common.db.search import page_search
 from common.exception.app_exception import AppApiException
-from common.utils.common import valid_license, password_encrypt, get_random_chars
+from common.utils.common import valid_license, password_encrypt, password_verify, get_random_chars
 from common.utils.rsa_util import decrypt
 from maxkb import settings
+from maxkb.const import CONFIG
 from maxkb.conf import PROJECT_DIR
 from system_manage.models import SystemSetting, SettingType, AuthTargetType, WorkspaceUserResourcePermission
 from users.models import User
@@ -116,7 +117,7 @@ class UserProfileSerializer(serializers.Serializer):
             'source': user.source,
             'role': auth.role_list,
             'permissions': auth.permission_list,
-            'is_edit_password': user.password == 'd880e722c47a34d8e9fce789fc62389d' if user.source == 'LOCAL' else False,
+            'is_edit_password': password_verify(CONFIG.get('DEFAULT_PASSWORD', 'MaxKB@123..'), user.password) if user.source == 'LOCAL' else False,
             'language': user.language,
             'workspace_list': workspace_list,
             'role_name': role_name


### PR DESCRIPTION
## Summary

Replace unsalted MD5 password hashing with Django's PBKDF2-SHA256 (`make_password` / `check_password`) for all user account passwords, while preserving login compatibility for any existing MD5-hashed passwords through transparent rehashing on next successful login.

## Vulnerability

- **Class:** CWE-327 (Use of a Broken or Risky Cryptographic Algorithm) / CWE-916 (Use of Password Hash With Insufficient Computational Effort)
- **Affected function:** `password_encrypt()` in `apps/common/utils/common.py`
- **Affected flow:** every code path that stores a user password — admin seeding (`apps/users/migrations/0001_initial.py`), user creation, password reset, profile update — and the login flow in `apps/users/serializers/login.py` that compared `password=password_encrypt(password)` directly in the DB query.

The previous implementation was:

```python
def password_encrypt(row_password):
    md5 = hashlib.md5()
    md5.update(row_password.encode())
    return md5.hexdigest()
```

This is unsalted MD5 with no work factor. Concretely:

1. The default admin user is seeded by migration with `password_encrypt('MaxKB@123..')`, producing the deterministic hash `d880e722c47a34d8e9fce789fc62389d` — a value previously hard-coded in `UserProfileSerializer` to detect "still using default password". Identical passwords across users produce identical hashes.
2. Any compromise that leaks the `user` table (SQL injection, backup leak, ops insider, dependency RCE, etc.) yields hashes that are trivially reversed via rainbow tables / GPU brute force at billions of guesses per second.
3. Recovered plaintext passwords enable credential stuffing against email, SSO, and other services where users reuse passwords — a real impact that DB read access alone does not provide.

The login serializer also filtered users by `password=password_encrypt(password)`, which both enforces the unsalted-hash design (you can't filter by a salted hash) and mixes the secret comparison into a SQL `WHERE` clause rather than a constant-time compare.

## Fix

`apps/common/utils/common.py`:
- `password_encrypt()` now delegates to Django's `make_password()` (PBKDF2-SHA256, per-password salt, ~600k iterations by default in modern Django).
- Added `password_verify()` that first calls `check_password()` (handles PBKDF2 and any future Django hasher) and falls back to a constant-shape MD5 check only when the stored value matches the legacy 32-hex-char shape.
- Added `needs_password_upgrade()` to detect legacy hashes for transparent rehashing.

`apps/users/serializers/login.py`:
- Replaced the `User.objects.filter(username=..., password=password_encrypt(...))` lookup with a username lookup followed by `password_verify(password, user.password)`.
- On successful login against a legacy MD5 hash, the stored hash is rewritten to PBKDF2 (`user.save(update_fields=['password'])`).

`apps/users/serializers/user.py`:
- Replaced the hard-coded MD5 comparison `user.password == 'd880e722c47a34d8e9fce789fc62389d'` (used to flag "default password still set") with `password_verify(CONFIG.get('DEFAULT_PASSWORD', 'MaxKB@123..'), user.password)`, which works for both legacy and PBKDF2 hashes.

All write-side callers of `password_encrypt()` (creation, reset, profile update, etc.) automatically store PBKDF2 output without further changes.

## What was tested

- Verified `make_password()` / `check_password()` round-trip for a sample password produces a PBKDF2 hash and verifies correctly.
- Verified `_is_legacy_md5_hash()` accepts a 32-hex-char string and rejects PBKDF2-formatted strings (which contain `$` separators).
- Walked the login flow end-to-end:
  - Fresh user → hash stored as `pbkdf2_sha256$...`, login succeeds via `check_password`.
  - Pre-existing MD5 hash → first login succeeds via the legacy fallback, then `needs_password_upgrade()` triggers and the row is rewritten to PBKDF2; subsequent logins go through the PBKDF2 path.
  - Wrong password → `password_verify` returns `False`, `_handle_failed_login` runs as before; lockout/captcha logic is unchanged.
- Confirmed no other code paths still call `hashlib.md5` for password storage; the only remaining MD5 use is the explicit legacy-fallback helper.
- Diff is intentionally minimal: 3 files, ~66 insertions / 16 deletions.

## Security analysis

- **Exploitability of the original bug:** any read of the `user` table reveals MD5 hashes that can be cracked offline at GPU speeds; identical passwords across users collide; `MaxKB@123..` reduces to a known constant.
- **What the fix changes:** stored hashes are per-user salted PBKDF2-SHA256 with a high iteration count, so DB exposure no longer yields plaintext at any practical cost. Login no longer puts the password (in any form) into a SQL `WHERE` clause; verification uses Django's constant-time `check_password`.
- **Backward compatibility:** existing deployments keep working — old MD5 hashes still authenticate, and are upgraded to PBKDF2 the first time the user logs in. There is no forced password reset.
- **Known residual:** legacy MD5 hashes for users who never log in remain weak until upgraded. This is the standard cost of an in-place hasher migration; it can be addressed later by an offline rewrap or a forced reset for inactive accounts, but is out of scope for this patch.

## Adversarial review

Before submitting we tried to disprove this. The main counter-argument is "you need DB access to exploit it, and DB access is already game over." That's not equivalent: read-only DB exposure (backup leak, `SELECT`-only SQLi, log scraping, replica access) does not by itself give an attacker the user's plaintext credential — but unsalted MD5 does. Recovered plaintext enables credential stuffing on third-party services that the application boundary cannot protect, which is the specific harm CWE-916 captures. We also checked whether Django or the framework was already upgrading these hashes transparently — it isn't, because the codebase bypasses Django's auth stack and stores raw MD5 in a plain `CharField`.

cc @lewiswigmore
