### PR TITLE
【backup】perf: 1) `执行详情` 里的 `图片` 可点击放大查看，`文档` 和 `其他文件` 可点击下载了; 2) `文档内容提取` 节点的执行详情中，会显示 `输入文档` 了。

### DIFF
--- a/apps/application/flow/step_node/document_extract_node/impl/base_document_extract_node.py
+++ b/apps/application/flow/step_node/document_extract_node/impl/base_document_extract_node.py
@@ -17,12 +17,12 @@ splitter = '\n`-----------------------------------`\n'
 class BaseDocumentExtractNode(IDocumentExtractNode):
     def save_context(self, details, workflow_manage):
         self.context['content'] = details.get('content')
+        self.context['document_list'] = details.get('document_list')
         self.context['exception_message'] = details.get('err_message')
 
     def execute(self, document, chat_id=None, **kwargs):
         get_buffer = FileBufferHandle().get_buffer
 
-        self.context['document_list'] = document
         content = []
         if document is None or not isinstance(document, list):
             return NodeResult({'content': '', 'document_list': []}, {})

--- a/ui/src/components/execution-detail-card/index.vue
+++ b/ui/src/components/execution-detail-card/index.vue
@@ -68,10 +68,15 @@
 
                   <el-space wrap>
                     <template v-for="(f, i) in data.document_list" :key="i">
-                      <el-card shadow="never" style="--el-card-padding: 8px" class="file cursor">
+                      <el-card
+                        shadow="never"
+                        style="--el-card-padding: 8px"
+                        class="file cursor"
+                        @click="downloadFile(f)"
+                      >
                         <div class="flex align-center">
                           <img :src="getImgUrl(f && f?.name)" alt="" width="24" />
-                          <div class="ml-4 ellipsis" :title="f && f?.name">
+                          <div class="ml-4 ellipsis" :title="getFileName(f)">
                             {{ f && f?.name }}
                           </div>
                         </div>
@@ -86,10 +91,16 @@
                     <template v-for="(f, i) in data.image_list" :key="i">
                       <el-image
                         :src="f.url"
-                        alt=""
+                        :alt="getFileName(f)"
+                        :title="getFileName(f)"
                         fit="cover"
                         style="width: 40px; height: 40px; display: block"
                         class="border-r-6"
+                        :preview-src-list="data.image_list.map((img: any) => img.url)"
+                        :initial-index="i"
+                        :zoom-rate="1.2"
+                        :max-scale="7"
+                        :min-scale="0.2"
                       />
                     </template>
                   </el-space>
@@ -109,7 +120,7 @@
                   </el-space>
                 </div>
                 <div v-if="data.video_list?.length > 0">
-                  <p class="mb-8 color-secondary">{{ $t('common.fileUpload.image') }}:</p>
+                  <p class="mb-8 color-secondary">{{ $t('common.fileUpload.video') }}:</p>
 
                   <el-space wrap>
                     <template v-for="(f, i) in data.video_list" :key="i">
@@ -124,14 +135,19 @@
                   </el-space>
                 </div>
                 <div v-if="data.other_list?.length > 0">
-                  <p class="mb-8 color-secondary">{{ $t('common.fileUpload.document') }}:</p>
+                  <p class="mb-8 color-secondary">{{ $t('common.fileUpload.other') }}:</p>
 
                   <el-space wrap>
                     <template v-for="(f, i) in data.other_list" :key="i">
-                      <el-card shadow="never" style="--el-card-padding: 8px" class="file cursor">
+                      <el-card
+                        shadow="never"
+                        style="--el-card-padding: 8px"
+                        class="file cursor"
+                        @click="downloadFile(f)"
+                      >
                         <div class="flex align-center">
                           <img :src="getImgUrl(f && f?.name)" alt="" width="24" />
-                          <div class="ml-4 ellipsis" :title="f && f?.name">
+                          <div class="ml-4 ellipsis" :title="getFileName(f)">
                             {{ f && f?.name }}
                           </div>
                         </div>
@@ -222,14 +238,27 @@
               </h5>
               <div class="p-8-12 border-t-dashed lighter pre-wrap">
                 <template v-if="Array.isArray(data.question)">
