### PR TITLE
fix: update file upload category to TEMPORARY_120_MINUTE

### DIFF
--- a/ui/src/views/document/ImportWorkflowDocument.vue
+++ b/ui/src/views/document/ImportWorkflowDocument.vue
@@ -73,8 +73,8 @@ provide(
   (file: any, onProgress?: (percent: number, event: any) => void, loading?: Ref<boolean>) => {
     return applicationApi.postUploadFileProgress(
       file,
-      id as string,
-      'KNOWLEDGE',
+      'TEMPORARY_120_MINUTE',
+      'TEMPORARY_120_MINUTE',
       onProgress,
       loading,
     )


### PR DESCRIPTION
fix: update file upload category to TEMPORARY_120_MINUTE  --bug=1071434@tapd-62980211 --user=刘瑞斌 【知识库】上传文件成功后，退出导入文档界面或者刷新页面，已上传的文件没有从数据库删除 https://www.tapd.cn/62980211/s/1970352 