### PR TITLE
i18n: Rename menu title field in user input settings

### DIFF
--- a/ui/src/components/ai-chat/component/inline-params/InlineFormItem.vue
+++ b/ui/src/components/ai-chat/component/inline-params/InlineFormItem.vue
@@ -94,7 +94,7 @@ const itemValue = computed({
 
 const attrs = computed(() => {
   const base = props.formfield.attrs || {}
-  if (props.formfield.input_type === 'MultiSelect') {
+  if (props.formfield.input_type === 'MultiSelect' || props.formfield.input_type === 'Knowledge') {
     return {
       ...base,
       'collapse-tags': true,

--- a/ui/src/components/ai-chat/component/user-form/index.vue
+++ b/ui/src/components/ai-chat/component/user-form/index.vue
@@ -99,12 +99,9 @@ const form_data_context = computed({
   },
 })
 
-watch(
-  () => props.application,
-  (data) => {
-    handleInputFieldList()
-  },
-)
+watch([() => props.application, () => props.excludeFields], () => {
+  handleInputFieldList()
+})
 
 function handleInputFieldList() {
   dynamicsFormRefresh.value++

--- a/ui/src/components/ai-chat/index.vue
+++ b/ui/src/components/ai-chat/index.vue
@@ -186,6 +186,7 @@ import { ChatManagement, type chatType } from '@/api/type/application'
 import { randomId } from '@/utils/common'
 import useStore from '@/stores'
 import { debounce } from 'lodash'
+import { useElementSize } from '@vueuse/core'
 import AnswerContent from '@/components/ai-chat/component/answer-content/index.vue'
 import QuestionContent from '@/components/ai-chat/component/question-content/index.vue'
 import TransitionContent from '@/components/ai-chat/component/transition-content/index.vue'
@@ -257,17 +258,24 @@ const emit = defineEmits([
   'update:selection',
 ])
 const { application, common, chatUser } = useStore()
+
+const aiChatRef = ref()
+const { width: rootWidth } = useElementSize(aiChatRef)
+
 const isMobile = computed(() => {
   return common.isMobile() || mode === 'embed' || mode === 'mobile'
 })
-const maxExposed = computed(() => (isMobile.value ? 1 : 3))
+
+const isNarrow = computed(() => rootWidth.value > 0 && rootWidth.value < 1040)
+
+const maxExposed = computed(() => (isNarrow.value ? 1 : 3))
 const inlineExposedFields = computed<string[]>(() =>
   (
-    props.applicationDetails?.work_flow?.nodes?.find((v: any) => v.id === 'base-node')
-      ?.properties?.user_input_field_list_setting?.exposed_fields || []
+    props.applicationDetails?.work_flow?.nodes?.find((v: any) => v.id === 'base-node')?.properties
+      ?.user_input_field_list_setting?.exposed_fields || []
   ).slice(0, maxExposed.value),
 )
-const aiChatRef = ref()
+
 const scrollDiv = ref()
 const dialogScrollbar = ref()
 const loading = ref(false)

--- a/ui/src/components/dynamics-form/items/knowledge/Knowledge.vue
+++ b/ui/src/components/dynamics-form/items/knowledge/Knowledge.vue
@@ -3,6 +3,7 @@
     <el-select
       v-model="selectedIds"
       multiple
+      v-bind="$attrs"
       class="w-full"
       :placeholder="$t('views.chatLog.selectKnowledgePlaceholder')"
     >
@@ -41,6 +42,8 @@ const props = withDefaults(
   }>(),
   { modelValue: () => [] },
 )
+
+defineOptions({ inheritAttrs: false })
 
 const emit = defineEmits(['update:modelValue', 'change'])
 

--- a/ui/src/locales/lang/en-US/ai-chat.ts
+++ b/ui/src/locales/lang/en-US/ai-chat.ts
@@ -148,4 +148,5 @@ export default {
   executing: 'Executing',
   userInputSettingTip:
     'Only Model, Knowledge, Switch, Date, TreeSelect, Single Select, and Multi Select component types are supported',
+  remainingParamsMenuTitle: 'Menu Title for Remaining Parameters',
 }

--- a/ui/src/locales/lang/zh-CN/ai-chat.ts
+++ b/ui/src/locales/lang/zh-CN/ai-chat.ts
@@ -145,4 +145,5 @@ export default {
   userInputSetting: '外置参数设置（最多可显示3个）',
   executing: '正在执行',
   userInputSettingTip: '仅支持模型、知识库、开关、日期、树形选项卡、单选框、多选框组件类型',
+  remainingParamsMenuTitle: '其他参数收纳菜单标题',
 }

--- a/ui/src/locales/lang/zh-Hant/ai-chat.ts
+++ b/ui/src/locales/lang/zh-Hant/ai-chat.ts
@@ -145,4 +145,5 @@ export default {
   userInputSetting: '外置參數設定（最多可顯示3個）',
   executing: '正在執行',
   userInputSettingTip: '僅支援模型、知識庫、開關、日期、樹形選項卡、單選框、多選框元件類型',
+  remainingParamsMenuTitle: '其他參數收納選單標題',
 }

--- a/ui/src/workflow/nodes/base-node/component/UserInputTitleDialog.vue
+++ b/ui/src/workflow/nodes/base-node/component/UserInputTitleDialog.vue
@@ -38,7 +38,7 @@
           />
         </el-select>
       </el-form-item>
-      <el-form-item :label="$t('common.title')" prop="menu_title">
+      <el-form-item :label="$t('aiChat.remainingParamsMenuTitle')" prop="menu_title">
         <el-input
           v-model="form.menu_title"
           maxlength="64"


### PR DESCRIPTION
fix: Collapse multi-select tags in inline params<br>fix: Width-based exposed params cap and reactive UserForm<br>i18n: Rename menu title field in user input settings 