### PR TITLE
fix: [Application] The dialogue generates multiple charts for echarts…

### DIFF
--- a/ui/src/components/markdown/EchartsRander.vue
+++ b/ui/src/components/markdown/EchartsRander.vue
@@ -13,7 +13,7 @@
 <script lang="ts" setup>
 import { onMounted, onBeforeUnmount, nextTick, watch, ref } from 'vue'
 import * as echarts from 'echarts'
-
+import { randomId } from '@/utils/common'
 // ── props ──────────────────────────────────────────────────────────────────
 const props = defineProps<{ option: string }>()
 
@@ -59,7 +59,7 @@ const EVAL_TIMEOUT_MS = 5000
 
 const evalInSandbox = (option_json: any): Promise<{ option: any; style: any }> => {
   return new Promise((resolve, reject) => {
-    const id = ++evalSeq
+    const id = randomId()
     let settled = false
 
     const timer = setTimeout(() => {


### PR DESCRIPTION
…, and after refreshing, all charts are overwritten by the first chart

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.