### PR TITLE
【官方已修复过】perf: In the execution details of `Image Understanding`, correctly display the system prompt after variable replacement

### DIFF
--- a/apps/application/flow/step_node/image_understand_step_node/impl/base_image_understand_node.py
+++ b/apps/application/flow/step_node/image_understand_step_node/impl/base_image_understand_node.py
@@ -164,6 +164,9 @@ class BaseImageUnderstandNode(IImageUnderstandNode):
         self.context['history_message'] = history_message
         question = self.generate_prompt_question(prompt)
         self.context['question'] = question.content
+        # 生成系统提示（变量替换）
+        system = self.workflow_manage.generate_prompt(system) if system else ''
+        self.context['system'] = system
         # 生成消息列表, 真实的history_message
         message_list = self.generate_message_list(image_model, system, prompt,
                                                   self.get_history_message(history_chat_record, dialogue_number), image)
@@ -296,7 +299,7 @@ class BaseImageUnderstandNode(IImageUnderstandNode):
 
         if system is not None and len(system) > 0:
             return [
-                SystemMessage(self.workflow_manage.generate_prompt(system)),
+                SystemMessage(system),
                 *history_message,
                 *messages
             ]
@@ -320,7 +323,7 @@ class BaseImageUnderstandNode(IImageUnderstandNode):
             'name': self.node.properties.get('stepName'),
             "index": index,
             'run_time': self.context.get('run_time'),
-            'system': self.node_params.get('system'),
+            'system': self.context.get('system'),
             'history_message': [{'content': message.content, 'role': message.type} for message in
                                 (self.context.get('history_message') if self.context.get(
                                     'history_message') is not None else [])],


### PR DESCRIPTION
fixes the #6180

perf: In the execution details of `Image Understanding`, correctly display the system prompt after variable replacement

---

优化：在 `图片理解` 的执行详情中，正确显示变量替换后的系统提示词：

---

### 我设置的系统提示词
<img width="309" height="800" alt="图片" src="https://github.com/user-attachments/assets/aea5a40c-a9d0-419c-8673-405e04cb894f" />

### 优化前，显示效果：
<img width="965" height="694" alt="图片" src="https://github.com/user-attachments/assets/958dcfa9-d780-4f51-a940-9e12ca210b80" />

### 优化后，显示效果：
<img width="959" height="675" alt="图片" src="https://github.com/user-attachments/assets/8eb07372-cc97-476f-b66b-2e731ca1e2f9" />