### PR TITLE
fix: sanitize exported chat HTML content

### DIFF
--- a/ui/env.d.ts
+++ b/ui/env.d.ts
@@ -1,6 +1,19 @@
 /// <reference types="vite/client" />
 declare module 'katex'
 declare module 'pdfjs-dist/build/pdf.mjs'
+declare module 'sanitize-html' {
+  interface IOptions {
+    allowedTags?: string[]
+    allowedAttributes?: Record<string, string[]>
+    allowedSchemes?: string[]
+    allowedSchemesByTag?: Record<string, string[]>
+    allowProtocolRelative?: boolean
+  }
+
+  function sanitizeHtml(dirty: string, options?: IOptions): string
+
+  export = sanitizeHtml
+}
 interface Window {
   sendMessage: ?((message: string, other_params_data: any) => void)
   chatUserProfile: ?(() => any)

--- a/ui/src/views/chat/pc/index.vue
+++ b/ui/src/views/chat/pc/index.vue
@@ -245,6 +245,7 @@
 import {ref, onMounted, nextTick, computed, watch, provide} from 'vue'
 import {marked} from 'marked'
 import {saveAs} from 'file-saver'
+import sanitizeHtml from 'sanitize-html'
 import chatAPI from '@/api/chat/chat'
 import useStore from '@/stores'
 import useResize from '@/layout/hooks/useResize'
@@ -541,7 +542,49 @@ async function exportHTML(): Promise<void> {
       return `# ${record.problem_text}\n\n${answerText}\n\n`
     })
     .join('\n')
-  const htmlContent: any = marked(markdownContent)
+  const rawHtmlContent = await marked(markdownContent)
+  const htmlContent = sanitizeHtml(rawHtmlContent, {
+    allowedTags: [
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'p',
+      'br',
+      'hr',
+      'blockquote',
+      'pre',
+      'code',
+      'em',
+      'strong',
+      'del',
+      'ul',
+      'ol',
+      'li',
+      'table',
+      'thead',
+      'tbody',
+      'tr',
+      'th',
+      'td',
+      'a',
+      'img',
+    ],
+    allowedAttributes: {
+      a: ['href', 'name', 'target', 'title'],
+      img: ['src', 'alt', 'title'],
+      code: ['class'],
+      th: ['align'],
+      td: ['align'],
+    },
+    allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+    allowedSchemesByTag: {
+      img: ['http', 'https'],
+    },
+    allowProtocolRelative: false,
+  })
 
   const blob: Blob = new Blob([htmlContent], {type: 'text/html;charset=utf-8'})
   saveAs(blob, suggestedName)


### PR DESCRIPTION
#### What this PR does / why we need it?

This PR sanitizes exported chat HTML content before generating downloadable `.html` files.

Previously, exported HTML content was generated directly from chat markdown via `marked(...)` without sanitization. Since exported content may contain user messages and assistant responses, raw HTML or dangerous URL schemes could persist into the exported file.

This change reduces potential export-based XSS risks in exported chat HTML files.

#### Summary of your change

* Sanitize exported HTML using `sanitize-html`
* Preserve common Markdown export elements:

  * headings
  * paragraphs
  * lists
  * blockquotes
  * code blocks
  * tables
  * links
  * images
* Restrict dangerous tags, event handler attributes, and unsafe URL schemes
* Keep the change isolated to the HTML export flow
* Add minimal TypeScript declaration for `sanitize-html`
* Update `marked(markdownContent)` to `await marked(markdownContent)` for current type compatibility

#### Please indicate you've done the following:

* [x] Made sure tests are passing and test coverage is added if needed.
* [x] Made sure commit message follow the rule of [[Conventional Commits specification](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/).
* [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
```release-note id="wh7s26"
Fixed potential XSS risk in exported HTML chat exports by sanitizing generated HTML content before download.
```
