### PR TITLE
perf: optimize vector search SQL to leverage HNSW/GIN index for 40-500x speedup

### DIFF
--- a/apps/knowledge/sql/blend_search.sql
+++ b/apps/knowledge/sql/blend_search.sql
@@ -1,3 +1,11 @@
+WITH vector_top AS (
+	SELECT id,
+	       paragraph_id,
+	       (embedding::vector(%s) <=> %s) AS distance
+	FROM embedding ${embedding_query}
+	ORDER BY (embedding::vector(%s) <=> %s)
+	LIMIT LEAST(%s * 10, 500)
+)
 SELECT
 	paragraph_id,
 	comprehensive_score,
@@ -5,24 +13,15 @@ SELECT
 FROM
 	(
 	SELECT DISTINCT ON
-		( "paragraph_id" ) ( 1 - distance + ts_similarity ) as similarity, *,
-		(1 - distance + ts_similarity) AS comprehensive_score
+		(vc.paragraph_id) vc.paragraph_id,
+		(1 - vc.distance + COALESCE(ts_rank_cd(e.search_vector, websearch_to_tsquery('simple', %s), 32), 0)) AS comprehensive_score
 	FROM
-		(
-		SELECT
-			*,
-			(embedding.embedding::vector(%s) <=>  %s) as distance,
-			(ts_rank_cd( embedding.search_vector, websearch_to_tsquery('simple', %s ), 32 )) AS ts_similarity
-		FROM
-			embedding ${embedding_query}
-		    ORDER BY distance
-		) TEMP
+		vector_top vc
+	JOIN embedding e ON e.id = vc.id
 	ORDER BY
-		paragraph_id,
-		similarity DESC
-	) DISTINCT_TEMP
-WHERE
-	comprehensive_score >%s
-ORDER BY
-	comprehensive_score DESC
-	LIMIT %s
+		vc.paragraph_id,
+		comprehensive_score DESC
+	) sub
+WHERE comprehensive_score>%s
+ORDER BY comprehensive_score DESC
+LIMIT %s

--- a/apps/knowledge/sql/embedding_search.sql
+++ b/apps/knowledge/sql/embedding_search.sql
@@ -1,3 +1,10 @@
+WITH vector_top AS (
+	SELECT paragraph_id,
+	       (embedding::vector(%s) <=> %s) AS distance
+	FROM embedding ${embedding_query}
+	ORDER BY (embedding::vector(%s) <=> %s)
+	LIMIT LEAST(%s * 10, 500)
+)
 SELECT
     paragraph_id,
 	comprehensive_score,
@@ -5,13 +12,14 @@ SELECT
 FROM
 	(
 	SELECT DISTINCT ON
-		("paragraph_id") ( 1 - distance ),* ,(1 - distance) AS comprehensive_score
+		(vc.paragraph_id) vc.paragraph_id,
+		(1 - vc.distance) AS comprehensive_score
 	FROM
-		( SELECT *, ( embedding.embedding::vector(%s) <=>  %s ) AS distance FROM embedding ${embedding_query} ORDER BY distance) TEMP
+		vector_top vc
 	ORDER BY
-		paragraph_id,
-		distance
-	) DISTINCT_TEMP
+		vc.paragraph_id,
+		comprehensive_score DESC
+	) sub
 WHERE comprehensive_score>%s
 ORDER BY comprehensive_score DESC
 LIMIT %s

--- a/apps/knowledge/sql/keywords_search.sql
+++ b/apps/knowledge/sql/keywords_search.sql
@@ -7,7 +7,8 @@ FROM
 	SELECT DISTINCT ON
 		("paragraph_id") ( similarity ),* ,similarity AS comprehensive_score
 	FROM
-		( SELECT *,ts_rank_cd(embedding.search_vector,websearch_to_tsquery('simple',%s),32) AS similarity  FROM embedding ${keywords_query}) TEMP
+		( SELECT *,ts_rank_cd(embedding.search_vector,websearch_to_tsquery('simple',%s),32) AS similarity  FROM embedding ${keywords_query}
+		AND COALESCE(search_vector @@ websearch_to_tsquery('simple',%s), false)) TEMP
 	ORDER BY
 		paragraph_id,
 		similarity DESC

--- a/apps/knowledge/vector/pg_vector.py
+++ b/apps/knowledge/vector/pg_vector.py
@@ -123,15 +123,27 @@ class PGVector(BaseVectorStore):
         exclude_dict = {}
         query_text = normalize_for_embedding(query_text)
         embedding_query = embedding.embed_query(query_text)
-        query_set = QuerySet(Embedding).filter(knowledge_id__in=knowledge_id_list, is_active=True)
         if exclude_document_id_list is not None and len(exclude_document_id_list) > 0:
             exclude_dict.__setitem__("document_id__in", exclude_document_id_list)
-        query_set = query_set.exclude(**exclude_dict)
         for search_handle in search_handle_list:
             if search_handle.support(search_mode):
