### PR TITLE
fix: Fix when `source_value` is `null`, the result of the `ge`, `gt`, `le` and `lt` comparators is incorrect

### DIFF
--- a/apps/application/flow/compare/ge_compare.py
+++ b/apps/application/flow/compare/ge_compare.py
@@ -12,6 +12,9 @@ from .compare import Compare
 class GECompare(Compare):
 
     def compare(self, source_value, compare, target_value):
+        if source_value is None:
+            return target_value is None
+
         try:
             return float(source_value) >= float(target_value)
         except Exception:

--- a/apps/application/flow/compare/gt_compare.py
+++ b/apps/application/flow/compare/gt_compare.py
@@ -12,6 +12,9 @@ from .compare import Compare
 class GTCompare(Compare):
 
     def compare(self, source_value, compare, target_value):
+        if source_value is None:
+            return False
+
         try:
             return float(source_value) > float(target_value)
         except Exception:

--- a/apps/application/flow/compare/le_compare.py
+++ b/apps/application/flow/compare/le_compare.py
@@ -12,6 +12,9 @@ from .compare import Compare
 class LECompare(Compare):
 
     def compare(self, source_value, compare, target_value):
+        if source_value is None:
+            return target_value is None
+
         try:
             return float(source_value) <= float(target_value)
         except Exception:

--- a/apps/application/flow/compare/lt_compare.py
+++ b/apps/application/flow/compare/lt_compare.py
@@ -12,6 +12,9 @@ from .compare import Compare
 class LTCompare(Compare):
 
     def compare(self, source_value, compare, target_value):
+        if source_value is None:
+            return False
+
         try:
             return float(source_value) < float(target_value)
         except Exception:


### PR DESCRIPTION
fix: Fix when `source_value` is `null`, the result of the `ge`, `gt`, `le` and `lt` comparators is incorrect
修复当 `source_value` 为 `None` 时，`ge`, `gt`, `le` 和 `lt` 4个比较器的结果不正确的问题。

---

今天测试另一个PR的功能时，意外发现了这个BUG  (^_^)

错误的结果截图：
<img width="1214" height="629" alt="图片" src="https://github.com/user-attachments/assets/56bb4fcb-b94c-40dd-88b4-8f73b8ce91c4" />