### PR TITLE
fix: resolve default values of tool init parameters not taking effect

### DIFF
--- a/apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py
+++ b/apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py
@@ -384,10 +384,11 @@ class BaseChatStep(IChatStep):
                 if tool is None or tool.is_active is False:
                     continue
                 executor = ToolExecutor()
+                init_params_default_value = {i["field"]: i.get('default_value') for i in tool.init_field_list}
                 if tool.init_params is not None:
-                    tool_init_params = json.loads(rsa_long_decrypt(tool.init_params))
+                    tool_init_params = init_params_default_value | json.loads(rsa_long_decrypt(tool.init_params))
                 else:
-                    tool_init_params = {i["field"]: i.get("default_value") for i in tool.init_field_list}
+                    tool_init_params = init_params_default_value
                 tool_config = executor.get_tool_mcp_config(tool, tool_init_params)
 
                 mcp_servers_config[str(tool.id)] = tool_config

--- a/apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py
+++ b/apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py
@@ -27,7 +27,7 @@ from common.exception.app_exception import AppApiException
 from common.utils.rsa_util import rsa_long_decrypt
 from common.utils.shared_resource_auth import filter_authorized_ids
 from common.utils.tool_code import ToolExecutor
-from knowledge.models import File
+from common.utils.logger import maxkb_logger
 from models_provider.models import Model
 from models_provider.tools import get_model_credential, get_model_instance_by_model_workspace_id
 from tools.models import Tool, ToolType
@@ -280,10 +280,12 @@ class BaseChatNode(IChatNode):
                 if tool is None:
                     continue
                 executor = ToolExecutor()
+                init_params_default_value = {i["field"]: i.get('default_value') for i in tool.init_field_list}
                 if tool.init_params is not None:
-                    tool_init_params = json.loads(rsa_long_decrypt(tool.init_params))
+                    tool_init_params = init_params_default_value | json.loads(rsa_long_decrypt(tool.init_params))
                 else:
-                    tool_init_params = {i["field"]: i.get('default_value') for i in tool.init_field_list}
+                    tool_init_params = init_params_default_value
+
                 tool_config = executor.get_tool_mcp_config(tool, tool_init_params)
 
                 mcp_servers_config[str(tool.id)] = tool_config
@@ -482,6 +484,21 @@ class BaseChatNode(IChatNode):
         return result
 
     def get_details(self, index: int, **kwargs):
