### PR TITLE
fix: Qwen3 TTS Model default voice parameters not support longxiaochun

### DIFF
--- a/apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py
+++ b/apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py
@@ -57,6 +57,37 @@ class AliyunBaiLianTTSModelGeneralParams(BaseForm):
     )
 
 
+class AliyunBaiLianQwenTTSModelGeneralParams(BaseForm):
+    """
+    Parameters class for the Aliyun BaiLian Qwen TTS model.
+    Defines fields such as voice and speech rate.
+    """
+
+    voice = SingleSelect(
+        TooltipLabel(_('Timbre'), _('Please select a system voice supported by Qwen-TTS')),
+        required=True,
+        default_value='Cherry',
+        text_field='value',
+        value_field='value',
+        option_list=[
+            {'label': 'Cherry', 'value': 'Cherry'},
+            {'label': 'Serena', 'value': 'Serena'},
+            {'label': 'Ethan', 'value': 'Ethan'},
+            {'label': 'Chelsie', 'value': 'Chelsie'},
+        ]
+    )
+
+    speech_rate = SliderField(
+        TooltipLabel(_('Speaking speed'), _('[0.5, 2], the default is 1, usually one decimal place is enough')),
+        required=True,
+        default_value=1,
+        _min=0.5,
+        _max=2,
+        _step=0.1,
+        precision=1
+    )
+
+
 class AliyunBaiLianTTSModelCredential(BaseForm, BaseModelCredential):
     """
     Credential class for the Aliyun BaiLian TTS (Text-to-Speech) model.
@@ -140,4 +171,6 @@ class AliyunBaiLianTTSModelCredential(BaseForm, BaseModelCredential):
         :param model_name: Name of the model.
         :return: Parameter setting form.
         """
+        if 'qwen' in model_name and 'tts' in model_name:
+            return AliyunBaiLianQwenTTSModelGeneralParams()
         return AliyunBaiLianTTSModelGeneralParams()


### PR DESCRIPTION
#### What this PR does / why we need it?
当前 qwen3 默认 TSS 默认参数根本就无法满足 qwen3-tts-flash 模型，所以添加模型时候一定会报错。
百炼文档里的 qwen3-tts-flash 示例音色是 Cherry，不是当前 v2 分支代码默认的 longxiaochun
对应问题issue： [https://github.com/1Panel-dev/MaxKB/issues/6236](https://github.com/1Panel-dev/MaxKB/issues/6236)

<img width="2898" height="1896" alt="d504fda22c850ba23dc1423d7b4e722d" src="https://github.com/user-attachments/assets/1f8421ac-0774-4093-91c7-1ac8eee98651" />

#### Summary of your change
追加一套 tss 音频模型初始化参数，为了适配 tss-flash 模型场景，已经自测通过。
<img width="2898" height="1896" alt="6d54792e4f803cd2b5471473bd485009" src="https://github.com/user-attachments/assets/6f70105f-e634-4761-8f82-806aceda9250" />


#### Please indicate you've done the following:

- [✅] Made sure tests are passing and test coverage is added if needed.
- [✅] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [✅] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.