### PR TITLE
fix: use simple config for SearchVector to avoid double stemming

### DIFF
--- a/apps/common/event/listener_manage.py
+++ b/apps/common/event/listener_manage.py
@@ -230,7 +230,7 @@ class ListenerManagement:
             )
             data_list = list(QuerySet(Embedding).filter(paragraph_id=paragraph_id))
             for data, chunk in zip(data_list, chunks):
-                data.search_vector = SearchVector(Value(to_ts_vector(chunk, user_words=user_words)))
+                data.search_vector = SearchVector(Value(to_ts_vector(chunk, user_words=user_words)), config='simple')
             # 批量保存，减少数据库写入次数
             QuerySet(Embedding).filter(paragraph_id=paragraph_id).bulk_update(data_list, ["search_vector"])
 

--- a/apps/knowledge/vector/pg_vector.py
+++ b/apps/knowledge/vector/pg_vector.py
@@ -71,7 +71,7 @@ class PGVector(BaseVectorStore):
             source_id=source_id,
             embedding=text_embedding,
             source_type=source_type,
-            search_vector=SearchVector(Value(to_ts_vector(text, user_words=terms))),
+            search_vector=SearchVector(Value(to_ts_vector(text, user_words=terms)), config='simple'),
         )
         embedding.save()
         return True
@@ -99,7 +99,8 @@ class PGVector(BaseVectorStore):
                                 .values_list("content", flat=True)
                             ),
                         )
-                    )
+                    ),
+                    config='simple',
                 ),
             )
             for index in range(0, len(texts))


### PR DESCRIPTION
fix: use simple config for SearchVector to avoid double stemming 