### PR TITLE
feat: username check remove

### DIFF
--- a/apps/local_model/models/user.py
+++ b/apps/local_model/models/user.py
@@ -17,7 +17,7 @@ class User(models.Model):
     id = models.UUIDField(primary_key=True, max_length=128, default=uuid.uuid7, editable=False, verbose_name="主键id")
     email = models.EmailField(unique=True, null=True, blank=True, verbose_name="邮箱", db_index=True)
     phone = models.CharField(max_length=20, verbose_name="电话", default="", db_index=True)
-    nick_name = models.CharField(max_length=150, verbose_name="昵称", unique=True, db_index=True)
+    nick_name = models.CharField(max_length=150, verbose_name="昵称", db_index=True)
     username = models.CharField(max_length=150, unique=True, verbose_name="用户名", db_index=True)
     password = models.CharField(max_length=150, verbose_name="密码")
     role = models.CharField(max_length=150, verbose_name="角色")

--- a/apps/local_model/models/user.py
+++ b/apps/local_model/models/user.py
@@ -17,7 +17,7 @@ class User(models.Model):
     id = models.UUIDField(primary_key=True, max_length=128, default=uuid.uuid7, editable=False, verbose_name="主键id")
     email = models.EmailField(unique=True, null=True, blank=True, verbose_name="邮箱", db_index=True)
     phone = models.CharField(max_length=20, verbose_name="电话", default="", db_index=True)
-    nick_name = models.CharField(max_length=150, verbose_name="昵称", db_index=True)
+    nick_name = models.CharField(max_length=150, verbose_name="昵称", unique=True, db_index=True)
     username = models.CharField(max_length=150, unique=True, verbose_name="用户名", db_index=True)
     password = models.CharField(max_length=150, verbose_name="密码")
     role = models.CharField(max_length=150, verbose_name="角色")

--- a/apps/users/models/user.py
+++ b/apps/users/models/user.py
@@ -17,7 +17,7 @@ class User(models.Model):
     id = models.UUIDField(primary_key=True, max_length=128, default=uuid.uuid7, editable=False, verbose_name="主键id")
     email = models.EmailField(unique=True, null=True, blank=True, verbose_name="邮箱", db_index=True)
     phone = models.CharField(max_length=20, verbose_name="电话", default="", db_index=True)
-    nick_name = models.CharField(max_length=150, verbose_name="昵称", unique=True, db_index=True)
+    nick_name = models.CharField(max_length=150, verbose_name="昵称", db_index=True)
     username = models.CharField(max_length=150, unique=True, verbose_name="用户名", db_index=True)
     password = models.CharField(max_length=150, verbose_name="密码")
     role = models.CharField(max_length=150, verbose_name="角色")

--- a/apps/users/models/user.py
+++ b/apps/users/models/user.py
@@ -17,7 +17,7 @@ class User(models.Model):
     id = models.UUIDField(primary_key=True, max_length=128, default=uuid.uuid7, editable=False, verbose_name="主键id")
     email = models.EmailField(unique=True, null=True, blank=True, verbose_name="邮箱", db_index=True)
     phone = models.CharField(max_length=20, verbose_name="电话", default="", db_index=True)
-    nick_name = models.CharField(max_length=150, verbose_name="昵称", db_index=True)
+    nick_name = models.CharField(max_length=150, verbose_name="昵称", unique=True, db_index=True)
     username = models.CharField(max_length=150, unique=True, verbose_name="用户名", db_index=True)
     password = models.CharField(max_length=150, verbose_name="密码")
     role = models.CharField(max_length=150, verbose_name="角色")

--- a/apps/users/serializers/user.py
+++ b/apps/users/serializers/user.py
@@ -220,15 +220,12 @@ class UserManageSerializer(serializers.Serializer):
         def _check_unique_username_and_email(self):
             username = self.data.get('username')
             email = self.data.get('email')
-            nick_name = self.data.get('nick_name')
-            user = User.objects.filter(Q(username=username) | Q(email=email) | Q(nick_name=nick_name)).first()
+            user = User.objects.filter(Q(username=username) | Q(email=email)).first()
             if user:
                 if user.email == email:
                     raise ExceptionCodeConstants.EMAIL_IS_EXIST.value.to_app_api_exception()
                 if user.username == username:
                     raise ExceptionCodeConstants.USERNAME_IS_EXIST.value.to_app_api_exception()
-                if user.nick_name == nick_name:
-                    raise ExceptionCodeConstants.NICKNAME_IS_EXIST.value.to_app_api_exception()
 
     class Query(serializers.Serializer):
         username = serializers.CharField(
@@ -411,12 +408,6 @@ class UserManageSerializer(serializers.Serializer):
         def is_valid(self, *, user_id=None, raise_exception=False):
             super().is_valid(raise_exception=True)
             self._check_unique_email(user_id)
-            self._check_unique_nick_name(user_id)
-
-        def _check_unique_nick_name(self, user_id):
-            nick_name = self.data.get('nick_name')
-            if nick_name and User.objects.filter(nick_name=nick_name).exclude(id=user_id).exists():
-                raise AppApiException(1008, _('Nickname is already in use'))
 
         def _check_unique_email(self, user_id):
             email = self.data.get('email')

--- a/apps/users/serializers/user.py
+++ b/apps/users/serializers/user.py
@@ -220,12 +220,15 @@ class UserManageSerializer(serializers.Serializer):
         def _check_unique_username_and_email(self):
             username = self.data.get('username')
             email = self.data.get('email')
-            user = User.objects.filter(Q(username=username) | Q(email=email)).first()
+            nick_name = self.data.get('nick_name')
+            user = User.objects.filter(Q(username=username) | Q(email=email) | Q(nick_name=nick_name)).first()
             if user:
                 if user.email == email:
                     raise ExceptionCodeConstants.EMAIL_IS_EXIST.value.to_app_api_exception()
                 if user.username == username:
                     raise ExceptionCodeConstants.USERNAME_IS_EXIST.value.to_app_api_exception()
+                if user.nick_name == nick_name:
+                    raise ExceptionCodeConstants.NICKNAME_IS_EXIST.value.to_app_api_exception()
 
     class Query(serializers.Serializer):
         username = serializers.CharField(
@@ -408,6 +411,12 @@ class UserManageSerializer(serializers.Serializer):
         def is_valid(self, *, user_id=None, raise_exception=False):
             super().is_valid(raise_exception=True)
             self._check_unique_email(user_id)
+            self._check_unique_nick_name(user_id)
+
+        def _check_unique_nick_name(self, user_id):
+            nick_name = self.data.get('nick_name')
+            if nick_name and User.objects.filter(nick_name=nick_name).exclude(id=user_id).exists():
+                raise AppApiException(1008, _('Nickname is already in use'))
 
         def _check_unique_email(self, user_id):
             email = self.data.get('email')


### PR DESCRIPTION
#### What this PR does / why we need it?

本 PR 移除用户昵称 `nick_name` 的唯一性限制，允许不同用户使用相同昵称。

当前系统中昵称被当作唯一字段处理，导致用户创建或编辑资料时，如果昵称重复会被拦截。昵称本身更偏向展示名称，不适合作为唯一身份标识；用户唯一性仍应由 `username`、`email` 等字段保证。

#### Summary of your change

- 移除 `User.nick_name` 字段上的 `unique=True` 约束
- 创建用户时不再校验昵称唯一性
- 更新用户信息时不再校验昵称唯一性
- 保留用户名和邮箱的唯一性校验逻辑