### PR TITLE
fix: support importing tool_code on windows

### DIFF
--- a/apps/common/tests.py
+++ b/apps/common/tests.py
@@ -1,0 +1,32 @@
+import builtins
+import importlib
+import os
+import sys
+from unittest import TestCase
+from unittest.mock import patch
+
+
+class ToolCodeImportTest(TestCase):
+    def test_imports_when_unix_only_modules_are_unavailable(self):
+        original_import = builtins.__import__
+
+        def import_without_unix_only_modules(name, *args, **kwargs):
+            if name in {"pwd", "resource"}:
+                raise ModuleNotFoundError(f"No module named '{name}'")
+            return original_import(name, *args, **kwargs)
+
+        env = {
+            "MAXKB_CONFIG_TYPE": "ENV",
+            "DJANGO_SETTINGS_MODULE": "maxkb.settings",
+        }
+
+        original_module = sys.modules.pop("common.utils.tool_code", None)
+        try:
+            with patch.dict(os.environ, env), patch.object(
+                builtins, "__import__", side_effect=import_without_unix_only_modules
+            ):
+                importlib.import_module("common.utils.tool_code")
+        finally:
+            sys.modules.pop("common.utils.tool_code", None)
+            if original_module is not None:
+                sys.modules["common.utils.tool_code"] = original_module

--- a/apps/common/utils/tool_code.py
+++ b/apps/common/utils/tool_code.py
@@ -5,9 +5,7 @@ import getpass
 import gzip
 import json
 import os
-import pwd
 import random
-import resource
 import socket
 import subprocess
 import sys
@@ -21,6 +19,16 @@ from django.utils.translation import gettext_lazy as _
 from maxkb.const import BASE_DIR, CONFIG, PROJECT_DIR
 
 from common.utils.logger import maxkb_logger
+
+try:
+    import pwd
+except ModuleNotFoundError:
+    pwd = None
+
+try:
+    import resource
+except ModuleNotFoundError:
+    resource = None
 
 _enable_sandbox = bool(int(CONFIG.get("SANDBOX", 0)))
 _run_user = "sandbox" if _enable_sandbox else getpass.getuser()
@@ -37,6 +45,12 @@ _process_limit_cpu_cores = (
     else os.cpu_count()
 )  # 只支持linux，window和mac不支持
 _process_limit_mem_mb = int(CONFIG.get("SANDBOX_PYTHON_PROCESS_LIMIT_MEM_MB", "256"))
+
+
+def _get_set_run_user_code():
+    if not _enable_sandbox or pwd is None:
+        return ""
+    return f"os.setgid({pwd.getpwnam(_run_user).pw_gid});os.setuid({pwd.getpwnam(_run_user).pw_uid});"
 
 
 class ToolExecutor:
@@ -103,11 +117,7 @@ class ToolExecutor:
         action_function = (
             f"({function_name!a}, locals_v.get({function_name!a}))" if function_name else "locals_v.popitem()"
         )
-        set_run_user = (
-            f"os.setgid({pwd.getpwnam(_run_user).pw_gid});os.setuid({pwd.getpwnam(_run_user).pw_uid});"
-            if _enable_sandbox
-            else ""
-        )
+        set_run_user = _get_set_run_user_code()
         _exec_code = f"""
 try:
     import os, sys, json
@@ -302,11 +312,7 @@ sys.stdout.flush()
 
     def generate_mcp_server_code(self, code_str, params, name, description, tool_id):
         code = self._generate_mcp_server_code(code_str, params, name, description, tool_id)
-        set_run_user = (
-            f"os.setgid({pwd.getpwnam(_run_user).pw_gid});os.setuid({pwd.getpwnam(_run_user).pw_uid});"
-            if _enable_sandbox
-            else ""
-        )
+        set_run_user = _get_set_run_user_code()
         return f"""
 import os, sys, logging
 logging.basicConfig(level=logging.WARNING)
@@ -358,7 +364,7 @@ exec({dedent(code)!a})
         }
 
         def _set_resource_limit():
-            if not _enable_sandbox or not sys.platform.startswith("linux"):
+            if not _enable_sandbox or not sys.platform.startswith("linux") or resource is None:
                 return
             with suppress(Exception):
                 resource.setrlimit(resource.RLIMIT_AS, (_process_limit_mem_mb * 1024 * 1024,) * 2)


### PR DESCRIPTION
## 背景

在 Windows 本地启动后端调试服务时，请求接口会触发 Django URL resolver 加载 `application` 相关模块，随后导入 `common.utils.tool_code`。该模块顶层无条件导入了 `pwd` 和 `resource`，这两个模块属于 Unix/Linux 平台能力，Windows 标准库中不存在，因此会在导入阶段直接抛出：

```text
ModuleNotFoundError: No module named 'pwd'
```

这会导致后端虽然能启动 development server，但访问接口时返回 500，实际业务代码还没有执行到。

## 修改前

- `tool_code.py` 顶层直接 `import pwd`、`import resource`。
- `pwd.getpwnam(...)` 只在启用 sandbox 后用于生成 `setgid/setuid` 切换用户代码，但模块导入发生在配置判断之前，Windows 会提前失败。
- `_set_resource_limit()` 的资源限制逻辑只面向 Linux sandbox 场景，但 `resource` 也在顶层强制导入。
- 缺少覆盖“Windows 缺少 Unix-only 模块时仍可导入 tool_code”的回归测试。

## 修改后

- 将 `pwd` 和 `resource` 改为可选导入，缺失时赋值为 `None`。
- 新增 `_get_set_run_user_code()`，只在 sandbox 启用且 `pwd` 可用时生成 `os.setgid/os.setuid` 代码。
- `_set_resource_limit()` 增加 `resource is None` 保护，非 Linux 或缺少 `resource` 时直接跳过资源限制逻辑。
- 新增 `ToolCodeImportTest`，通过模拟 `pwd/resource` 不可用，验证 `common.utils.tool_code` 仍可正常导入。

## 前后对比

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| Windows 本地后端启动后访问接口 | 导入 `tool_code.py` 时因缺少 `pwd` 抛 500 | `tool_code.py` 可正常导入，URL resolver 可加载 |
| Linux sandbox 启用 | 使用 `pwd` 生成 `setgid/setuid` 代码 | `pwd` 可用时保持原有行为 |
| 非 Linux / 未启用 sandbox | 仍需要成功导入 Unix-only 模块 | 不依赖 Unix-only 模块，按原逻辑跳过 sandbox 用户切换和资源限制 |
| 回归覆盖 | 无专项测试 | 增加导入回归测试 |

## 测试情况

已执行：

```bash
python -m unittest apps.common.tests.ToolCodeImportTest.test_imports_when_unix_only_modules_are_unavailable
```

结果：通过。

已执行 Django URL resolver 导入验证：

```bash
python -c "import django; django.setup(); from django.urls import get_resolver; patterns = get_resolver().url_patterns; print('url_patterns', len(patterns))"
```

结果：成功输出 `url_patterns 16`。

验证过程中仍有 `pydub` 找不到 ffmpeg 的 RuntimeWarning，该警告与本次 `pwd/resource` 导入问题无关。

## 总结

本次修复将 Linux/Unix-only 能力限制在实际需要的 sandbox 分支内，避免 Windows 本地调试时因模块顶层导入失败阻断后端请求，同时保留 Linux sandbox 场景下原有的用户切换和资源限制行为。