### PR TITLE
fix: correct file removal logic that bypassed size limit on folder up…

### DIFF
--- a/ui/src/components/dynamics-form/items/upload/LocalFileUpload.vue
+++ b/ui/src/components/dynamics-form/items/upload/LocalFileUpload.vue
@@ -86,24 +86,32 @@ const loading = ref<boolean>(false)
 const UploadRef = ref()
 // 上传on-change事件
 const fileHandleChange = (file: any, fileList: UploadFiles) => {
+  // 按文件唯一标识精确定位并移除当前文件
+  // 注意：不能使用 splice(-1, 1) 盲删末尾元素，文件夹上传时会误删正常文件而放走超限文件
+  const removeCurrentFile = () => {
+    const index = fileList.findIndex((item: any) => item.uid === file.uid)
+    if (index !== -1) {
+      fileList.splice(index, 1)
+    }
+  }
   //1、判断文件大小是否合法，文件限制不能大于100M
   const isLimit = file?.size / 1024 / 1024 < file_size_limit.value
   if (!isLimit) {
     MsgError(t('views.document.tip.fileLimitSizeTip1') + file_size_limit.value + 'MB')
-    fileList.splice(-1, 1) //移除当前超出大小的文件
+    removeCurrentFile() //移除当前超出大小的文件
     return false
   }
   if (!file_type_list.value.includes(fileType(file.name).toLocaleUpperCase())) {
     if (file?.name !== '.DS_Store') {
       MsgError(t('views.document.upload.errorMessage2'))
     }
-    fileList.splice(-1, 1)
+    removeCurrentFile()
     return false
   }
 
   if (file?.size === 0) {
     MsgError(t('views.document.upload.errorMessage3'))
-    fileList.splice(-1, 1)
+    removeCurrentFile()
     return false
   }
   upload(file.raw, loading).then((ok: any) => {

--- a/ui/src/views/document/upload/UploadComponent.vue
+++ b/ui/src/views/document/upload/UploadComponent.vue
@@ -281,11 +281,19 @@ function deleteFile(index: number | string) {
 
 // 上传on-change事件
 const fileHandleChange = (file: any, fileList: UploadFiles) => {
+  // 按文件唯一标识精确定位并移除当前文件
+  // 注意：不能使用 splice(-1, 1) 盲删末尾元素，文件夹上传时会误删正常文件而放走超限文件
+  const removeCurrentFile = () => {
+    const index = fileList.findIndex((item: any) => item.uid === file.uid)
+    if (index !== -1) {
+      fileList.splice(index, 1)
+    }
+  }
   //1、判断文件大小是否合法，文件限制不能大于100M
   const isLimit = file?.size / 1024 / 1024 < file_size_limit.value
   if (!isLimit) {
     MsgError(t('views.document.tip.fileLimitSizeTip1') + file_size_limit.value + 'MB')
-    fileList.splice(-1, 1) //移除当前超出大小的文件
+    removeCurrentFile() //移除当前超出大小的文件
     return false
   }
 
@@ -293,12 +301,12 @@ const fileHandleChange = (file: any, fileList: UploadFiles) => {
     if (file?.name !== '.DS_Store') {
       MsgError(t('views.document.upload.errorMessage2'))
     }
-    fileList.splice(-1, 1)
+    removeCurrentFile()
     return false
   }
   if (file?.size === 0) {
     MsgError(t('views.document.upload.errorMessage3'))
-    fileList.splice(-1, 1)
+    removeCurrentFile()
     return false
   }
 }

--- a/ui/src/views/tool/SkillToolFormDrawer.vue
+++ b/ui/src/views/tool/SkillToolFormDrawer.vue
@@ -354,17 +354,25 @@ function deleteInitField(index: any) {
 }
 
 const fileHandleChange = (file: any, fileList: UploadFiles) => {
+  // 按文件唯一标识精确定位并移除当前文件
+  // 注意：不能使用 splice(-1, 1) 盲删末尾元素，文件夹上传时会误删正常文件而放走超限文件
+  const removeCurrentFile = () => {
+    const index = fileList.findIndex((item: any) => item.uid === file.uid)
+    if (index !== -1) {
+      fileList.splice(index, 1)
+    }
+  }
   //1、判断文件大小是否合法，文件限制不能大于100M
   const isLimit = file?.size / 1024 / 1024 < file_size_limit.value
   if (!isLimit) {
     MsgError(t('views.document.tip.fileLimitSizeTip1') + file_size_limit.value + 'MB')
-    fileList.splice(-1, 1) //移除当前超出大小的文件
+    removeCurrentFile() //移除当前超出大小的文件
     return false
   }
 
   if (file?.size === 0) {
     MsgError(t('views.document.upload.errorMessage3'))
-    fileList.splice(-1, 1)
+    removeCurrentFile()
     return false
   }
   if (fileList.length > 1) {


### PR DESCRIPTION
# What this PR does / why we need it?
修复了文件上传校验中一个隐蔽但影响较大的缺陷：在文件夹批量上传场景下，超过 100MB 大小限制的文件无法被正确拦截，仍然会被上传成功。问题根因： 三个上传组件的 fileHandleChange 在校验失败时，统一使用 fileList.splice(-1, 1) 来移除"当前文件"。但 -1 是数组末尾索引，删的其实是列表最后一个元素，而非触发校验失败的那个文件。
单文件上传时，当前文件恰好就在列表末尾，误删的恰好是它，bug 被掩盖，所以常规测试发现不了。
文件夹上传时，el-upload 会对每个文件依次触发 on-change，传入的 fileList 是同一个累积列表。当某个超限文件触发校验失败时，被删掉的是列表末尾的一个正常文件，而超限文件原封不动地留在列表里被继续上传。如果文件夹里有多个超限文件，每个都会误删一个正常文件，导致"超限文件全留着、正常文件被误删"的连锁反应。
这个缺陷直接绕过了前端的大小限制防线，因此需要修复。

# Summary of your change
在以下三个组件的 fileHandleChange 函数中，将盲删末尾元素的 fileList.splice(-1, 1) 替换为按文件唯一标识（uid）精确定位后再移除：
ui/src/views/document/upload/UploadComponent.vue（知识库文档上传）
ui/src/components/dynamics-form/items/upload/LocalFileUpload.vue（动态表单本地文件上传）
ui/src/views/tool/SkillToolFormDrawer.vue（技能工具文件上传）
每个组件内新增一个 removeCurrentFile 辅助函数，在校验失败的三个分支（大小超限、格式不符、空文件）统一调用它，确保被移除的始终是真正不合规的那个文件。
