### PR TITLE
【backup】perf: Adjust the width of `start-node`, `tool-start-node` and `tool-base-node` and the column width of their parameters

### DIFF
--- a/ui/src/workflow/nodes/base-node/component/ApiInputFieldTable.vue
+++ b/ui/src/workflow/nodes/base-node/component/ApiInputFieldTable.vue
@@ -13,7 +13,7 @@
     ref="tableRef"
     row-key="variable"
   >
-    <el-table-column prop="variable" :label="$t('dynamicsForm.paramForm.field.label')">
+    <el-table-column prop="variable" :label="$t('dynamicsForm.paramForm.field.label')" width="130">
       <template #default="{ row }">
         <span class="ellipsis-1" :title="row.variable">
           {{ row.variable }}
@@ -27,21 +27,21 @@
         </span>
       </template>
     </el-table-column>
-    <el-table-column prop="default_value" :label="$t('dynamicsForm.default.label')">
+    <el-table-column prop="default_value" :label="$t('dynamicsForm.default.label')" width="100">
       <template #default="{ row }">
         <span class="ellipsis-1" :title="row.default_value">
           {{ row.default_value }}
         </span>
       </template>
     </el-table-column>
-    <el-table-column :label="$t('common.required')">
+    <el-table-column :label="$t('common.required')" width="55">
       <template #default="{ row }">
         <div @click.stop>
           <el-switch disabled size="small" v-model="row.is_required" />
         </div>
       </template>
     </el-table-column>
-    <el-table-column :label="$t('common.operation')" align="left" width="90">
+    <el-table-column :label="$t('common.operation')" align="left" width="80">
       <template #default="{ row, $index }">
         <span class="mr-4">
           <el-tooltip effect="dark" :content="$t('common.modify')" placement="top">

--- a/ui/src/workflow/nodes/base-node/component/ChatFieldTable.vue
+++ b/ui/src/workflow/nodes/base-node/component/ChatFieldTable.vue
@@ -19,7 +19,7 @@
     ref="tableRef"
     row-key="field"
   >
-    <el-table-column prop="field" :label="$t('dynamicsForm.paramForm.field.label')" width="95">
+    <el-table-column prop="field" :label="$t('dynamicsForm.paramForm.field.label')" width="130">
       <template #default="{ row }">
         <span :title="row.field" class="ellipsis-1">{{ row.field }}</span>
       </template>
@@ -34,7 +34,7 @@
         >
       </template>
     </el-table-column>
-    <el-table-column :label="$t('common.operation')" align="left" width="90">
+    <el-table-column :label="$t('common.operation')" align="left" width="80">
       <template #default="{ row, $index }">
         <span class="mr-4">
           <el-tooltip effect="dark" :content="$t('common.modify')" placement="top">

--- a/ui/src/workflow/nodes/base-node/component/UserInputFieldTable.vue
+++ b/ui/src/workflow/nodes/base-node/component/UserInputFieldTable.vue
@@ -42,27 +42,26 @@
         >
       </template>
     </el-table-column>
-    <el-table-column :label="$t('dynamicsForm.paramForm.input_type.label')" width="95">
+    <el-table-column :label="$t('dynamicsForm.paramForm.input_type.label')" width="97">
       <template #default="{ row }">
         <el-tag size="small" type="info" class="info-tag">{{
           input_type_list.find((item) => item.value === row.input_type)?.label
         }}</el-tag>
       </template>
     </el-table-column>
-
-    <el-table-column prop="default_value" :label="$t('dynamicsForm.default.label')">
+    <el-table-column prop="default_value" :label="$t('dynamicsForm.default.label')" width="100">
       <template #default="{ row }">
         <span :title="row.default_value" class="ellipsis-1">{{ getDefaultValue(row) }}</span>
       </template>
     </el-table-column>
-    <el-table-column :label="$t('common.required')">
+    <el-table-column :label="$t('common.required')" width="55">
       <template #default="{ row }">
         <div @click.stop>
           <el-switch disabled size="small" v-model="row.required" />
         </div>
       </template>
     </el-table-column>
-    <el-table-column :label="$t('common.operation')" align="left" width="90">
+    <el-table-column :label="$t('common.operation')" align="left" width="80">
       <template #default="{ row, $index }">
         <span class="mr-4">
           <el-tooltip effect="dark" :content="$t('common.modify')" placement="top">

--- a/ui/src/workflow/nodes/start-node/index.ts
+++ b/ui/src/workflow/nodes/start-node/index.ts
@@ -1,12 +1,20 @@
 import StartNodeVue from './index.vue'
 import { AppNode, AppNodeModel } from '@/workflow/common/app-node'
+
 class StartNode extends AppNode {
   constructor(props: any) {
     super(props, StartNodeVue)
   }
 }
+
+class StartNodeModel extends AppNodeModel {
+  get_width() {
+    return 400
+  }
+}
+
 export default {
   type: 'start-node',
-  model: AppNodeModel,
+  model: StartNodeModel,
   view: StartNode
 }