-                return search_handle.handle(
-                    query_set, query_text, embedding_query, top_number, similarity, search_mode, knowledge_id_list
-                )
+                # Query per knowledge base to leverage per-KB partial HNSW indexes
+                # (WHERE knowledge_id = '{k_id}'), which won't be used with knowledge_id__in
+                if len(knowledge_id_list) == 1:
+                    query_set = QuerySet(Embedding).filter(knowledge_id=knowledge_id_list[0], is_active=True).exclude(**exclude_dict)
+                    return search_handle.handle(
+                        query_set, query_text, embedding_query, top_number, similarity, search_mode, knowledge_id_list
+                    )
+                else:
+                    all_results = []
+                    for kid in knowledge_id_list:
+                        query_set = QuerySet(Embedding).filter(knowledge_id=kid, is_active=True).exclude(**exclude_dict)
+                        results = search_handle.handle(
+                            query_set, query_text, embedding_query, top_number, similarity, search_mode, knowledge_id_list
+                        )
+                        all_results.extend(results)
+                    all_results.sort(key=lambda x: x.get("similarity", x.get("comprehensive_score", 0)), reverse=True)
+                    return all_results[:top_number]
 
     def query(
         self,
@@ -149,19 +161,35 @@ class PGVector(BaseVectorStore):
         exclude_dict = {}
         if knowledge_id_list is None or len(knowledge_id_list) == 0:
             return []
-        query_set = QuerySet(Embedding).filter(knowledge_id__in=knowledge_id_list, is_active=is_active)
-        if document_id_list is not None and len(document_id_list) > 0:
-            query_set = query_set.filter(document_id__in=document_id_list)
-        if exclude_document_id_list is not None and len(exclude_document_id_list) > 0:
-            query_set = query_set.exclude(document_id__in=exclude_document_id_list)
-        if exclude_paragraph_list is not None and len(exclude_paragraph_list) > 0:
-            query_set = query_set.exclude(paragraph_id__in=exclude_paragraph_list)
-        query_set = query_set.exclude(**exclude_dict)
         for search_handle in search_handle_list:
             if search_handle.support(search_mode):
-                return search_handle.handle(
-                    query_set, query_text, query_embedding, top_n, similarity, search_mode, knowledge_id_list
-                )
+                # Query per knowledge base to leverage per-KB partial HNSW indexes
+                # (WHERE knowledge_id = '{k_id}'), which won't be used with knowledge_id__in
+                def build_query_set(kid):
+                    qs = QuerySet(Embedding).filter(knowledge_id=kid, is_active=is_active)
+                    if document_id_list is not None and len(document_id_list) > 0:
+                        qs = qs.filter(document_id__in=document_id_list)
+                    if exclude_document_id_list is not None and len(exclude_document_id_list) > 0:
+                        qs = qs.exclude(document_id__in=exclude_document_id_list)
+                    if exclude_paragraph_list is not None and len(exclude_paragraph_list) > 0:
+                        qs = qs.exclude(paragraph_id__in=exclude_paragraph_list)
+                    qs = qs.exclude(**exclude_dict)
+                    return qs
+                if len(knowledge_id_list) == 1:
+                    query_set = build_query_set(knowledge_id_list[0])
+                    return search_handle.handle(
+                        query_set, query_text, query_embedding, top_n, similarity, search_mode, knowledge_id_list
+                    )
+                else:
+                    all_results = []
+                    for kid in knowledge_id_list:
+                        query_set = build_query_set(kid)
+                        results = search_handle.handle(
+                            query_set, query_text, query_embedding, top_n, similarity, search_mode, knowledge_id_list
+                        )
+                        all_results.extend(results)
+                    all_results.sort(key=lambda x: x.get("similarity", x.get("comprehensive_score", 0)), reverse=True)
+                    return all_results[:top_n]
 
     def update_by_source_id(self, source_id: str, instance: Dict):
         QuerySet(Embedding).filter(source_id=source_id).update(**instance)
@@ -236,7 +264,7 @@ class EmbeddingSearch(ISearch):
             with_table_name=True,
         )
         embedding_model = select_list(
-            exec_sql, [len(query_embedding), json.dumps(query_embedding), *exec_params, similarity, top_number]
+            exec_sql, [len(query_embedding), json.dumps(query_embedding), *exec_params, len(query_embedding), json.dumps(query_embedding), top_number, similarity, top_number]
         )
         return embedding_model
 
@@ -268,7 +296,7 @@ class KeywordsSearch(ISearch):
             else None
         )
         embedding_model = select_list(
-            exec_sql, [to_query(query_text, user_words=terms), *exec_params, similarity, top_number]
+            exec_sql, [to_query(query_text, user_words=terms), *exec_params, to_query(query_text, user_words=terms), similarity, top_number]
         )
         return embedding_model
 
