### PR TITLE
fix: [Agent] After disabling the display of execution details in the settings, the conversation still shows the node execution progress.

### DIFF
--- a/ui/src/components/ai-chat/component/answer-content/index.vue
+++ b/ui/src/components/ai-chat/component/answer-content/index.vue
@@ -12,22 +12,24 @@
           'padding-right': showUserAvatar ? 'var(--padding-left)' : '0',
         }"
       >
-        <el-card
-          v-if="!chatRecord.write_ed && progress && index >= answer_text_list.length - 1"
-          shadow="always"
-          class="border-r-8 mb-8"
-          style="--el-card-padding: 1px 16px; width: fit-content"
-        >
-          <div class="flex align-center">
-            <component
-              :is="iconComponent(`${progress.node_type}-icon`)"
-              class="mr-8"
-              :size="16"
-              style="--el-avatar-border-radius: 3px"
-            ></component>
-            <MdRenderer :source="progress.content"></MdRenderer>
-          </div>
-        </el-card>
+        <template v-if="type === 'debug-ai-chat' ? true : application.show_exec">
+          <el-card
+            v-if="!chatRecord.write_ed && progress && index >= answer_text_list.length - 1"
+            shadow="always"
+            class="border-r-8 mb-8"
+            style="--el-card-padding: 1px 16px; width: fit-content"
+          >
+            <div class="flex align-center">
+              <component
+                :is="iconComponent(`${progress.node_type}-icon`)"
+                class="mr-8"
+                :size="16"
+                style="--el-avatar-border-radius: 3px"
+              ></component>
+              <MdRenderer :source="progress.content"></MdRenderer>
+            </div>
+          </el-card>
+        </template>
         <el-card shadow="always" class="border-r-8" style="--el-card-padding: 6px 16px">
           <MdRenderer
             v-if="


### PR DESCRIPTION
fix: [Agent] After disabling the display of execution details in the settings, the conversation still shows the node execution progress. 