### PR TITLE
fix: show param dialog button when only API params exist in debug chat

### DIFF
--- a/ui/src/components/ai-chat/component/inline-params/index.vue
+++ b/ui/src/components/ai-chat/component/inline-params/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="inline-params" v-if="fieldList.length > 0">
+  <div class="inline-params" v-if="fieldList.length > 0 || apiInput">
     <template v-for="item in exposedFields" :key="item.field">
       <InlineFormItem
         v-if="show(item)"
@@ -18,7 +18,7 @@
     <el-button
       ref="triggerBtnRef"
       style="padding: 8px"
-      v-if="dialogFields.length > 0"
+      v-if="dialogFields.length > 0 || apiInput"
       @click="emit('openDialog')"
     >
       <AppIcon iconName="app-all-menu"></AppIcon>
@@ -39,6 +39,7 @@ const props = defineProps<{
   application: any
   formData: any
   maxExposed?: number
+  apiInput?: boolean
 }>()
 
 const emit = defineEmits(['update:formData', 'openDialog'])

--- a/ui/src/components/ai-chat/index.vue
+++ b/ui/src/components/ai-chat/index.vue
@@ -212,6 +212,7 @@
               :application="applicationDetails"
               :maxExposed="maxExposed"
               v-model:form-data="form_data"
+              :apiInput="isAPIInput"
               @openDialog="handleOpenDialog"
             >
             </InlineParams>


### PR DESCRIPTION
fix: show param dialog button when only API params exist in debug chat 