### PR TITLE
fix: refresh workflow form knowledge snapshots

### DIFF
--- a/apps/application/serializers/application.py
+++ b/apps/application/serializers/application.py
@@ -103,6 +103,42 @@ def hand_node(node, update_tool_map):
         node.get("properties", {}).get("node_data", {})["tool_lib_id"] = update_tool_map.get(tool_lib_id, tool_lib_id)
 
 
+def update_form_knowledge_fields(workflow):
+    if workflow is None:
+        return
+    for node in workflow.get("nodes", []):
+        if node.get("type") == "form-node":
+            form_field_list = node.get("properties", {}).get("node_data", {}).get("form_field_list", [])
+            for field in form_field_list:
+                if field.get("input_type") != "Knowledge":
+                    continue
+                knowledge_list = field.get("attrs", {}).get("knowledge_list", [])
+                knowledge_id_list = [
+                    str(knowledge.get("id")) for knowledge in knowledge_list if knowledge.get("id") is not None
+                ]
+                current_knowledge_dict = {
+                    str(knowledge.id): knowledge
+                    for knowledge in QuerySet(Knowledge).filter(id__in=list(set(knowledge_id_list)))
+                }
+                refreshed_knowledge_list = []
+                for knowledge in knowledge_list:
+                    current_knowledge = current_knowledge_dict.get(str(knowledge.get("id")))
+                    if current_knowledge is None:
+                        refreshed_knowledge_list.append(knowledge)
+                    else:
+                        refreshed_knowledge_list.append(
+                            {
+                                **knowledge,
+                                "name": current_knowledge.name,
+                                "type": current_knowledge.type,
+                                "embedding_model_id": current_knowledge.embedding_model_id,
+                            }
+                        )
+                field.setdefault("attrs", {})["knowledge_list"] = refreshed_knowledge_list
+        if node.get("type") == "loop-node":
+            update_form_knowledge_fields(node.get("properties", {}).get("node_data", {}).get("loop_body") or {})
+
+
 class MKInstance:
     def __init__(self, application: dict, function_lib_list: List[dict], version: str, tool_list: List[dict]):
         self.application = application
@@ -1408,6 +1444,7 @@ class ApplicationOperateSerializer(serializers.Serializer):
             knowledge_id_list = [k.get("id") for k in knowledge_list]
         else:
             self.update_knowledge_node(application.work_flow, available_knowledge_dict)
+            update_form_knowledge_fields(application.work_flow)
 
         return {
             **ApplicationSerializerModel(application).data,


### PR DESCRIPTION
#### What this PR does / why we need it?

修复智能体【收集表单】节点引用知识库时，知识库改名后节点中展示的知识库名称未同步更新的问题。

原因是【收集表单】节点中的知识库字段会在工作流 JSON 中保存一份知识库快照，包括 `id`、`name`、`type`、`embedding_model_id`。此前应用详情接口只刷新了知识库检索节点中的知识库信息，没有刷新表单节点中的知识库快照，导致知识库改名后仍展示旧名称。

#### Summary of your change

- 在应用详情返回工作流数据时，刷新【收集表单】节点中的知识库字段。
- 根据表单字段中已保存的知识库 `id` 查询当前最新的知识库信息。
- 同步更新表单节点知识库快照中的：
  - `name`
  - `type`
  - `embedding_model_id`
- 支持递归处理循环节点中的【收集表单】节点。
- 未新增文件，仅在现有应用序列化逻辑中补充刷新处理。