### PR TITLE
fix: handle multiple entries in zip file extraction to prevent data loss

### DIFF
--- a/apps/knowledge/models/knowledge.py
+++ b/apps/knowledge/models/knowledge.py
@@ -435,15 +435,19 @@ class File(AppModelMixin):
         buffer = io.BytesIO()
         for chunk in self.get_bytes_stream():
             buffer.write(chunk)
+        data = buffer.getvalue()
         try:
             # 解压数据
             with zipfile.ZipFile(buffer) as zip_file:
+                names = [name for name in zip_file.namelist() if not name.endswith("/")]
+                if len(names) != 1:
+                    return data
                 # 用 zip 内实际存储的条目名，避免文件名不匹配
-                name = zip_file.namelist()[0]
+                name = names[0]
                 return zip_file.read(name)
-        except Exception as e:
+        except zipfile.BadZipFile:
             # 如果数据不是zip格式，直接返回原始数据
-            return buffer.getvalue()
+            return data
 
     def get_bytes_stream(self, start=0, end=None, chunk_size=64 * 1024):
         def _read_with_offset():


### PR DESCRIPTION
fix: handle multiple entries in zip file extraction to prevent data loss  --bug=1071129@tapd-62980211 --user=刘瑞斌 【github#6238】从旧版本（2.3.1）升级到最新版（2.10.1-lts），下载知识库的word文档，文件损坏 https://www.tapd.cn/62980211/s/1962254 