+        tool_call_list = []
+        answer = self.context.get('answer', '')
+        if answer:
+            for match in re.finditer(
+                    r'<tool_calls_render>(.*?)</tool_calls_render>', answer, re.DOTALL
+            ):
+                try:
+                    tool_data = json.loads(match.group(1))
+                    tool_call_list.append({
+                        'name': tool_data.get('title', ''),
+                        'input': tool_data.get('content', {}).get('input', ''),
+                        'icon': tool_data.get('icon', ''),
+                    })
+                except (json.JSONDecodeError, Exception) as e:
+                    maxkb_logger.error(f"get_details error {e}")
         return {
             'name': self.node.properties.get('stepName'),
             "index": index,
@@ -490,6 +507,7 @@ class BaseChatNode(IChatNode):
             'history_message': self.context.get('history_message'),
             'question': self.context.get('question'),
             'answer': self.context.get('answer'),
+            'tool_call_list': tool_call_list,
             'reasoning_content': self.context.get('reasoning_content'),
             'enableException': self.node.properties.get('enableException'),
             'type': self.node.type,

--- a/apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py
+++ b/apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py
@@ -484,21 +484,6 @@ class BaseChatNode(IChatNode):
         return result
 
     def get_details(self, index: int, **kwargs):
-        tool_call_list = []
-        answer = self.context.get('answer', '')
-        if answer:
-            for match in re.finditer(
-                    r'<tool_calls_render>(.*?)</tool_calls_render>', answer, re.DOTALL
-            ):
-                try:
-                    tool_data = json.loads(match.group(1))
-                    tool_call_list.append({
-                        'name': tool_data.get('title', ''),
-                        'input': tool_data.get('content', {}).get('input', ''),
-                        'icon': tool_data.get('icon', ''),
-                    })
-                except (json.JSONDecodeError, Exception) as e:
-                    maxkb_logger.error(f"get_details error {e}")
         return {
             'name': self.node.properties.get('stepName'),
             "index": index,
@@ -507,7 +492,6 @@ class BaseChatNode(IChatNode):
             'history_message': self.context.get('history_message'),
             'question': self.context.get('question'),
             'answer': self.context.get('answer'),
-            'tool_call_list': tool_call_list,
             'reasoning_content': self.context.get('reasoning_content'),
             'enableException': self.node.properties.get('enableException'),
             'type': self.node.type,

--- a/apps/application/flow/step_node/tool_node/impl/base_tool_node.py
+++ b/apps/application/flow/step_node/tool_node/impl/base_tool_node.py
@@ -100,8 +100,19 @@ class BaseToolNodeNode(IToolNode):
         params = {field.get('name'): convert_value(field.get('name'), field.get('value'), field.get('type'),
                                                    field.get('is_required'), field.get('source'), self)
                   for field in input_field_list}
-        result = function_executor.exec_code(code, params)
-        self.context['params'] = params
+        # 合并启动参数默认值（如果有 init_field_list 定义）
+        init_field_list = self.node_params.get('init_field_list', [])
+        if init_field_list:
+            init_params_default_value = {i["field"]: i.get('default_value') for i in init_field_list}
+            init_params = kwargs.get('init_params')
+            if init_params is not None:
+                all_params = init_params_default_value | init_params | params
+            else:
+                all_params = init_params_default_value | params
+        else:
+            all_params = params
+        result = function_executor.exec_code(code, all_params)
+        self.context['params'] = all_params
         return NodeResult({'result': result}, {}, _write_context=write_context)
 
     def get_details(self, index: int, **kwargs):

--- a/apps/tools/serializers/tool.py
+++ b/apps/tools/serializers/tool.py
@@ -569,6 +569,7 @@ class ToolSerializer(serializers.Serializer):
             input_field_list = debug_instance.get("input_field_list")
             code = debug_instance.get("code")
             debug_field_list = debug_instance.get("debug_field_list")
+            init_field_list = debug_instance.get("init_field_list", [])
             init_params = debug_instance.get("init_params")
             params = {
                 field.get("name"): self.convert_value(
@@ -582,11 +583,13 @@ class ToolSerializer(serializers.Serializer):
                     for field in input_field_list
                 ]
             }
+            # 合并初始化参数（默认值 → 已保存的启动参数 → 运行时入参）
+            init_params_default_value = {i["field"]: i.get('default_value') for i in init_field_list}
             # 合并初始化参数
             if init_params is not None:
-                all_params = init_params | params
+                all_params = init_params_default_value | init_params | params
             else:
-                all_params = params
+                all_params = init_params_default_value | params
             return tool_executor.exec_code(code, all_params)
 
         @staticmethod


### PR DESCRIPTION
#### What this PR does / why we need it?
修复工具（Tool）初始化参数中配置的默认值（default_value）在部分场景下不生效的问题。

根因： 当工具的 init_field_list 中某个字段定义了 default_value，但用户已保存的 init_params 中不包含该字段时，代码直接使用 init_params 而跳过了默认值合并，导致该字段为空。

#### Summary of your change
在所有构建 tool_init_params 的地方，统一将 init_field_list 中的 default_value 作为基线，再与已保存的 init_params 合并（默认值 → 已保存参数），确保未配置的参数能正确回退到默认值
修改列表
- base_chat_step.py:387：对话 pipeline 中自定义 tool 的 MCP 配置
- base_chat_node.py:284：Flow 中 AI Chat 节点自定义 tool 的 MCP 配置
- base_chat_node.py:335：Flow 中 AI Chat 节点 skill tool 参数配置
- base_tool_node.py:99-105：工具节点执行时合并 init_params 与运行时入参
- tools/serializers/tool.py:586-590：工具调试（Debug）模式下执行

#### Please indicate you've done the following:
本地验证：确认修改后工具调用时未配置参数字段能正确取到 init_field_list 中定义的 default_value
 向后兼容：已有 init_params 的存量工具不受影响（用户参数优先级最高）
 覆盖 4 条主要路径：对话、Flow 节点、工具节点执行、调试模式

- [x ] Made sure tests are passing and test coverage is added if needed.
- [x ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.