-                  <div v-for="(item, qIndex) in data.question" :key="qIndex">
+                  <!-- 先显示图片列表 -->
+                  <template v-for="(item, qIndex) in getImageList(data.question)" :key="qIndex">
                     <el-image
-                      v-if="item.type === 'image_url'"
                       :src="item.image_url?.url || item.image_url"
-                      alt=""
+                      :alt="getFileName(item)"
+                      :title="getFileName(item)"
                       fit="cover"
-                      style="width: 40px; height: 40px; display: block"
-                      class="border-r-6 mb-8"
+                      style="width: 40px; height: 40px"
+                      class="border-r-6 mb-8 mr-8"
+                      :preview-src-list="getImageList(data.question).map((img: any) => img.image_url?.url || img.image_url)"
+                      :initial-index="qIndex"
+                      :zoom-rate="1.2"
+                      :max-scale="7"
+                      :min-scale="0.2"
+                    />
+                  </template>
+                  <!-- 再显示视频和文本 -->
+                  <div v-for="(item, qIndex) in data.question" :key="qIndex">
+                    <span
+                      style="display:none"
+                      v-if="item.type === 'image_url'"
                     />
                     <video
                       v-else-if="item.type === 'video_url'"
@@ -354,6 +383,33 @@
           <!-- 文档内容提取 -->
           <template v-if="data.type === WorkflowType.DocumentExtractNode">
             <div class="card-never border-r-6">
+              <h5 class="p-8-12">
+                {{ $t('common.fileUpload.document') }}
+              </h5>
+              <div class="p-8-12 border-t-dashed lighter">
+                <div v-if="data.document_list?.length > 0">
+                  <el-space wrap>
+                    <template v-for="(doc, i) in data.document_list" :key="i">
+                      <el-card
+                        shadow="never"
+                        style="--el-card-padding: 8px"
+                        class="file cursor"
+                        @click="downloadFile(doc)"
+                      >
+                        <div class="flex align-center">
+                          <img :src="getImgUrl(doc && doc?.name)" alt="" width="24" />
+                          <div class="ml-4 ellipsis" :title="getFileName(doc)">
+                            {{ doc && doc?.name }}
+                          </div>
+                        </div>
+                      </el-card>
+                    </template>
+                  </el-space>
+                </div>
+                <div v-else>-</div>
+              </div>
+            </div>
+            <div class="card-never border-r-6 mt-8">
               <h5 class="p-8-12 flex align-center">
                 <span class="mr-4"> {{ $t('common.param.outputParam') }}</span>
 
@@ -592,10 +648,14 @@
                         <el-image
                           v-if="h.type === 'image_url'"
                           :src="h.image_url.url"
-                          alt=""
+                          :alt="getFileName(h)"
+                          :title="getFileName(h)"
                           fit="cover"
                           style="width: 40px; height: 40px; display: inline-block"
                           class="border-r-6 mr-8"
+                          :zoom-rate="1.2"
+                          :max-scale="7"
+                          :min-scale="0.2"
                         />
 
                         <span v-else>{{ h.text }}<br /></span>
@@ -622,10 +682,16 @@
                     <template v-for="(f, i) in data.image_list" :key="i">
                       <el-image
                         :src="f.url || (f.file_id ? `./oss/file/${f.file_id}` : '')"
-                        alt=""
+                        :alt="getFileName(f)"
+                        :title="getFileName(f)"
                         fit="cover"
                         style="width: 40px; height: 40px; display: block"
                         class="border-r-6"
+                        :preview-src-list="data.image_list.map((img: any) => img.url || (img.file_id ? `./oss/file/${img.file_id}` : ''))"
+                        :initial-index="i"
+                        :zoom-rate="1.2"
+                        :max-scale="7"
+                        :min-scale="0.2"
                       />
                     </template>
                   </el-space>
@@ -803,6 +869,7 @@
               </div>
             </div>
           </template>
+          <!-- 文生视频 -->
           <template v-if="data.type == WorkflowType.TextToVideoGenerateNode">
             <div class="card-never border-r-6 mt-8">
               <h5 class="p-8-12">
@@ -837,7 +904,7 @@
               </div>
             </div>
           </template>
-
+          <!-- 图生视频 -->
           <template v-if="data.type == WorkflowType.ImageToVideoGenerateNode">
             <div class="card-never border-r-6 mt-8">
               <h5 class="p-8-12">
