### PR TITLE
fix: block import when oversized files exist in upload list

### DIFF
--- a/ui/src/views/document/upload/UploadComponent.vue
+++ b/ui/src/views/document/upload/UploadComponent.vue
@@ -414,7 +414,6 @@ const fileHandleChange = (file: any, fileList: UploadFiles) => {
   if (!isLimit) {
     item.status = 'error'
     item.errMsg = t('dynamicsForm.UploadInput.errorTip.sizeError')
-    // MsgError(t('views.document.tip.fileLimitSizeTip1') + file_size_limit.value + 'MB')
     // fileList.splice(-1, 1) //移除当前超出大小的文件
     form.value.fileList?.push(item)
     removeCurrentFile()
@@ -494,6 +493,11 @@ const handlePreview = (bool: boolean) => {
 */
 function validate() {
   if (!FormRef.value) return
+  const errorFiles = form.value.fileList.filter((i: any) => i.status === 'error')
+  if (errorFiles.length > 0) {
+    MsgError(t('views.document.tip.fileLimitSizeTip1') + file_size_limit.value + 'MB')
+    return Promise.resolve(false)
+  }
   return FormRef.value.validate((valid: any) => {
     return valid
   })


### PR DESCRIPTION
#### What this PR does / why we need it?

此前，当用户选择的文件超出知识库大小限制时，文件虽然会在上传列表中被标记为错误状态，但并没有拦截用户继续点击「导入」或「下一步」按钮。这导致超限文件仍会被提交到后端，用户体验不够友好。

本 PR 在 `UploadComponent.validate()` 中增加了提交前校验：如果文件列表中存在错误状态（如大小超限）的文件，将拦截本次提交，并弹出简洁的提示（如「每个文件不超过 100MB」），不列出具体文件名。

#### Summary of your change

- **修改文件**：`ui/src/views/document/upload/UploadComponent.vue`
- **修改内容**：在 `validate()` 函数中新增前置检查，遍历 `fileList` 查找 `status === 'error'` 的文件项；若存在则触发 `MsgError` 提示，并返回 `Promise.resolve(false)` 中断提交流程。