--- a/ui/src/workflow/nodes/tool-base-node/component/input/InputFieldTable.vue
+++ b/ui/src/workflow/nodes/tool-base-node/component/input/InputFieldTable.vue
@@ -17,7 +17,7 @@
   </div>
 
   <el-table ref="inputFieldTableRef" :data="inputFieldList" class="mb-16">
-    <el-table-column prop="field" :label="$t('views.tool.form.paramName.label')">
+    <el-table-column prop="field" :label="$t('views.tool.form.paramName.label')" width="170">
       <template #default="{ row }">
         <span class="ellipsis-1" :title="row.field">
           {{ row.field }}
@@ -31,19 +31,19 @@
         </span>
       </template>
     </el-table-column>
-    <el-table-column :label="$t('views.tool.form.dataType.label')">
+    <el-table-column :label="$t('views.tool.form.dataType.label')" width="95">
       <template #default="{ row }">
         <el-tag type="info" class="info-tag">{{ row.type }}</el-tag>
       </template>
     </el-table-column>
-    <el-table-column :label="$t('common.required')">
+    <el-table-column :label="$t('common.required')" width="55">
       <template #default="{ row }">
         <div @click.stop>
           <el-switch disabled size="small" v-model="row.is_required" />
         </div>
       </template>
     </el-table-column>
-    <el-table-column :label="$t('common.operation')" align="left" width="90">
+    <el-table-column :label="$t('common.operation')" align="left" width="80">
       <template #default="{ row, $index }">
         <span class="mr-4">
           <el-tooltip effect="dark" :content="$t('common.modify')" placement="top">

--- a/ui/src/workflow/nodes/tool-base-node/component/output/OutputFieldTable.vue
+++ b/ui/src/workflow/nodes/tool-base-node/component/output/OutputFieldTable.vue
@@ -19,7 +19,7 @@
   <el-table ref="inputFieldTableRef" :data="inputFieldList" class="mb-16">
     <el-table-column prop="field" :label="$t('views.tool.form.paramName.label')" />
     <el-table-column prop="label" :label="$t('dynamicsForm.paramForm.name.label')" />
-    <el-table-column :label="$t('common.operation')" align="left" width="90">
+    <el-table-column :label="$t('common.operation')" align="left" width="80">
       <template #default="{ row, $index }">
         <span class="mr-4">
           <el-tooltip effect="dark" :content="$t('common.modify')" placement="top">

--- a/ui/src/workflow/nodes/tool-base-node/index.ts
+++ b/ui/src/workflow/nodes/tool-base-node/index.ts
@@ -1,12 +1,20 @@
 import ToolBaseNodeVue from './index.vue'
 import { AppNode, AppNodeModel } from '@/workflow/common/app-node'
+
 class ToolBaseNode extends AppNode {
   constructor(props: any) {
     super(props, ToolBaseNodeVue)
   }
 }
+
+class ToolBaseNodeModel extends AppNodeModel {
+  get_width() {
+    return 600
+  }
+}
+
 export default {
   type: 'tool-base-node',
-  model: AppNodeModel,
+  model: ToolBaseNodeModel,
   view: ToolBaseNode,
 }

--- a/ui/src/workflow/nodes/tool-start-node/index.ts
+++ b/ui/src/workflow/nodes/tool-start-node/index.ts
@@ -1,9 +1,10 @@
-import ToolBaseNodeVue from './index.vue'
+import ToolStartNodeVue from './index.vue'
 import { AppNode, AppNodeModel } from '@/workflow/common/app-node'
 import { t } from '@/locales'
-class ToolBaseNode extends AppNode {
+
+class ToolStartNode extends AppNode {
   constructor(props: any) {
-    super(props, ToolBaseNodeVue)
+    super(props, ToolStartNodeVue)
   }
   get_node_field_list() {
     const result = []
@@ -29,8 +30,15 @@ class ToolBaseNode extends AppNode {
     return result
   }
 }
+
+class ToolStartNodeModel extends AppNodeModel {
+  get_width() {
+    return 400
+  }
+}
+
 export default {
   type: 'tool-start-node',
-  model: AppNodeModel,
-  view: ToolBaseNode,
+  model: ToolStartNodeModel,
+  view: ToolStartNode,
 }


### PR DESCRIPTION
perf: Adjust the width of `start-node` and `tool-base-node` and the column width of their parameters

---

1. 加大 `start-node`、`tool-start-node` 和 `tool-base-node` 的宽度，避免显示字数太少。
    - `start-node`: 340 加大到 400
    - `tool-base-node`: 500 加大到 600
2. 优化 `tool-base-node` 的 `用户输入` 和 `输出参数` 表格的各列宽度

---

### `tool-base-node` 优化前截图：
<img width="1920" height="879" alt="图片" src="https://github.com/user-attachments/assets/f61744db-f5f9-4dcb-9864-36436a16aa49" />

### `tool-base-node` 优化后截图：
<img width="1920" height="879" alt="图片" src="https://github.com/user-attachments/assets/16dc83c1-3a6a-40c4-9ad3-0738a6109388" />