@@ -863,10 +930,14 @@
                 <div v-if="typeof data.first_frame_url === 'string'">
                   <el-image
                     :src="data.first_frame_url"
-                    alt=""
+                    :alt="getFileName(data)"
+                    :title="getFileName(data)"
                     fit="cover"
                     style="width: 40px; height: 40px; display: block"
                     class="border-r-6"
+                    :zoom-rate="1.2"
+                    :max-scale="7"
+                    :min-scale="0.2"
                   />
                 </div>
                 <div v-else-if="Array.isArray(data.first_frame_url)">
@@ -874,10 +945,16 @@
                     <template v-for="(f, i) in data.first_frame_url" :key="i">
                       <el-image
                         :src="f.url"
-                        alt=""
+                        :alt="getFileName(f)"
+                        :title="getFileName(f)"
                         fit="cover"
                         style="width: 40px; height: 40px; display: block"
                         class="border-r-6"
+                        :preview-src-list="data.first_frame_url.map((img: any) => img.url)"
+                        :initial-index="i"
+                        :zoom-rate="1.2"
+                        :max-scale="7"
+                        :min-scale="0.2"
                       />
                     </template>
                   </el-space>
@@ -892,10 +969,14 @@
                 <div v-if="typeof data.last_frame_url === 'string'">
                   <el-image
                     :src="data.last_frame_url"
-                    alt=""
+                    :alt="getFileName(data)"
+                    :title="getFileName(data)"
                     fit="cover"
                     style="width: 40px; height: 40px; display: block"
                     class="border-r-6"
+                    :zoom-rate="1.2"
+                    :max-scale="7"
+                    :min-scale="0.2"
                   />
                 </div>
                 <div v-else-if="Array.isArray(data.last_frame_url)">
@@ -903,10 +984,16 @@
                     <template v-for="(f, i) in data.last_frame_url" :key="i">
                       <el-image
                         :src="f.url"
-                        alt=""
+                        :alt="getFileName(f)"
+                        :title="getFileName(f)"
                         fit="cover"
                         style="width: 40px; height: 40px; display: block"
                         class="border-r-6"
+                        :preview-src-list="data.last_frame_url.map((img: any) => img.url)"
+                        :initial-index="i"
+                        :zoom-rate="1.2"
+                        :max-scale="7"
+                        :min-scale="0.2"
                       />
                     </template>
                   </el-space>
@@ -1422,6 +1509,33 @@ const isKnowLedge = computed(() => props.type === 'knowledge')
 const currentLoopNode = ref(0)
 const currentParagraph = ref(0)
 const currentWriteContent = ref(0)
+
+const getImageList = (questions: any) => {
+  const imageList: any[] = []
+  questions.forEach((question: any) => {
+    if (question.type === 'image_url') {
+      imageList.push(question)
+    }
+  })
+  return imageList
+}
+
+const getFileName = (file: any) => {
+  if (file) {
+    return file?.file_name || file?.name || file?.image_url?.details || JSON.stringify(file)
+  } else {
+    return ''
+  }
+}
+
+// 下载文件
+const downloadFile = (file: any) => {
+  if (file && (file.url || file.file_id || file.id)) {
+    window.open(file.url || `./oss/file/${file.file_id || file.id}`, '_blank')
+  } else {
+    console.error('下载文件失败，原因：链接未知，file =', file)
+  }
+}
 </script>
 <style lang="scss" scoped>
 .execution-detail-card {


### PR DESCRIPTION
### perf: 
1. `执行详情` 里的 `图片` 可点击放大查看了，`文档` 和 `其他文件` 可点击下载了;
2. `文档内容提取` 节点的执行详情中，会显示 `输入文档` 了。

---

### 效果：
1. `图片理解` 的的执行详情截图：
<img width="980" height="703" alt="图片" src="https://github.com/user-attachments/assets/fefa4ca0-a2b2-466e-b8de-893ab3a9bc24" />
<img width="1920" height="879" alt="图片" src="https://github.com/user-attachments/assets/f19833d6-193f-418a-9795-7dbe0ada1fc1" />

2. `文档内容提取` 节点的执行详情截图：
<img width="986" height="536" alt="图片" src="https://github.com/user-attachments/assets/12088c3d-3533-4305-8c5b-b21359704521" />
