### PR TITLE
fix: fix redirect to read page url error

### DIFF
--- a/ui/src/stores/modules/application.ts
+++ b/ui/src/stores/modules/application.ts
@@ -1,9 +1,18 @@
 import { defineStore } from 'pinia'
 const useApplicationStore = defineStore('application', {
   state: () => ({
-    location: `${window.location.origin}${window.MaxKB.chatPrefix ? window.MaxKB.chatPrefix : window.MaxKB.prefix}/`,
+    location: `${getChatOrigin()}${
+      window.MaxKB.chatPrefix ? window.MaxKB.chatPrefix : window.MaxKB.prefix
+    }/`,
   }),
   actions: {},
 })
+
+function getChatOrigin() {
+  if (import.meta.env.DEV && window.location.port === '3000') {
+    return `${window.location.protocol}//${window.location.hostname}:3001`
+  }
+  return window.location.origin
+}
 
 export default useApplicationStore


### PR DESCRIPTION
#### What this PR does / why we need it?
本地环境点击【去对话】按钮跳转错误链接，无法进入到对话页面

#### Summary of your change
只是修复了本地环境点击【去对话】按钮时候，跳转 URL 错误的问题，现已修复成功
<img width="808" height="386" alt="image" src="https://github.com/user-attachments/assets/697370f4-2a0f-475e-bb33-863ec6d31ed0" />

对应issue链接：https://github.com/1Panel-dev/MaxKB/issues/6256

#### Please indicate you've done the following:

- [ ✅ ] Made sure tests are passing and test coverage is added if needed.
- [ ✅ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ✅ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.