@@ -302,8 +330,11 @@ class BlendSearch(ISearch):
             [
                 len(query_embedding),
                 json.dumps(query_embedding),
-                to_query(query_text, user_words=terms),
                 *exec_params,
+                len(query_embedding),
+                json.dumps(query_embedding),
+                top_number,
+                to_query(query_text, user_words=terms),
                 similarity,
                 top_number,
             ],


### PR DESCRIPTION
## Summary

The current vector search SQL queries perform **full table scans** even when HNSW/GIN indexes exist, causing severe performance degradation on large datasets.

This PR rewrites the 3 search SQL files to use index-friendly query patterns and adds per-knowledge-base query routing to leverage partial HNSW indexes, achieving **40-500x speedup** on large-scale deployments.

## Problem

Two issues prevent HNSW/GIN indexes from being used:

### 1. SQL queries don't utilize indexes
Although `common.py` already creates per-knowledge-base HNSW indexes (`embedding_hnsw_idx_{k_id}`), the SQL queries **fail to utilize these indexes**:

- **embedding_search.sql**: `ORDER BY distance` scans the entire embedding table (no LIMIT in inner query), pgvector falls back to exact search
- **blend_search.sql**: Computes both vector distance and `ts_rank_cd` for every row in a single pass, full table scan with no early termination  
- **keywords_search.sql**: `ts_rank_cd()` computed on every row without `@@` pre-filter, no GIN index utilization

### 2. Per-KB partial indexes bypassed by knowledge_id__in
`hit_test()` and `query()` use `knowledge_id__in=knowledge_id_list` which produces `WHERE knowledge_id IN (...)`. PostgreSQL cannot use partial indexes with `WHERE knowledge_id = '{k_id}'` in this case, falling back to full table scan across all knowledge bases.

## Solution

### SQL Optimization (3 files)

**embedding_search.sql** — Use CTE (`WITH vector_top AS`) to first fetch top-K candidates via HNSW index with `LIMIT LEAST(top_number * 10, 500)`, then apply DISTINCT ON and threshold filtering on the small candidate set.

**blend_search.sql** — Two-phase approach: CTE first gets vector candidates via HNSW (with LIMIT), then `JOIN embedding` to compute `ts_rank_cd` text scores only on the candidate set. Uses `COALESCE(..., 0)` for rows without text scores.

**keywords_search.sql** — Add `AND search_vector @@ websearch_to_tsquery('simple', %s)` pre-filter to leverage GIN index, avoiding full-table `ts_rank_cd` computation.

### Per-KB Query Routing (pg_vector.py)

Split `hit_test()` and `query()` to iterate per knowledge base when multiple KBs are queried. Each per-KB query uses `knowledge_id=kid` (exact match) which enables PostgreSQL to use the corresponding partial HNSW index. Results from all KBs are merged and sorted by similarity. Single KB case is optimized to avoid overhead.

### Parameter Update (pg_vector.py)

Update parameter arrays in all 3 search classes (`EmbeddingSearch`, `KeywordsSearch`, `BlendSearch`) to match the new SQL placeholder order.

## Performance Results

Tested on production data: **770K vectors, 22GB embedding table, 5 knowledge bases, PostgreSQL 17 + pgvector**

The test environment uses a 3840-dimension embedding model (beyond pgvector's default 2000-dim HNSW limit), with additional `halfvec` configuration applied separately. The optimizations in this PR are dimension-independent and benefit all deployments.

| Search Mode | Before | After | Speedup |
|------------|--------|-------|---------|
| blend_search | 16,358ms | ~220ms | **74x** |
| embedding_search | 6,551ms | ~160ms | **41x** |
| keywords_search | 10,662ms | ~20ms | **533x** |

## Additional Recommendation: Disable PostgreSQL JIT

PostgreSQL JIT compilation was designed for long-running analytical queries. For vector search queries that complete in <10ms with HNSW indexes, JIT compilation overhead (50-200ms) far exceeds the actual query execution time.

**Recommended**: Add `jit = off` to `postgresql.conf`. PostgreSQL 19 will disable JIT by default, aligning with this recommendation.

**Before disabling JIT** (single embedding query):
```
JIT compilation: 159ms
Query execution: 3ms
Total: ~162ms
```

**After disabling JIT**:
```
Query execution: 3.4ms
Total: ~3.4ms (47x faster)
```

## Prerequisites

- PostgreSQL with pgvector extension (HNSW indexes are already created by `common.py` per knowledge base)
- GIN index on `search_vector` column (recommended for keywords_search optimization):
  ```sql
  CREATE INDEX embedding_search_vector_gin_idx ON embedding USING GIN (search_vector);
  ```

## Testing

- [x] Tested with 770K vectors (22GB) on PostgreSQL 17 + pgvector
- [x] All 3 search modes (embedding/keywords/blend) return correct results
- [x] Multi-KB query tested (5 knowledge bases)
- [x] Backward compatible - no schema changes required, only SQL query + routing optimization