### PR TITLE
fix: Fix an exception where incomplete parameters were generated by a large model when calling the `Workflow Tool` in the `ai-chat` node, resulting in missing parameters being thrown

### DIFF
--- a/apps/application/flow/tools.py
+++ b/apps/application/flow/tools.py
@@ -1031,7 +1031,10 @@ def get_workflow_args(tool, qv):
             input_field_list = node.get("properties").get("user_input_field_list")
             return build_schema(
                 {
-                    field.get("field"): (get_type(field.get("type")), Field(..., description=field.get("desc")))
+                    field.get("field"): (
+                        get_type(field.get("type")),
+                        Field(..., required=True, description=field.get("desc")) if field.get("is_required") else Field(default=None, required=False, description=field.get("desc"))
+                    )
                     for field in input_field_list
                 }
             )


### PR DESCRIPTION
#### What this PR does / why we need it?
fix: Fix an exception where incomplete parameters were generated by a large model when calling the `Workflow Tool` in the `ai-chat` node, resulting in missing parameters being thrown

修复在 `ai-chat` 节点调用 `工作流工具` 时，大模型不生成完整参数时，抛出缺失参数异常的问题

fixes #6172

#### Summary of your change
<img width="700" height="869" alt="601990123-c424f38a-9088-4f8d-9705-8edbe54d1891" src="https://github.com/user-attachments/assets/a0acece2-c2a3-4eec-ad79-ffbb298cdc3b" />


#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.