### PR TITLE
【backup】feat: 添加 Django 国际化翻译文件自动化脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ tmp/
 config.yml
 .SANDBOX_BANNED_HOSTS
 copilot-instructions.md
+
+# Backup Files
+*.bak

--- a/apps/application/flow/step_node/loop_node/i_loop_node.py
+++ b/apps/application/flow/step_node/loop_node/i_loop_node.py
@@ -30,12 +30,12 @@ class ILoopNodeSerializer(serializers.Serializer):
         if loop_type == 'ARRAY':
             array = self.data.get('array')
             if array is None or len(array) == 0:
-                message = _('{field}, this field is required.', field='array')
+                message = _('{field}, this field is required.').format(field='array')
                 raise AppApiException(500, message)
         elif loop_type == 'NUMBER':
             number = self.data.get('number')
             if number is None:
-                message = _('{field}, this field is required.', field='number')
+                message = _('{field}, this field is required.').format(field='number')
                 raise AppApiException(500, message)
 
 

--- a/apps/application/serializers/application.py
+++ b/apps/application/serializers/application.py
@@ -69,6 +69,76 @@ from application.models.application_access_token import ApplicationAccessToken
 from application.serializers.common import update_resource_mapping_by_application
 
 
+def get_bound_tool_ids(instance: Dict) -> List[str]:
+    """
+    收集应用配置(含工作流节点)中引用的所有工具id,用于绑定前的权限校验
+    """
+    tool_ids = set()
+    for key in ("tool_ids", "skill_tool_ids", "mcp_tool_ids"):
+        for tool_id in (instance.get(key) or []):
+            tool_ids.add(str(tool_id))
+    if instance.get("mcp_tool_id"):
+        tool_ids.add(str(instance.get("mcp_tool_id")))
+
+    def walk(work_flow):
+        if not work_flow:
+            return
+        for node in work_flow.get("nodes", []) or []:
+            node_data = (node.get("properties") or {}).get("node_data") or {}
+            for key in ("tool_lib_id", "mcp_tool_id"):
+                if node_data.get(key):
+                    tool_ids.add(str(node_data.get(key)))
+            for key in ("mcp_tool_ids", "tool_ids", "skill_tool_ids"):
+                for tool_id in (node_data.get(key) or []):
+                    tool_ids.add(str(tool_id))
+            if node.get("type") == "loop-node":
+                walk(node_data.get("loop_body"))
+
+    walk(instance.get("work_flow"))
+    return list(tool_ids)
+
+
+def get_authorized_tool_ids(user_id: str, workspace_id: str, tool_ids: List[str]) -> List[str]:
+    """
+    返回 tool_ids 中当前用户被授权绑定/使用的工具id。
+    工作空间管理员默认拥有全部工具权限;其他用户必须在 workspace_user_resource_permission
+    中存在针对该工具的显式授权记录(默认拒绝)。
+    """
+    if not tool_ids:
+        return []
+    tool_ids = list({str(t) for t in tool_ids})
+    if is_workspace_manage(user_id, workspace_id):
+        return tool_ids
+    granted_tool_ids = {
+        str(permission.target)
+        for permission in QuerySet(WorkspaceUserResourcePermission).filter(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            auth_target_type=AuthTargetType.TOOL.value,
+            target__in=tool_ids,
+        )
+        if "VIEW" in permission.permission_list or "ROLE" in permission.permission_list
+    }
+    return [tool_id for tool_id in tool_ids if tool_id in granted_tool_ids]
+
+
+def validate_bound_tool_permissions(user_id: str, workspace_id: str, instance: Dict):
+    """
+    校验应用/工作流中绑定的工具,当前用户是否都有权限使用,防止低权限成员
+    绑定自己被禁止访问的工具,并通过应用/工作流执行绕过工具的单独授权控制。
+    """
+    tool_ids = get_bound_tool_ids(instance)
+    if not tool_ids:
+        return
+    authorized_tool_ids = set(get_authorized_tool_ids(user_id, workspace_id, tool_ids))
+    unauthorized_tool_ids = [tool_id for tool_id in tool_ids if tool_id not in authorized_tool_ids]
+    if unauthorized_tool_ids:
+        message = lazy_format(
+            _("No permission to use tool(s): {tool_ids}"), tool_ids=", ".join(unauthorized_tool_ids)
+        )
+        raise AppApiException(403, str(message))
+
+
 def get_base_node_work_flow(work_flow):
     node_list = work_flow.get("nodes")
     base_node_list = [node for node in node_list if node.get("id") == "base-node"]
@@ -623,6 +693,7 @@ class ApplicationSerializer(serializers.Serializer):
         workspace_id = self.data.get("workspace_id")
         wq = ApplicationCreateSerializer.WorkflowRequest(data=instance)
         wq.is_valid(raise_exception=True)
+        validate_bound_tool_permissions(user_id, workspace_id, instance)
         application_model = wq.to_application_model(user_id, workspace_id, instance)
         application_model.save()
         # 插入认证信息
@@ -703,6 +774,20 @@ class ApplicationSerializer(serializers.Serializer):
                 if not exits_tool_id_list.__contains__(tool.get("id"))
                 and not exits_tool_id_list.__contains__(generate_uuid((tool.get("id") + workspace_id or "")))
             ]
+        # 导入包内新建的工具由导入者本人持有,无需校验;仅需校验绑定到已存在工具的引用
+        existing_bound_tool_ids = [
+            tool_id for tool_id in get_bound_tool_ids(application) if tool_id not in update_tool_map
+        ]
+        if existing_bound_tool_ids:
+            authorized_tool_ids = set(get_authorized_tool_ids(user_id, workspace_id, existing_bound_tool_ids))
+            unauthorized_tool_ids = [
+                tool_id for tool_id in existing_bound_tool_ids if tool_id not in authorized_tool_ids
+            ]
+            if unauthorized_tool_ids:
+                message = lazy_format(
+                    _("No permission to use tool(s): {tool_ids}"), tool_ids=", ".join(unauthorized_tool_ids)
+                )
+                raise AppApiException(403, str(message))
         application_model = self.to_application(application, workspace_id, user_id, update_tool_map, folder_id)
         tool_model_list = [self.to_tool(f, workspace_id, user_id) for f in tool_list]
         application_model.save()
@@ -1189,6 +1274,8 @@ class ApplicationOperateSerializer(serializers.Serializer):
         #  处理工作流模板逻辑
         if "work_flow_template" in instance:
             return self.update_template_workflow(instance, application)
+
+        validate_bound_tool_permissions(self.data.get("user_id"), self.data.get("workspace_id"), instance)
 
         if instance.get("model_id") is None or len(instance.get("model_id")) == 0:
             application.model_id = None

--- a/apps/chat/mcp/tools.py
+++ b/apps/chat/mcp/tools.py
@@ -3,6 +3,7 @@ import re
 
 import uuid_utils.compat as uuid
 from django.db.models import QuerySet
+from django.utils import timezone
 
 from application.models import ApplicationApiKey, Application, ChatUserType, ChatSourceChoices
 from chat.serializers.chat import ChatSerializers
@@ -13,6 +14,8 @@ class MCPToolHandler:
         app_key = QuerySet(ApplicationApiKey).filter(secret_key=auth_header, is_active=True).first()
         if not app_key:
             raise PermissionError("Invalid API Key")
+        if app_key.is_permanent is False and app_key.expire_time < timezone.now():
+            raise PermissionError("API Key is expired")
 
         self.application = QuerySet(Application).filter(id=app_key.application_id, is_publish=True).first()
         if not self.application:

--- a/apps/common/utils/fork.py
+++ b/apps/common/utils/fork.py
@@ -1,5 +1,7 @@
 import copy
+import ipaddress
 import re
+import socket
 import traceback
 from functools import reduce
 from typing import List, Set
@@ -12,6 +14,44 @@ from bs4 import BeautifulSoup
 from common.utils.logger import maxkb_logger
 
 requests.packages.urllib3.disable_warnings()
+
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("198.18.0.0/15"),
+    ipaddress.ip_network("198.51.100.0/24"),
+    ipaddress.ip_network("203.0.113.0/24"),
+    ipaddress.ip_network("240.0.0.0/4"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def _validate_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Disallowed URL scheme: {parsed.scheme!r}")
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("Missing hostname in URL")
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise ValueError(f"Cannot resolve host {hostname!r}: {exc}") from exc
+    for addr_info in addr_infos:
+        ip_str = addr_info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if any(ip in net for net in _BLOCKED_NETWORKS):
+            raise ValueError(f"URL resolves to a blocked internal address: {ip}")
 
 
 class ChildLink:
@@ -29,27 +69,34 @@ class ForkManage:
         self.fork_child(ChildLink(self.base_url, None), self.selector_list, level, exclude_link_url, fork_handler)
 
     @staticmethod
-    def fork_child(child_link: ChildLink, selector_list: List[str], level: int, exclude_link_url: Set[str],
-                   fork_handler):
+    def fork_child(
+        child_link: ChildLink, selector_list: List[str], level: int, exclude_link_url: Set[str], fork_handler
+    ):
         if level < 0:
             return
         else:
             child_link.url = remove_fragment(child_link.url)
-            child_url = child_link.url[:-1] if child_link.url.endswith('/') else child_link.url
+            child_url = child_link.url[:-1] if child_link.url.endswith("/") else child_link.url
         if not exclude_link_url.__contains__(child_url):
             exclude_link_url.add(child_url)
             response = Fork(child_link.url, selector_list).fork()
             fork_handler(child_link, response)
             for child_link in response.child_link_list:
-                child_url = child_link.url[:-1] if child_link.url.endswith('/') else child_link.url
+                child_url = child_link.url[:-1] if child_link.url.endswith("/") else child_link.url
                 if not exclude_link_url.__contains__(child_url):
                     ForkManage.fork_child(child_link, selector_list, level - 1, exclude_link_url, fork_handler)
 
 
 def remove_fragment(url: str) -> str:
     parsed_url = urlparse(url)
-    modified_url = ParseResult(scheme=parsed_url.scheme, netloc=parsed_url.netloc, path=parsed_url.path,
-                               params=parsed_url.params, query=parsed_url.query, fragment=None)
+    modified_url = ParseResult(
+        scheme=parsed_url.scheme,
+        netloc=parsed_url.netloc,
+        path=parsed_url.path,
+        params=parsed_url.params,
+        query=parsed_url.query,
+        fragment=None,
+    )
     return urlunparse(modified_url)
 
 
@@ -63,54 +110,68 @@ class Fork:
 
         @staticmethod
         def success(html_content: str, child_link_list: List[ChildLink]):
-            return Fork.Response(html_content, child_link_list, 200, '')
+            return Fork.Response(html_content, child_link_list, 200, "")
 
         @staticmethod
         def error(message: str):
-            return Fork.Response('', [], 500, message)
+            return Fork.Response("", [], 500, message)
 
     def __init__(self, base_fork_url: str, selector_list: List[str]):
+        _validate_url(base_fork_url)
         base_fork_url = remove_fragment(base_fork_url)
         parsed = urlparse(base_fork_url)
-        path = parsed.path.rstrip('/')
-        self.base_fork_url = urlunparse((
-            parsed.scheme,
-            parsed.netloc,
-            path,
-            None,
-            None,
-            None  # fragment
-        ))
+        path = parsed.path.rstrip("/")
+        self.base_fork_url = urlunparse(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                path,
+                None,
+                None,
+                None,  # fragment
+            )
+        )
         parsed = urlsplit(base_fork_url)
         query = parsed.query
         if query is not None and len(query) > 0:
-            self.base_fork_url = self.base_fork_url + '?' + query
+            self.base_fork_url = self.base_fork_url + "?" + query
         self.selector_list = [selector for selector in selector_list if selector is not None and len(selector) > 0]
         self.urlparse = urlparse(self.base_fork_url)
-        self.base_url = ParseResult(scheme=self.urlparse.scheme, netloc=self.urlparse.netloc, path='', params='',
-                                    query='',
-                                    fragment='').geturl()
+        self.base_url = ParseResult(
+            scheme=self.urlparse.scheme, netloc=self.urlparse.netloc, path="", params="", query="", fragment=""
+        ).geturl()
 
     def get_child_link_list(self, bf: BeautifulSoup):
         # Compute the crawl prefix: parent directory when base_fork_url is an HTML file
         crawl_prefix = self.base_fork_url
-        if crawl_prefix.endswith(('.html', '.htm')):
-            crawl_prefix = crawl_prefix.rsplit('/', 1)[0]
+        if crawl_prefix.endswith((".html", ".htm")):
+            crawl_prefix = crawl_prefix.rsplit("/", 1)[0]
         pattern = "^((?!(http:|https:|tel:/|#|mailto:|javascript:))|" + crawl_prefix + "|/).*"
-        link_list = bf.find_all(name='a', href=re.compile(pattern))
-        result = [ChildLink(link.get('href'), link) if link.get('href').startswith(self.base_url) else ChildLink(
-            self.base_url + link.get('href'), link) for link in link_list]
+        link_list = bf.find_all(name="a", href=re.compile(pattern))
+        result = [
+            ChildLink(link.get("href"), link)
+            if link.get("href").startswith(self.base_url)
+            else ChildLink(self.base_url + link.get("href"), link)
+            for link in link_list
+        ]
         result = [row for row in result if row.url.startswith(crawl_prefix)]
         return result
 
     def get_content_html(self, bf: BeautifulSoup):
         if self.selector_list is None or len(self.selector_list) == 0:
             return str(bf)
-        params = reduce(lambda x, y: {**x, **y},
-                        [{'class_': selector.replace('.', '')} if selector.startswith('.') else
-                         {'id': selector.replace("#", "")} if selector.startswith("#") else {'name': selector} for
-                         selector in
-                         self.selector_list], {})
+        params = reduce(
+            lambda x, y: {**x, **y},
+            [
+                {"class_": selector.replace(".", "")}
+                if selector.startswith(".")
+                else {"id": selector.replace("#", "")}
+                if selector.startswith("#")
+                else {"name": selector}
+                for selector in self.selector_list
+            ],
+            {},
+        )
         f = bf.find_all(**params)
         return "\n".join([str(row) for row in f])
 
@@ -119,53 +180,58 @@ class Fork:
         field_value: str = tag[field]
         if field_value.startswith("/"):
             result = urlparse(base_fork_url)
-            result_url = ParseResult(scheme=result.scheme, netloc=result.netloc, path=field_value, params='', query='',
-                                     fragment='').geturl()
+            result_url = ParseResult(
+                scheme=result.scheme, netloc=result.netloc, path=field_value, params="", query="", fragment=""
+            ).geturl()
         else:
             # When base_fork_url is an HTML file (not a directory), resolve relative
             # links against its parent directory to avoid broken paths like
             # /en/index.html/about_dolphindb.html
-            if base_fork_url.endswith(('.html', '.htm')):
-                base = base_fork_url.rsplit('/', 1)[0] + '/'
+            if base_fork_url.endswith((".html", ".htm")):
+                base = base_fork_url.rsplit("/", 1)[0] + "/"
             else:
-                base = base_fork_url + '/'
+                base = base_fork_url + "/"
             result_url = urljoin(base, field_value)
-        result_url = result_url[:-1] if result_url.endswith('/') else result_url
+        result_url = result_url[:-1] if result_url.endswith("/") else result_url
         tag[field] = result_url
 
     def reset_beautiful_soup(self, bf: BeautifulSoup):
         reset_config_list = [
             {
-                'field': 'href',
+                "field": "href",
             },
             {
-                'field': 'src',
-            }
+                "field": "src",
+            },
         ]
         for reset_config in reset_config_list:
-            field = reset_config.get('field')
-            tag_list = bf.find_all(**{field: re.compile('^(?!(http:|https:|tel:/|#|mailto:|javascript:)).*')})
+            field = reset_config.get("field")
+            tag_list = bf.find_all(**{field: re.compile("^(?!(http:|https:|tel:/|#|mailto:|javascript:)).*")})
             for tag in tag_list:
                 self.reset_url(tag, field, self.base_fork_url)
             # 去掉 href 以 # 开头的锚点链接，保留文字
-        for a in bf.find_all('a', href=re.compile('^#')):
+        for a in bf.find_all("a", href=re.compile("^#")):
             a.unwrap()
         return bf
 
     @staticmethod
     def get_beautiful_soup(response):
-        encoding = response.encoding if response.encoding is not None and response.encoding != 'ISO-8859-1' else response.apparent_encoding
+        encoding = (
+            response.encoding
+            if response.encoding is not None and response.encoding != "ISO-8859-1"
+            else response.apparent_encoding
+        )
         html_content = response.content.decode(encoding)
         beautiful_soup = BeautifulSoup(html_content, "html.parser")
-        meta_list = beautiful_soup.find_all('meta')
+        meta_list = beautiful_soup.find_all("meta")
         charset_list = Fork.get_charset_list(meta_list)
         if len(charset_list) > 0:
             charset = charset_list[0]
             if charset != encoding:
                 try:
-                    html_content = response.content.decode(charset, errors='replace')
+                    html_content = response.content.decode(charset, errors="replace")
                 except Exception as e:
-                    maxkb_logger.error(f'{e}: {traceback.format_exc()}')
+                    maxkb_logger.error(f"{e}: {traceback.format_exc()}")
                 return BeautifulSoup(html_content, "html.parser")
         return beautiful_soup
 
@@ -174,39 +240,50 @@ class Fork:
         charset_list = []
         for meta in meta_list:
             if meta.attrs is not None:
-                if 'charset' in meta.attrs:
-                    charset_list.append(meta.attrs.get('charset'))
-                elif meta.attrs.get('http-equiv', '').lower() == 'content-type' and 'content' in meta.attrs:
-                    match = re.search(r'charset=([^\s;]+)', meta.attrs['content'], re.I)
+                if "charset" in meta.attrs:
+                    charset_list.append(meta.attrs.get("charset"))
+                elif meta.attrs.get("http-equiv", "").lower() == "content-type" and "content" in meta.attrs:
+                    match = re.search(r"charset=([^\s;]+)", meta.attrs["content"], re.I)
                     if match:
                         charset_list.append(match.group(1))
         return charset_list
 
     def fork(self):
         try:
-
             headers = {
-                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36'
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36"
             }
 
-            maxkb_logger.info(f'fork:{self.base_fork_url}')
-            response = requests.get(self.base_fork_url, verify=False, headers=headers)
+            maxkb_logger.info(f"fork:{self.base_fork_url}")
+            url = self.base_fork_url
+            for _ in range(10):
+                response = requests.get(url, verify=True, headers=headers, allow_redirects=False, timeout=(10, 30))
+                if response.status_code in (301, 302, 303, 307, 308):
+                    location = response.headers.get("Location")
+                    if not location:
+                        break
+                    location = urljoin(url, location)
+                    _validate_url(location)
+                    url = location
+                    continue
+                break
             if response.status_code != 200:
                 maxkb_logger.error(f"url: {self.base_fork_url} code:{response.status_code}")
                 return Fork.Response.error(f"url: {self.base_fork_url} code:{response.status_code}")
             bf = self.get_beautiful_soup(response)
         except Exception as e:
-            maxkb_logger.error(f'{str(e)}:{traceback.format_exc()}')
+            maxkb_logger.error(f"{str(e)}:{traceback.format_exc()}")
             return Fork.Response.error(str(e))
         bf = self.reset_beautiful_soup(bf)
         link_list = self.get_child_link_list(bf)
         content = self.get_content_html(bf)
 
-        r = markdownify(content, heading_style='ATX')
+        r = markdownify(content, heading_style="ATX")
         return Fork.Response.success(r, link_list)
 
 
 def handler(base_url, response: Fork.Response):
     maxkb_logger.info(base_url.url, base_url.tag.text if base_url.tag else None, response.content)
+
 
 # ForkManage('https://bbs.fit2cloud.com/c/de/6', ['.md-content']).fork(3, set(), handler)

--- a/apps/common/utils/fork.py
+++ b/apps/common/utils/fork.py
@@ -17,7 +17,16 @@ requests.packages.urllib3.disable_warnings()
 
 _BLOCKED_NETWORKS = [
     ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("100.64.0.0/10"),
     ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("198.18.0.0/15"),
+    ipaddress.ip_network("198.51.100.0/24"),
+    ipaddress.ip_network("203.0.113.0/24"),
+    ipaddress.ip_network("240.0.0.0/4"),
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
@@ -248,7 +257,7 @@ class Fork:
             maxkb_logger.info(f"fork:{self.base_fork_url}")
             url = self.base_fork_url
             for _ in range(10):
-                response = requests.get(url, verify=False, headers=headers, allow_redirects=False, timeout=(10, 30))
+                response = requests.get(url, verify=True, headers=headers, allow_redirects=False, timeout=(10, 30))
                 if response.status_code in (301, 302, 303, 307, 308):
                     location = response.headers.get("Location")
                     if not location:

--- a/apps/common/utils/fork.py
+++ b/apps/common/utils/fork.py
@@ -1,7 +1,5 @@
 import copy
-import ipaddress
 import re
-import socket
 import traceback
 from functools import reduce
 from typing import List, Set
@@ -14,44 +12,6 @@ from bs4 import BeautifulSoup
 from common.utils.logger import maxkb_logger
 
 requests.packages.urllib3.disable_warnings()
-
-_BLOCKED_NETWORKS = [
-    ipaddress.ip_network("0.0.0.0/8"),
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("100.64.0.0/10"),
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("198.18.0.0/15"),
-    ipaddress.ip_network("198.51.100.0/24"),
-    ipaddress.ip_network("203.0.113.0/24"),
-    ipaddress.ip_network("240.0.0.0/4"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),
-    ipaddress.ip_network("fe80::/10"),
-]
-
-
-def _validate_url(url: str) -> None:
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError(f"Disallowed URL scheme: {parsed.scheme!r}")
-    hostname = parsed.hostname
-    if not hostname:
-        raise ValueError("Missing hostname in URL")
-    try:
-        addr_infos = socket.getaddrinfo(hostname, None)
-    except socket.gaierror as exc:
-        raise ValueError(f"Cannot resolve host {hostname!r}: {exc}") from exc
-    for addr_info in addr_infos:
-        ip_str = addr_info[4][0]
-        try:
-            ip = ipaddress.ip_address(ip_str)
-        except ValueError:
-            continue
-        if any(ip in net for net in _BLOCKED_NETWORKS):
-            raise ValueError(f"URL resolves to a blocked internal address: {ip}")
 
 
 class ChildLink:
@@ -69,34 +29,27 @@ class ForkManage:
         self.fork_child(ChildLink(self.base_url, None), self.selector_list, level, exclude_link_url, fork_handler)
 
     @staticmethod
-    def fork_child(
-        child_link: ChildLink, selector_list: List[str], level: int, exclude_link_url: Set[str], fork_handler
-    ):
+    def fork_child(child_link: ChildLink, selector_list: List[str], level: int, exclude_link_url: Set[str],
+                   fork_handler):
         if level < 0:
             return
         else:
             child_link.url = remove_fragment(child_link.url)
-            child_url = child_link.url[:-1] if child_link.url.endswith("/") else child_link.url
+            child_url = child_link.url[:-1] if child_link.url.endswith('/') else child_link.url
         if not exclude_link_url.__contains__(child_url):
             exclude_link_url.add(child_url)
             response = Fork(child_link.url, selector_list).fork()
             fork_handler(child_link, response)
             for child_link in response.child_link_list:
-                child_url = child_link.url[:-1] if child_link.url.endswith("/") else child_link.url
+                child_url = child_link.url[:-1] if child_link.url.endswith('/') else child_link.url
                 if not exclude_link_url.__contains__(child_url):
                     ForkManage.fork_child(child_link, selector_list, level - 1, exclude_link_url, fork_handler)
 
 
 def remove_fragment(url: str) -> str:
     parsed_url = urlparse(url)
-    modified_url = ParseResult(
-        scheme=parsed_url.scheme,
-        netloc=parsed_url.netloc,
-        path=parsed_url.path,
-        params=parsed_url.params,
-        query=parsed_url.query,
-        fragment=None,
-    )
+    modified_url = ParseResult(scheme=parsed_url.scheme, netloc=parsed_url.netloc, path=parsed_url.path,
+                               params=parsed_url.params, query=parsed_url.query, fragment=None)
     return urlunparse(modified_url)
 
 
@@ -110,68 +63,54 @@ class Fork:
 
         @staticmethod
         def success(html_content: str, child_link_list: List[ChildLink]):
-            return Fork.Response(html_content, child_link_list, 200, "")
+            return Fork.Response(html_content, child_link_list, 200, '')
 
         @staticmethod
         def error(message: str):
-            return Fork.Response("", [], 500, message)
+            return Fork.Response('', [], 500, message)
 
     def __init__(self, base_fork_url: str, selector_list: List[str]):
-        _validate_url(base_fork_url)
         base_fork_url = remove_fragment(base_fork_url)
         parsed = urlparse(base_fork_url)
-        path = parsed.path.rstrip("/")
-        self.base_fork_url = urlunparse(
-            (
-                parsed.scheme,
-                parsed.netloc,
-                path,
-                None,
-                None,
-                None,  # fragment
-            )
-        )
+        path = parsed.path.rstrip('/')
+        self.base_fork_url = urlunparse((
+            parsed.scheme,
+            parsed.netloc,
+            path,
+            None,
+            None,
+            None  # fragment
+        ))
         parsed = urlsplit(base_fork_url)
         query = parsed.query
         if query is not None and len(query) > 0:
-            self.base_fork_url = self.base_fork_url + "?" + query
+            self.base_fork_url = self.base_fork_url + '?' + query
         self.selector_list = [selector for selector in selector_list if selector is not None and len(selector) > 0]
         self.urlparse = urlparse(self.base_fork_url)
-        self.base_url = ParseResult(
-            scheme=self.urlparse.scheme, netloc=self.urlparse.netloc, path="", params="", query="", fragment=""
-        ).geturl()
+        self.base_url = ParseResult(scheme=self.urlparse.scheme, netloc=self.urlparse.netloc, path='', params='',
+                                    query='',
+                                    fragment='').geturl()
 
     def get_child_link_list(self, bf: BeautifulSoup):
         # Compute the crawl prefix: parent directory when base_fork_url is an HTML file
         crawl_prefix = self.base_fork_url
-        if crawl_prefix.endswith((".html", ".htm")):
-            crawl_prefix = crawl_prefix.rsplit("/", 1)[0]
+        if crawl_prefix.endswith(('.html', '.htm')):
+            crawl_prefix = crawl_prefix.rsplit('/', 1)[0]
         pattern = "^((?!(http:|https:|tel:/|#|mailto:|javascript:))|" + crawl_prefix + "|/).*"
-        link_list = bf.find_all(name="a", href=re.compile(pattern))
-        result = [
-            ChildLink(link.get("href"), link)
-            if link.get("href").startswith(self.base_url)
-            else ChildLink(self.base_url + link.get("href"), link)
-            for link in link_list
-        ]
+        link_list = bf.find_all(name='a', href=re.compile(pattern))
+        result = [ChildLink(link.get('href'), link) if link.get('href').startswith(self.base_url) else ChildLink(
+            self.base_url + link.get('href'), link) for link in link_list]
         result = [row for row in result if row.url.startswith(crawl_prefix)]
         return result
 
     def get_content_html(self, bf: BeautifulSoup):
         if self.selector_list is None or len(self.selector_list) == 0:
             return str(bf)
-        params = reduce(
-            lambda x, y: {**x, **y},
-            [
-                {"class_": selector.replace(".", "")}
-                if selector.startswith(".")
-                else {"id": selector.replace("#", "")}
-                if selector.startswith("#")
-                else {"name": selector}
-                for selector in self.selector_list
-            ],
-            {},
-        )
+        params = reduce(lambda x, y: {**x, **y},
+                        [{'class_': selector.replace('.', '')} if selector.startswith('.') else
+                         {'id': selector.replace("#", "")} if selector.startswith("#") else {'name': selector} for
+                         selector in
+                         self.selector_list], {})
         f = bf.find_all(**params)
         return "\n".join([str(row) for row in f])
 
@@ -180,58 +119,53 @@ class Fork:
         field_value: str = tag[field]
         if field_value.startswith("/"):
             result = urlparse(base_fork_url)
-            result_url = ParseResult(
-                scheme=result.scheme, netloc=result.netloc, path=field_value, params="", query="", fragment=""
-            ).geturl()
+            result_url = ParseResult(scheme=result.scheme, netloc=result.netloc, path=field_value, params='', query='',
+                                     fragment='').geturl()
         else:
             # When base_fork_url is an HTML file (not a directory), resolve relative
             # links against its parent directory to avoid broken paths like
             # /en/index.html/about_dolphindb.html
-            if base_fork_url.endswith((".html", ".htm")):
-                base = base_fork_url.rsplit("/", 1)[0] + "/"
+            if base_fork_url.endswith(('.html', '.htm')):
+                base = base_fork_url.rsplit('/', 1)[0] + '/'
             else:
-                base = base_fork_url + "/"
+                base = base_fork_url + '/'
             result_url = urljoin(base, field_value)
-        result_url = result_url[:-1] if result_url.endswith("/") else result_url
+        result_url = result_url[:-1] if result_url.endswith('/') else result_url
         tag[field] = result_url
 
     def reset_beautiful_soup(self, bf: BeautifulSoup):
         reset_config_list = [
             {
-                "field": "href",
+                'field': 'href',
             },
             {
-                "field": "src",
-            },
+                'field': 'src',
+            }
         ]
         for reset_config in reset_config_list:
-            field = reset_config.get("field")
-            tag_list = bf.find_all(**{field: re.compile("^(?!(http:|https:|tel:/|#|mailto:|javascript:)).*")})
+            field = reset_config.get('field')
+            tag_list = bf.find_all(**{field: re.compile('^(?!(http:|https:|tel:/|#|mailto:|javascript:)).*')})
             for tag in tag_list:
                 self.reset_url(tag, field, self.base_fork_url)
             # 去掉 href 以 # 开头的锚点链接，保留文字
-        for a in bf.find_all("a", href=re.compile("^#")):
+        for a in bf.find_all('a', href=re.compile('^#')):
             a.unwrap()
         return bf
 
     @staticmethod
     def get_beautiful_soup(response):
-        encoding = (
-            response.encoding
-            if response.encoding is not None and response.encoding != "ISO-8859-1"
-            else response.apparent_encoding
-        )
+        encoding = response.encoding if response.encoding is not None and response.encoding != 'ISO-8859-1' else response.apparent_encoding
         html_content = response.content.decode(encoding)
         beautiful_soup = BeautifulSoup(html_content, "html.parser")
-        meta_list = beautiful_soup.find_all("meta")
+        meta_list = beautiful_soup.find_all('meta')
         charset_list = Fork.get_charset_list(meta_list)
         if len(charset_list) > 0:
             charset = charset_list[0]
             if charset != encoding:
                 try:
-                    html_content = response.content.decode(charset, errors="replace")
+                    html_content = response.content.decode(charset, errors='replace')
                 except Exception as e:
-                    maxkb_logger.error(f"{e}: {traceback.format_exc()}")
+                    maxkb_logger.error(f'{e}: {traceback.format_exc()}')
                 return BeautifulSoup(html_content, "html.parser")
         return beautiful_soup
 
@@ -240,50 +174,39 @@ class Fork:
         charset_list = []
         for meta in meta_list:
             if meta.attrs is not None:
-                if "charset" in meta.attrs:
-                    charset_list.append(meta.attrs.get("charset"))
-                elif meta.attrs.get("http-equiv", "").lower() == "content-type" and "content" in meta.attrs:
-                    match = re.search(r"charset=([^\s;]+)", meta.attrs["content"], re.I)
+                if 'charset' in meta.attrs:
+                    charset_list.append(meta.attrs.get('charset'))
+                elif meta.attrs.get('http-equiv', '').lower() == 'content-type' and 'content' in meta.attrs:
+                    match = re.search(r'charset=([^\s;]+)', meta.attrs['content'], re.I)
                     if match:
                         charset_list.append(match.group(1))
         return charset_list
 
     def fork(self):
         try:
+
             headers = {
-                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36"
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36'
             }
 
-            maxkb_logger.info(f"fork:{self.base_fork_url}")
-            url = self.base_fork_url
-            for _ in range(10):
-                response = requests.get(url, verify=True, headers=headers, allow_redirects=False, timeout=(10, 30))
-                if response.status_code in (301, 302, 303, 307, 308):
-                    location = response.headers.get("Location")
-                    if not location:
-                        break
-                    location = urljoin(url, location)
-                    _validate_url(location)
-                    url = location
-                    continue
-                break
+            maxkb_logger.info(f'fork:{self.base_fork_url}')
+            response = requests.get(self.base_fork_url, verify=False, headers=headers)
             if response.status_code != 200:
                 maxkb_logger.error(f"url: {self.base_fork_url} code:{response.status_code}")
                 return Fork.Response.error(f"url: {self.base_fork_url} code:{response.status_code}")
             bf = self.get_beautiful_soup(response)
         except Exception as e:
-            maxkb_logger.error(f"{str(e)}:{traceback.format_exc()}")
+            maxkb_logger.error(f'{str(e)}:{traceback.format_exc()}')
             return Fork.Response.error(str(e))
         bf = self.reset_beautiful_soup(bf)
         link_list = self.get_child_link_list(bf)
         content = self.get_content_html(bf)
 
-        r = markdownify(content, heading_style="ATX")
+        r = markdownify(content, heading_style='ATX')
         return Fork.Response.success(r, link_list)
 
 
 def handler(base_url, response: Fork.Response):
     maxkb_logger.info(base_url.url, base_url.tag.text if base_url.tag else None, response.content)
-
 
 # ForkManage('https://bbs.fit2cloud.com/c/de/6', ['.md-content']).fork(3, set(), handler)

--- a/apps/common/utils/fork.py
+++ b/apps/common/utils/fork.py
@@ -17,16 +17,7 @@ requests.packages.urllib3.disable_warnings()
 
 _BLOCKED_NETWORKS = [
     ipaddress.ip_network("0.0.0.0/8"),
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("100.64.0.0/10"),
     ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("198.18.0.0/15"),
-    ipaddress.ip_network("198.51.100.0/24"),
-    ipaddress.ip_network("203.0.113.0/24"),
-    ipaddress.ip_network("240.0.0.0/4"),
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
@@ -257,7 +248,7 @@ class Fork:
             maxkb_logger.info(f"fork:{self.base_fork_url}")
             url = self.base_fork_url
             for _ in range(10):
-                response = requests.get(url, verify=True, headers=headers, allow_redirects=False, timeout=(10, 30))
+                response = requests.get(url, verify=False, headers=headers, allow_redirects=False, timeout=(10, 30))
                 if response.status_code in (301, 302, 303, 307, 308):
                     location = response.headers.get("Location")
                     if not location:

--- a/apps/common/utils/tool_code.py
+++ b/apps/common/utils/tool_code.py
@@ -376,7 +376,7 @@ exec({dedent(code)!a})
             )
             return subprocess_result
         except subprocess.TimeoutExpired:
-            raise Exception(_(f"Process execution timed out after {_process_limit_timeout_seconds} seconds."))
+            raise Exception(_("Process execution timed out after {} seconds.").format(_process_limit_timeout_seconds))
 
     def validate_mcp_transport(self, code_str):
         servers = json.loads(code_str)

--- a/apps/knowledge/serializers/document.py
+++ b/apps/knowledge/serializers/document.py
@@ -694,7 +694,8 @@ class DocumentSerializers(serializers.Serializer):
             if not query_set.exists():
                 raise AppApiException(500, _("Knowledge id does not exist"))
             document_id = self.data.get("document_id")
-            if not QuerySet(Document).filter(id=document_id).exists():
+            knowledge_id = self.data.get("knowledge_id")
+            if not QuerySet(Document).filter(id=document_id, knowledge_id=knowledge_id).exists():
                 raise AppApiException(500, _("document id not exist"))
 
         def export(self, with_valid=True):

--- a/apps/knowledge/serializers/paragraph.py
+++ b/apps/knowledge/serializers/paragraph.py
@@ -117,7 +117,11 @@ class ParagraphSerializers(serializers.Serializer):
                 query_set = query_set.filter(workspace_id=workspace_id)
             if not query_set.exists():
                 raise AppApiException(500, _("Knowledge id does not exist"))
-            if not QuerySet(Paragraph).filter(id=self.data.get("paragraph_id")).exists():
+            if not QuerySet(Paragraph).filter(
+                id=self.data.get("paragraph_id"),
+                document_id=self.data.get("document_id"),
+                knowledge_id=self.data.get("knowledge_id"),
+            ).exists():
                 raise AppApiException(500, _("Paragraph id does not exist"))
 
         def list(self, with_valid=False):
@@ -209,7 +213,11 @@ class ParagraphSerializers(serializers.Serializer):
                 query_set = query_set.filter(workspace_id=workspace_id)
             if not query_set.exists():
                 raise AppApiException(500, _("Knowledge id does not exist"))
-            if not QuerySet(Paragraph).filter(id=self.data.get("paragraph_id")).exists():
+            if not QuerySet(Paragraph).filter(
+                id=self.data.get("paragraph_id"),
+                document_id=self.data.get("document_id"),
+                knowledge_id=self.data.get("knowledge_id"),
+            ).exists():
                 raise AppApiException(500, _("Paragraph id does not exist"))
 
         @staticmethod

--- a/apps/locales/en_US/LC_MESSAGES/django.po
+++ b/apps/locales/en_US/LC_MESSAGES/django.po
@@ -4255,7 +4255,7 @@ msgstr ""
 #: apps/models_provider/impl/openai_model_provider/credential/tti.py:29
 #: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:29
 msgid ""
-"       \n"
+"\n"
 "By default, images are produced in standard quality, but with DALL·E 3 you "
 "can set quality: \"hd\" to enhance detail. Square, standard quality images "
 "are generated fastest.\n"
@@ -4781,7 +4781,7 @@ msgstr ""
 
 #: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:44
 msgid ""
-"       \n"
+"\n"
 "Code Llama Instruct is a fine-tuned version of Code Llama's instructions, "
 "designed to perform specific tasks.\n"
 "        "

--- a/apps/locales/en_US/LC_MESSAGES/django.po
+++ b/apps/locales/en_US/LC_MESSAGES/django.po
@@ -3,12 +3,11 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-18 17:34+0800\n"
+"POT-Creation-Date: 2025-06-18 17:33+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,4733 +16,1421 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: apps/application/api/application_api.py:21
-#: apps/application/serializers/application.py:153
-msgid "Workflow Objects"
-msgstr ""
-
-#: apps/application/api/application_api.py:52
-#: apps/application/api/application_chat.py:104
-#: apps/application/api/application_chat_record.py:74
-#: apps/role_setting/api/role_setting.py:171 apps/shared/api/shared_tool.py:79
-#: apps/shared/api/shared_tool.py:119 apps/workspace/api/workspace.py:110
-#: apps/xpack/api/user_group.py:61
-msgid "Current page"
-msgstr ""
-
-#: apps/application/api/application_api.py:59
-#: apps/application/api/application_chat.py:111
-#: apps/application/api/application_chat_record.py:81
-#: apps/role_setting/api/role_setting.py:178 apps/shared/api/shared_tool.py:86
-#: apps/shared/api/shared_tool.py:126 apps/workspace/api/workspace.py:117
-#: apps/xpack/api/user_group.py:68
-msgid "Page size"
-msgstr ""
-
-#: apps/application/api/application_api.py:66
-#: apps/application/serializers/application.py:156
-#: apps/application/serializers/application.py:195
-#: apps/application/serializers/application.py:274
-#: apps/folders/serializers/folder.py:97 apps/folders/serializers/folder.py:139
-#: apps/knowledge/serializers/knowledge.py:52
-#: apps/knowledge/serializers/knowledge.py:59
-#: apps/tools/serializers/tool.py:453
-#: apps/xpack/serializers/dataset_lark_serializer.py:55
-msgid "folder id"
-msgstr ""
-
-#: apps/application/api/application_api.py:73
-#: apps/application/serializers/application.py:149
-#: apps/application/serializers/application.py:275
-#: apps/application/serializers/application.py:282
-#: apps/application/serializers/application.py:368
-msgid "Application Name"
-msgstr "Agent Name"
-
-#: apps/application/api/application_api.py:80
-#: apps/application/serializers/application.py:152
-#: apps/application/serializers/application.py:276
-#: apps/application/serializers/application.py:283
-#: apps/application/serializers/application.py:284
-#: apps/application/serializers/application.py:370
-msgid "Application Description"
-msgstr "Agent Description"
-
-#: apps/application/api/application_api.py:87
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:78
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:30
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:47
-#: apps/application/serializers/application.py:99
-#: apps/application/serializers/application.py:277
-#: apps/application/serializers/application.py:295
-#: apps/application/serializers/application.py:413
-#: apps/application/serializers/application.py:540
-#: apps/role_setting/api/role_setting.py:144 apps/tools/serializers/tool.py:357
-#: apps/tools/serializers/tool.py:390 apps/users/api/user.py:52
-#: apps/users/api/user.py:110 apps/users/api/user.py:126
-#: apps/users/serializers/user.py:325 apps/workspace/api/workspace.py:82
-#: apps/workspace/serializers/workspace_serializers.py:270
-#: apps/workspace/serializers/workspace_serializers.py:306
-#: apps/xpack/api/chat_user.py:49 apps/xpack/api/chat_user.py:92
-#: apps/xpack/serializers/chat_user.py:301
-msgid "User ID"
-msgstr ""
-
-#: apps/application/api/application_chat.py:70
-#: apps/application/serializers/application_chat.py:56
-msgid "Minimum number of likes"
-msgstr ""
-
-#: apps/application/api/application_chat.py:76
-#: apps/application/serializers/application_chat.py:58
-msgid "Minimum number of clicks"
-msgstr ""
-
-#: apps/application/api/application_chat.py:82
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:18
-#: apps/application/serializers/application_chat.py:59
-msgid "Comparator"
-msgstr ""
-
-#: apps/application/api/application_chat_record.py:46
-#: apps/application/api/application_chat_record.py:115
-#: apps/application/serializers/application_chat.py:47
-#: apps/application/serializers/application_chat_record.py:76
-msgid "Chat ID"
-msgstr ""
-
-#: apps/application/api/application_chat_record.py:53
-#: apps/application/serializers/application_chat_record.py:77
-msgid "Is it in order"
-msgstr ""
-
-#: apps/application/api/application_chat_record.py:122
-msgid "Chat Record ID"
-msgstr ""
-
-#: apps/application/api/application_chat_record.py:129
-#: apps/shared/api/shared_knowledge.py:235
-#: apps/shared/api/shared_knowledge.py:256 apps/xpack/api/knowledge_lark.py:47
-#: apps/xpack/api/knowledge_lark.py:79 apps/xpack/api/knowledge_lark.py:111
-msgid "Knowledge ID"
-msgstr ""
-
-#: apps/application/api/application_chat_record.py:136
-#: apps/shared/api/shared_knowledge.py:263 apps/xpack/api/knowledge_lark.py:86
-msgid "Document ID"
-msgstr ""
-
-#: apps/application/api/application_chat_record.py:148
-msgid "Paragraph ID"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:26
-msgid "Model type error"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:36
-#: apps/common/field/common.py:24 apps/common/field/common.py:37
-msgid "Message type error"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:55
-msgid "Conversation list"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:56
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:29
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:18
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:12
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:13
-#: apps/application/flow/step_node/question_node/i_question_node.py:18
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:12
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:13
-#: apps/application/serializers/application.py:101
-#: apps/application/serializers/application.py:285
-#: apps/knowledge/serializers/common.py:71 apps/shared/api/shared_model.py:76
-#: apps/shared/api/shared_model.py:98
-msgid "Model id"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:58
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:29
-msgid "Paragraph List"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:60
-#: apps/application/serializers/application_chat.py:182
-#: apps/application/serializers/application_chat_record.py:41
-#: apps/application/serializers/application_chat_record.py:140
-#: apps/application/serializers/application_chat_record.py:179
-#: apps/application/serializers/application_chat_record.py:247
-#: apps/application/serializers/application_chat_record.py:312
-#: apps/chat/serializers/chat.py:98 apps/chat/serializers/chat.py:114
-msgid "Conversation ID"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:62
-#: apps/application/flow/step_node/application_node/i_application_node.py:14
-#: apps/application/serializers/application_chat.py:182
-#: apps/chat/serializers/chat.py:40
-msgid "User Questions"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:65
-msgid "Post-processor"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:68
-msgid "Completion Question"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:70
-msgid "Streaming Output"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:71
-#: apps/xpack/serializers/resource_chat_user.py:93
-msgid "Chat user id"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:73
-msgid "Chat user Type"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:76
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:47
-msgid "No reference segment settings"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:81
-msgid "Model settings"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:84
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:29
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:29
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:28
-#: apps/application/flow/step_node/question_node/i_question_node.py:29
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:20
-msgid "Model parameter settings"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:91
-msgid "message type error"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:224
-#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:270
-msgid ""
-"Sorry, the AI model is not configured. Please go to the application to set "
-"up the AI model first."
-msgstr "Sorry, the agent's AI model is not configured. Please go to the agent settings to set up the AI model first."
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:26
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:24
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:24
-#: apps/application/serializers/application_chat_record.py:172
-msgid "question"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:32
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:27
-msgid "History Questions"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:34
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:23
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:20
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:18
-#: apps/application/flow/step_node/question_node/i_question_node.py:24
-msgid "Number of multi-round conversations"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:37
-msgid "Maximum length of the knowledge base paragraph"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:39
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:21
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:16
-#: apps/application/flow/step_node/question_node/i_question_node.py:21
-#: apps/application/serializers/application.py:79
-#: apps/application/serializers/application.py:124
-#: apps/knowledge/serializers/common.py:72
-msgid "Prompt word"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:41
-msgid "System prompt words (role)"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:44
-msgid "Completion problem"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:32
-#: apps/application/serializers/application.py:215
-msgid "Question completion prompt"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/reset_problem_step/impl/base_reset_problem_step.py:20
-#: apps/application/serializers/common.py:87
-#, python-brace-format
-msgid ""
-"() contains the user's question. Answer the guessed user's question based on "
-"the context ({question}) Requirement: Output a complete question and put it "
-"in the <data></data> tag"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:27
-msgid "System completes question text"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:30
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:39
-msgid "Dataset id list"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:33
-msgid "List of document ids to exclude"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:36
-msgid "List of exclusion vector ids"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:39
-#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:21
-#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:24
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:24
-#: apps/application/serializers/application.py:84
-#: apps/application/serializers/application_chat.py:185
-msgid "Reference segment number"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:42
-msgid "Similarity"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:45
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:30
-#: apps/application/serializers/application.py:91
-#: apps/knowledge/serializers/knowledge.py:100
-#: apps/knowledge/serializers/knowledge.py:643
-msgid "The type only supports embedding|keywords|blend"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:46
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:31
-#: apps/application/serializers/application.py:92
-msgid "Retrieval Mode"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:31
-#: apps/application/serializers/application.py:113
-#: apps/application/serializers/application.py:657
-#: apps/application/serializers/application.py:664
-#: apps/application/serializers/application.py:671
-#: apps/knowledge/serializers/document.py:643
-#: apps/knowledge/serializers/knowledge.py:220
-#: apps/models_provider/serializers/model_serializer.py:116
-#: apps/models_provider/serializers/model_serializer.py:134
-#: apps/models_provider/serializers/model_serializer.py:370
-#: apps/models_provider/tools.py:111 apps/shared/serializers/shared_model.py:32
-#: apps/shared/serializers/shared_model.py:65
-#: apps/shared/serializers/shared_model.py:82
-msgid "Model does not exist"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:33
-#, python-brace-format
-msgid "No permission to use this model {model_name}"
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:42
-msgid ""
-"The vector model of the associated knowledge base is inconsistent and the "
-"segmentation cannot be recalled."
-msgstr ""
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:44
-msgid "The knowledge base setting is wrong, please reset the knowledge base"
-msgstr ""
-
-#: apps/application/flow/common.py:206
-#, python-brace-format
-msgid "The branch {branch} of the {node} node needs to be connected"
-msgstr ""
-
-#: apps/application/flow/common.py:212
-#, python-brace-format
-msgid "{node} Nodes cannot be considered as end nodes"
-msgstr ""
-
-#: apps/application/flow/common.py:226
-msgid "The starting node is required"
-msgstr ""
-
-#: apps/application/flow/common.py:228
-msgid "There can only be one starting node"
-msgstr ""
-
-#: apps/application/flow/common.py:236
-#, python-brace-format
-msgid "The node {node} model does not exist"
-msgstr ""
-
-#: apps/application/flow/common.py:246
-#, python-brace-format
-msgid "Node {node} is unavailable"
-msgstr ""
-
-#: apps/application/flow/common.py:252
-#, python-brace-format
-msgid "The library ID of node {node} cannot be empty"
-msgstr ""
-
-#: apps/application/flow/common.py:255
-#, python-brace-format
-msgid "The function library for node {node} is not available"
-msgstr ""
-
-#: apps/application/flow/common.py:261
-msgid "Basic information node is required"
-msgstr ""
-
-#: apps/application/flow/common.py:263
-msgid "There can only be one basic information node"
-msgstr ""
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:20
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:15
-#: apps/application/flow/step_node/question_node/i_question_node.py:20
-#: apps/users/api/user.py:35 apps/users/api/user.py:102
-msgid "Role Setting"
-msgstr ""
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:26
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:25
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:30
-#: apps/application/flow/step_node/function_node/i_function_node.py:48
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:26
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:23
-#: apps/application/flow/step_node/question_node/i_question_node.py:27
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:15
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:16
-msgid "Whether to return content"
-msgstr ""
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:33
-msgid "Context Type"
-msgstr ""
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:35
-msgid "Whether to enable MCP"
-msgstr ""
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:36
-msgid "MCP Server"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:12
-#: apps/application/serializers/application.py:539
-#: apps/application/serializers/application_access_token.py:44
-#: apps/application/serializers/application_chat.py:38
-#: apps/application/serializers/application_chat.py:54
-#: apps/application/serializers/application_chat_record.py:43
-#: apps/application/serializers/application_chat_record.py:75
-#: apps/application/serializers/application_stats.py:35
-#: apps/application/serializers/application_version.py:21
-#: apps/application/serializers/application_version.py:67
-#: apps/chat/serializers/chat.py:118
-#: apps/chat/serializers/chat_authentication.py:80
-#: apps/xpack/api/application_setting.py:31 apps/xpack/api/platform.py:29
-#: apps/xpack/api/platform.py:70
-msgid "Application ID"
-msgstr "Agent ID"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:15
-msgid "API Input Fields"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:17
-msgid "User Input Fields"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:18
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:25
-#: apps/chat/serializers/chat.py:57 apps/tools/serializers/tool.py:391
-msgid "picture"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:19
-#: apps/application/flow/step_node/document_extract_node/i_document_extract_node.py:12
-#: apps/chat/serializers/chat.py:58
-msgid "document"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:20
-#: apps/chat/serializers/chat.py:59
-msgid "Audio"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:22
-#: apps/chat/serializers/chat.py:62
-msgid "Child Nodes"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:23
-#: apps/application/flow/step_node/form_node/i_form_node.py:21
-msgid "Form Data"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:57
-msgid ""
-"Parameter value error: The uploaded document lacks file_id, and the document "
-"upload fails"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:66
-msgid ""
-"Parameter value error: The uploaded image lacks file_id, and the image "
-"upload fails"
-msgstr ""
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:76
-msgid ""
-"Parameter value error: The uploaded audio lacks file_id, and the audio "
-"upload fails."
-msgstr ""
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:19
-#: apps/models_provider/api/provide.py:24
-msgid "value"
-msgstr ""
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:20
-msgid "Fields"
-msgstr ""
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:24
-msgid "Branch id"
-msgstr ""
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:25
-msgid "Branch Type"
-msgstr ""
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:26
-msgid "Condition or|and"
-msgstr ""
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:20
-msgid "Response Type"
-msgstr ""
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:21
-#: apps/application/flow/step_node/variable_assign_node/i_variable_assign_node.py:13
-msgid "Reference Field"
-msgstr ""
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:23
-msgid "Direct answer content"
-msgstr ""
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:31
-msgid "Reference field cannot be empty"
-msgstr ""
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:33
-msgid "Reference field error"
-msgstr ""
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:36
-msgid "Content cannot be empty"
-msgstr ""
-
-#: apps/application/flow/step_node/form_node/i_form_node.py:19
-msgid "Form Configuration"
-msgstr ""
-
-#: apps/application/flow/step_node/form_node/i_form_node.py:20
-msgid "Form output content"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:22
-#: apps/application/flow/step_node/function_node/i_function_node.py:24
-msgid "Variable Name"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:23
-#: apps/application/flow/step_node/function_node/i_function_node.py:34
-msgid "Variable Value"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:27
-msgid "Library ID"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:36
-msgid "The function has been deleted"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:43
-#, python-brace-format
-msgid "Field: {name} No value set"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:59
-#, python-brace-format
-msgid "Field: {name} Type: {_type} Value: {value} Unsupported this type"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:63
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:100
-#, python-brace-format
-msgid "Field: {name} Type: {_type} Value: {value} Type error"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:91
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:96
-#: apps/tools/serializers/tool.py:254 apps/tools/serializers/tool.py:259
-msgid "type error"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:106
-#: apps/tools/serializers/tool.py:398
-msgid "Function does not exist"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:108
-#, python-brace-format
-msgid "No permission to use this function {name}"
-msgstr ""
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:110
-#, python-brace-format
-msgid "Function {name} is unavailable"
-msgstr ""
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:25
-msgid "Is this field required"
-msgstr ""
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:26
-#: apps/knowledge/serializers/document.py:203
-#: apps/tools/serializers/tool.py:120
-msgid "type"
-msgstr ""
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:28
-msgid "The field only supports string|int|dict|array|float"
-msgstr ""
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:30
-#: apps/folders/serializers/folder.py:106
-#: apps/folders/serializers/folder.py:141
-#: apps/folders/serializers/folder.py:196 apps/tools/serializers/tool.py:124
-msgid "source"
-msgstr ""
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:32
-#: apps/tools/serializers/tool.py:126
-msgid "The field only supports custom|reference"
-msgstr ""
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:40
-#, python-brace-format
-msgid "{field}, this field is required."
-msgstr ""
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:46
-msgid "function"
-msgstr ""
-
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:14
-msgid "Prompt word (positive)"
-msgstr ""
-
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:16
-msgid "Prompt word (negative)"
-msgstr ""
-
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:23
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:20
-msgid "Conversation storage type"
-msgstr ""
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:13
-msgid "Mcp servers"
-msgstr ""
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:16
-msgid "Mcp server"
-msgstr ""
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:18
-msgid "Mcp tool"
-msgstr ""
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:21
-msgid "Tool parameters"
-msgstr ""
-
-#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:26
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:33
-msgid "Maximum number of words in a quoted segment"
-msgstr ""
-
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:27
-#: apps/knowledge/serializers/knowledge.py:97
-#: apps/knowledge/serializers/knowledge.py:640
-msgid "similarity"
-msgstr ""
-
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:18
-msgid "The audio file cannot be empty"
-msgstr ""
-
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:33
-msgid ""
-"Parameter value error: The uploaded audio lacks file_id, and the audio "
-"upload fails"
-msgstr ""
-
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:18
-msgid "Text content"
-msgstr ""
-
-#: apps/application/models/application_chat.py:79
-#: apps/xpack/serializers/channel/chat_manage.py:94
-#: apps/xpack/serializers/channel/chat_manage.py:152
-msgid ""
-"Sorry, no relevant content was found. Please re-describe your problem or "
-"provide more information. "
-msgstr ""
-
-#: apps/application/serializers/application.py:78
-msgid "No reference status"
-msgstr ""
-
-#: apps/application/serializers/application.py:86
-msgid "Acquaintance"
-msgstr ""
-
-#: apps/application/serializers/application.py:88
-msgid "Maximum number of quoted characters"
-msgstr ""
-
-#: apps/application/serializers/application.py:95
-msgid "Segment settings not referenced"
-msgstr ""
-
-#: apps/application/serializers/application.py:104
-#: apps/application/serializers/application_chat_record.py:176
-#: apps/application/serializers/application_chat_record.py:252
-#: apps/application/serializers/application_chat_record.py:317
-msgid "Knowledge base id"
-msgstr ""
-
-#: apps/application/serializers/application.py:105
-msgid "Knowledge Base List"
-msgstr ""
-
-#: apps/application/serializers/application.py:119
-msgid "The knowledge base id does not exist"
-msgstr ""
-
-#: apps/application/serializers/application.py:126
-msgid "Role prompts"
-msgstr ""
-
-#: apps/application/serializers/application.py:128
-msgid "No citation segmentation prompt"
-msgstr ""
-
-#: apps/application/serializers/application.py:130
-msgid "Thinking process switch"
-msgstr ""
-
-#: apps/application/serializers/application.py:134
-msgid "The thinking process begins to mark"
-msgstr ""
-
-#: apps/application/serializers/application.py:138
-msgid "End of thinking process marker"
-msgstr ""
-
-#: apps/application/serializers/application.py:155
-#: apps/application/serializers/application.py:203
-#: apps/application/serializers/application.py:378
-msgid "Opening remarks"
-msgstr ""
-
-#: apps/application/serializers/application.py:191
-msgid "application name"
-msgstr "Agent name"
-
-#: apps/application/serializers/application.py:194
-msgid "application describe"
-msgstr "Agent description"
-
-#: apps/application/serializers/application.py:197
-#: apps/application/serializers/application.py:372
-#: apps/common/constants/permission_constants.py:226
-#: apps/common/constants/permission_constants.py:259
-#: apps/common/constants/permission_constants.py:264
-#: apps/models_provider/views/model.py:63
-#: apps/models_provider/views/model.py:95
-#: apps/models_provider/views/model.py:113
-#: apps/models_provider/views/model.py:130
-#: apps/models_provider/views/model.py:145
-#: apps/models_provider/views/model.py:160
-#: apps/models_provider/views/model.py:173
-#: apps/models_provider/views/model.py:194
-#: apps/models_provider/views/model.py:210
-#: apps/models_provider/views/model_apply.py:29
-#: apps/models_provider/views/model_apply.py:41
-#: apps/models_provider/views/model_apply.py:53
-#: apps/models_provider/views/provide.py:25
-#: apps/models_provider/views/provide.py:48
-#: apps/models_provider/views/provide.py:62
-#: apps/models_provider/views/provide.py:80
-#: apps/models_provider/views/provide.py:97
-msgid "Model"
-msgstr ""
-
-#: apps/application/serializers/application.py:201
-#: apps/application/serializers/application.py:376
-msgid "Historical chat records"
-msgstr ""
-
-#: apps/application/serializers/application.py:206
-#: apps/application/serializers/application.py:380
-msgid "Related Knowledge Base"
-msgstr ""
-
-#: apps/application/serializers/application.py:213
-#: apps/application/serializers/application.py:390
-msgid "Question completion"
-msgstr ""
-
-#: apps/application/serializers/application.py:217
-msgid "Application Type"
-msgstr "Agent Type"
-
-#: apps/application/serializers/application.py:221
-msgid "Application type only supports SIMPLE|WORK_FLOW"
-msgstr "Agent type only supports SIMPLE|WORK_FLOW"
-
-#: apps/application/serializers/application.py:226
-#: apps/application/serializers/application.py:394
-msgid "Model parameters"
-msgstr ""
-
-#: apps/application/serializers/application.py:228
-#: apps/application/serializers/application.py:396
-msgid "Voice playback enabled"
-msgstr ""
-
-#: apps/application/serializers/application.py:230
-#: apps/application/serializers/application.py:398
-msgid "Voice playback model ID"
-msgstr ""
-
-#: apps/application/serializers/application.py:232
-#: apps/application/serializers/application.py:400
-msgid "Voice playback type"
-msgstr ""
-
-#: apps/application/serializers/application.py:234
-#: apps/application/serializers/application.py:402
-msgid "Voice playback autoplay"
-msgstr ""
-
-#: apps/application/serializers/application.py:236
-#: apps/application/serializers/application.py:404
-msgid "Voice recognition enabled"
-msgstr ""
-
-#: apps/application/serializers/application.py:238
-#: apps/application/serializers/application.py:406
-msgid "Speech recognition model ID"
-msgstr ""
-
-#: apps/application/serializers/application.py:240
-#: apps/application/serializers/application.py:408
-msgid "Voice recognition automatic transmission"
-msgstr ""
-
-#: apps/application/serializers/application.py:281
-msgid "Primary key id"
-msgstr ""
-
-#: apps/application/serializers/application.py:286
-msgid "Application type"
-msgstr "Agent type"
-
-#: apps/application/serializers/application.py:287
-#: apps/xpack/serializers/resource_chat_user.py:34
-#: apps/xpack/serializers/resource_chat_user.py:110
-#: apps/xpack/serializers/resource_chat_user_group.py:17
-#: apps/xpack/serializers/resource_chat_user_group.py:85
-msgid "Resource type"
-msgstr ""
-
-#: apps/application/serializers/application.py:288
-msgid "Affiliation user"
-msgstr ""
-
-#: apps/application/serializers/application.py:289
-msgid "Creation time"
-msgstr ""
-
-#: apps/application/serializers/application.py:290
-msgid "Modification time"
-msgstr ""
-
-#: apps/application/serializers/application.py:294
-#: apps/application/serializers/application_chat_record.py:42
-#: apps/application/serializers/application_chat_record.py:323
-#: apps/application/serializers/application_version.py:40
-#: apps/chat/serializers/chat.py:318 apps/role_setting/api/role_setting.py:147
-#: apps/users/api/user.py:64 apps/users/api/user.py:170
-#: apps/workspace/api/workspace.py:46 apps/workspace/api/workspace.py:66
-#: apps/workspace/api/workspace.py:85 apps/workspace/api/workspace.py:103
-#: apps/workspace/serializers/workspace_serializers.py:239
-#: apps/xpack/api/application_setting.py:24 apps/xpack/api/knowledge_lark.py:40
-#: apps/xpack/api/knowledge_lark.py:72 apps/xpack/api/knowledge_lark.py:104
-#: apps/xpack/api/platform.py:22 apps/xpack/api/platform.py:63
-msgid "Workspace ID"
-msgstr ""
-
-#: apps/application/serializers/application.py:363
-#: apps/knowledge/serializers/document.py:157
-#: apps/knowledge/serializers/document.py:162 apps/oss/serializers/file.py:57
-#: apps/tools/serializers/tool.py:356
-msgid "file"
-msgstr ""
-
-#: apps/application/serializers/application.py:384
-msgid "Dataset settings"
-msgstr ""
-
-#: apps/application/serializers/application.py:387
-msgid "Model setup"
-msgstr ""
-
-#: apps/application/serializers/application.py:391
-msgid "Icon"
-msgstr ""
-
-#: apps/application/serializers/application.py:412
-#: apps/application/serializers/application_api_key.py:33
-#: apps/application/serializers/application_api_key.py:64
-#: apps/folders/serializers/folder.py:101
-#: apps/folders/serializers/folder.py:140
-#: apps/folders/serializers/folder.py:195
-#: apps/knowledge/serializers/document.py:253
-#: apps/knowledge/serializers/document.py:347
-#: apps/knowledge/serializers/document.py:408
-#: apps/knowledge/serializers/document.py:502
-#: apps/knowledge/serializers/document.py:736
-#: apps/knowledge/serializers/document.py:888
-#: apps/knowledge/serializers/document.py:963
-#: apps/knowledge/serializers/document.py:983
-#: apps/knowledge/serializers/document.py:1166
-#: apps/knowledge/serializers/knowledge.py:208
-#: apps/knowledge/serializers/knowledge.py:448
-#: apps/knowledge/serializers/knowledge.py:557
-#: apps/knowledge/serializers/knowledge.py:635
-#: apps/knowledge/serializers/paragraph.py:134
-#: apps/knowledge/serializers/paragraph.py:346
-#: apps/knowledge/serializers/paragraph.py:438
-#: apps/knowledge/serializers/paragraph.py:558
-#: apps/knowledge/serializers/problem.py:176
-#: apps/knowledge/serializers/problem.py:204
-#: apps/models_provider/api/model.py:30 apps/models_provider/api/model.py:86
-#: apps/models_provider/api/model.py:99
-#: apps/models_provider/serializers/model_serializer.py:259
-#: apps/models_provider/serializers/model_serializer.py:323
-#: apps/models_provider/serializers/model_serializer.py:392
-#: apps/shared/api/shared_knowledge.py:131
-#: apps/shared/api/shared_knowledge.py:164 apps/shared/api/shared_tool.py:60
-#: apps/shared/api/shared_tool.py:147
-#: apps/shared/serializers/shared_knowledge.py:61
-#: apps/shared/serializers/shared_knowledge.py:109
-#: apps/shared/serializers/shared_knowledge.py:157
-#: apps/shared/serializers/shared_model.py:110
-#: apps/shared/serializers/shared_tool.py:45
-#: apps/shared/serializers/shared_tool.py:86
-#: apps/system_manage/serializers/user_resource_permission.py:74
-#: apps/tools/serializers/tool.py:188 apps/tools/serializers/tool.py:210
-#: apps/tools/serializers/tool.py:268 apps/tools/serializers/tool.py:358
-#: apps/tools/serializers/tool.py:389 apps/tools/serializers/tool.py:425
-#: apps/tools/serializers/tool.py:452
-#: apps/xpack/serializers/dataset_lark_serializer.py:45
-#: apps/xpack/serializers/resource_chat_user.py:33
-#: apps/xpack/serializers/resource_chat_user.py:109
-#: apps/xpack/serializers/resource_chat_user_group.py:16
-#: apps/xpack/serializers/resource_chat_user_group.py:84
-msgid "workspace id"
-msgstr ""
-
-#: apps/application/serializers/application.py:459
-msgid ""
-"The community version supports up to 5 applications. If you need more "
-"applications, please contact us (https://fit2cloud.com/)."
-msgstr ""
-
-#: apps/application/serializers/application.py:471
-#: apps/common/handle/impl/qa/zip_parse_qa_handle.py:56
-#: apps/common/handle/impl/text/zip_split_handle.py:69
-#: apps/knowledge/serializers/document.py:864
-#: apps/knowledge/serializers/document.py:871
-#: apps/tools/serializers/tool.py:370
-msgid "Unsupported file format"
-msgstr ""
-
-#: apps/application/serializers/application.py:545
-msgid "Application id does not exist"
-msgstr "Agent id does not exist"
-
-#: apps/application/serializers/application.py:591
-msgid "work_flow is a required field"
-msgstr ""
-
-#: apps/application/serializers/application.py:695
-#, python-brace-format
-msgid "Unknown knowledge base id {dataset_id}, unable to associate"
-msgstr ""
-
-#: apps/application/serializers/application_access_token.py:24
-msgid "Reset Token"
-msgstr ""
-
-#: apps/application/serializers/application_access_token.py:25
-msgid "Is it enabled"
-msgstr ""
-
-#: apps/application/serializers/application_access_token.py:28
-msgid "Number of visits"
-msgstr ""
-
-#: apps/application/serializers/application_access_token.py:30
-msgid "Whether to enable whitelist"
-msgstr ""
-
-#: apps/application/serializers/application_access_token.py:32
-#: apps/application/serializers/application_access_token.py:33
-msgid "Whitelist"
-msgstr ""
-
-#: apps/application/serializers/application_access_token.py:35
-msgid "Whether to display knowledge sources"
-msgstr ""
-
-#: apps/application/serializers/application_access_token.py:37
-#: apps/users/serializers/user.py:665
-#: apps/xpack/serializers/application_setting_serializer.py:37
-msgid "language"
-msgstr ""
-
-#: apps/application/serializers/application_api_key.py:21
-msgid "Availability"
-msgstr ""
-
-#: apps/application/serializers/application_api_key.py:24
-msgid "Is cross-domain allowed"
-msgstr ""
-
-#: apps/application/serializers/application_api_key.py:28
-msgid "Cross-domain address"
-msgstr ""
-
-#: apps/application/serializers/application_api_key.py:29
-msgid "Cross-domain list"
-msgstr ""
-
-#: apps/application/serializers/application_api_key.py:34
-#: apps/application/serializers/application_api_key.py:65
-#: apps/knowledge/serializers/knowledge.py:72
-#: apps/xpack/serializers/application_setting_serializer.py:77
-#: apps/xpack/serializers/dataset_lark_serializer.py:295
-msgid "application id"
-msgstr "Agent id"
-
-#: apps/application/serializers/application_api_key.py:41
-#: apps/chat/serializers/chat.py:277 apps/chat/serializers/chat.py:332
-#: apps/xpack/serializers/application_setting_serializer.py:103
-#: apps/xpack/serializers/platform_serializer.py:81
-#: apps/xpack/serializers/platform_serializer.py:103
-#: apps/xpack/serializers/platform_serializer.py:138
-#: apps/xpack/serializers/platform_serializer.py:149
-msgid "Application does not exist"
-msgstr "Agent does not exist"
-
-#: apps/application/serializers/application_api_key.py:66
-msgid "ApiKeyId"
-msgstr ""
-
-#: apps/application/serializers/application_api_key.py:87
-msgid "APIKey does not exist"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:33
-msgid "chat id"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:34
-#: apps/application/serializers/application_chat.py:51
-#: apps/application/serializers/application_chat.py:182
-#: apps/application/serializers/application_version.py:23
-msgid "summary"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:35
-msgid "Chat User ID"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:36
-msgid "Chat User Type"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:37
-msgid "Is delete"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:39
-#: apps/application/serializers/application_stats.py:25
-msgid "Number of conversations"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:40
-#: apps/application/serializers/application_stats.py:29
-msgid "Number of Likes"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:41
-#: apps/application/serializers/application_stats.py:31
-msgid "Number of thumbs-downs"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:42
-msgid "Number of tags"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:46
-msgid "Chat ID List"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:52
-#: apps/application/serializers/application_stats.py:36
-#: apps/xpack/serializers/operate_log_serializer.py:55
-msgid "Start time"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:53
-#: apps/application/serializers/application_stats.py:37
-#: apps/xpack/serializers/operate_log_serializer.py:56
-msgid "End time"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:61
-msgid "Only supports and|or"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:183
-msgid "Problem after optimization"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:184
-msgid "answer"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:184
-msgid "User feedback"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:186
-msgid "Section title + content"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:187
-#: apps/application/views/application_chat_record.py:139
-#: apps/application/views/application_chat_record.py:140
-#: apps/application/views/application_chat_record.py:141
-#: apps/common/constants/permission_constants.py:248
-msgid "Annotation"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:187
-msgid "Consuming tokens"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:188
-msgid "Time consumed (s)"
-msgstr ""
-
-#: apps/application/serializers/application_chat.py:189
-msgid "Question Time"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:44
-#: apps/application/serializers/application_chat_record.py:143
-#: apps/application/serializers/application_chat_record.py:250
-#: apps/application/serializers/application_chat_record.py:315
-#: apps/chat/serializers/chat.py:45
-msgid "Conversation record id"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:51
-msgid "Application authentication information does not exist"
-msgstr "Agent authentication information does not exist"
-
-#: apps/application/serializers/application_chat_record.py:53
-msgid "Displaying knowledge sources is not enabled"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:70
-#: apps/chat/serializers/chat.py:127 apps/chat/serializers/chat.py:274
-msgid "Conversation does not exist"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:152
-#: apps/application/serializers/application_chat_record.py:279
-#: apps/application/serializers/application_chat_record.py:336
-#: apps/chat/serializers/chat.py:205
-msgid "Conversation record does not exist"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:168
-msgid "Section title"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:169
-msgid "Paragraph content"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:177
-#: apps/application/serializers/application_chat_record.py:254
-#: apps/application/serializers/application_chat_record.py:319
-msgid "Document id"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:184
-#: apps/application/serializers/application_chat_record.py:260
-#: apps/knowledge/serializers/paragraph.py:246
-msgid "The document id is incorrect"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:203
-msgid "Conversation records that do not exist"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:321
-msgid "Paragraph id"
-msgstr ""
-
-#: apps/application/serializers/application_chat_record.py:340
-#, python-brace-format
-msgid ""
-"The paragraph id is wrong. The current conversation record does not exist. "
-"[{paragraph_id}] paragraph id"
-msgstr ""
-
-#: apps/application/serializers/application_stats.py:26
-msgid "Number of new users"
-msgstr ""
-
-#: apps/application/serializers/application_stats.py:27
-msgid "Total number of users"
-msgstr ""
-
-#: apps/application/serializers/application_stats.py:28
-msgid "date"
-msgstr ""
-
-#: apps/application/serializers/application_stats.py:30
-msgid "Tokens consumption"
-msgstr ""
-
-#: apps/application/serializers/application_version.py:36
-msgid "Version Name"
-msgstr ""
-
-#: apps/application/serializers/application_version.py:69
-msgid "Workflow version id"
-msgstr ""
-
-#: apps/application/serializers/application_version.py:79
-#: apps/application/serializers/application_version.py:94
-msgid "Workflow version does not exist"
-msgstr ""
-
-#: apps/application/views/application.py:41
-#: apps/application/views/application.py:42
-#: apps/application/views/application.py:43
-msgid "Create an application"
-msgstr ""
-
-#: apps/application/views/application.py:47
-#: apps/application/views/application.py:65
-#: apps/application/views/application.py:82
-#: apps/application/views/application.py:103
-#: apps/application/views/application.py:123
-#: apps/application/views/application.py:145
-#: apps/application/views/application.py:166
-#: apps/application/views/application.py:187
-#: apps/application/views/application.py:206
-#: apps/application/views/application_access_token.py:32
-#: apps/application/views/application_access_token.py:47
-#: apps/application/views/application_chat.py:102
-#: apps/application/views/application_chat.py:122
-#: apps/application/views/application_stats.py:33
-#: apps/common/constants/permission_constants.py:224
-#: apps/common/constants/permission_constants.py:234
-#: apps/xpack/views/application_setting.py:29
-#: apps/xpack/views/application_setting.py:47
-msgid "Application"
-msgstr ""
-
-#: apps/application/views/application.py:60
-#: apps/application/views/application.py:61
-#: apps/application/views/application.py:62
-msgid "Get the application list"
-msgstr "Get the agent list"
-
-#: apps/application/views/application.py:77
-#: apps/application/views/application.py:78
-#: apps/application/views/application.py:79
-msgid "Get the application list by page"
-msgstr "Get the agent list by page"
-
-#: apps/application/views/application.py:97
-#: apps/application/views/application.py:98
-#: apps/application/views/application.py:99
-msgid "Import Application"
-msgstr ""
-
-#: apps/application/views/application.py:117
-#: apps/application/views/application.py:118
-#: apps/application/views/application.py:119
-msgid "Export application"
-msgstr ""
-
-#: apps/application/views/application.py:140
-#: apps/application/views/application.py:141
-#: apps/application/views/application.py:142
-msgid "Deleting application"
-msgstr ""
-
-#: apps/application/views/application.py:160
-#: apps/application/views/application.py:161
-#: apps/application/views/application.py:162
-msgid "Modify the application"
-msgstr ""
-
-#: apps/application/views/application.py:181
-#: apps/application/views/application.py:182
-#: apps/application/views/application.py:183
-msgid "Get application details"
-msgstr "Get agent details"
-
-#: apps/application/views/application.py:200
-#: apps/application/views/application.py:201
-#: apps/application/views/application.py:202
-msgid "Publishing an application"
-msgstr ""
-
-#: apps/application/views/application_access_token.py:27
-#: apps/application/views/application_access_token.py:28
-#: apps/application/views/application_access_token.py:29
-msgid "Modify application access restriction information"
-msgstr "Modify agent access restriction information"
-
-#: apps/application/views/application_access_token.py:43
-#: apps/application/views/application_access_token.py:44
-#: apps/application/views/application_access_token.py:45
-msgid "Get application access restriction information"
-msgstr "Get agent access restriction information"
-
-#: apps/application/views/application_api_key.py:31
-#: apps/application/views/application_api_key.py:32
-#: apps/application/views/application_api_key.py:33
-msgid "Create application ApiKey"
-msgstr "Create agent ApiKey"
-
-#: apps/application/views/application_api_key.py:37
-#: apps/application/views/application_api_key.py:57
-#: apps/application/views/application_api_key.py:77
-#: apps/application/views/application_api_key.py:99
-msgid "Application Api Key"
-msgstr "Agent Api Key"
-
-#: apps/application/views/application_api_key.py:52
-msgid "GET application ApiKey List"
-msgstr "GET agent ApiKey List"
-
-#: apps/application/views/application_api_key.py:53
-#: apps/application/views/application_api_key.py:54
-msgid "Create application ApiKey List"
-msgstr "Create agent ApiKey List"
-
-#: apps/application/views/application_api_key.py:71
-#: apps/application/views/application_api_key.py:72
-#: apps/application/views/application_api_key.py:73
-msgid "Modify application API_KEY"
-msgstr "Modify agent API_KEY"
-
-#: apps/application/views/application_api_key.py:93
-#: apps/application/views/application_api_key.py:94
-#: apps/application/views/application_api_key.py:95
-msgid "Delete Application API_KEY"
-msgstr "Delete Agent API_KEY"
-
-#: apps/application/views/application_chat.py:35
-#: apps/application/views/application_chat.py:36
-#: apps/application/views/application_chat.py:37
-msgid "Get the conversation list"
-msgstr ""
-
-#: apps/application/views/application_chat.py:41
-#: apps/application/views/application_chat.py:61
-#: apps/application/views/application_chat.py:82
-#: apps/application/views/application_chat_record.py:37
-#: apps/application/views/application_chat_record.py:58
-#: apps/application/views/application_chat_record.py:82
-#: apps/application/views/application_chat_record.py:106
-#: apps/application/views/application_chat_record.py:125
-#: apps/application/views/application_chat_record.py:145
-#: apps/application/views/application_chat_record.py:171
-msgid "Application/Conversation Log"
-msgstr "Agent/Conversation Log"
-
-#: apps/application/views/application_chat.py:55
-#: apps/application/views/application_chat.py:56
-#: apps/application/views/application_chat.py:57
-msgid "Get the conversation list by page"
-msgstr ""
-
-#: apps/application/views/application_chat.py:76
-#: apps/application/views/application_chat.py:77
-#: apps/application/views/application_chat.py:78
-msgid "Export conversation"
-msgstr ""
-
-#: apps/application/views/application_chat.py:97
-#: apps/application/views/application_chat.py:98
-#: apps/application/views/application_chat.py:99
-msgid "Get a temporary session id based on the application id"
-msgstr "Get a temporary session id based on the agent id"
-
-#: apps/application/views/application_chat.py:116
-#: apps/application/views/application_chat.py:117
-#: apps/application/views/application_chat.py:118 apps/chat/views/chat.py:93
-#: apps/chat/views/chat.py:94 apps/chat/views/chat.py:95
-msgid "dialogue"
-msgstr ""
-
-#: apps/application/views/application_chat_record.py:31
-#: apps/application/views/application_chat_record.py:32
-#: apps/application/views/application_chat_record.py:33
-msgid "Get the conversation record list"
-msgstr ""
-
-#: apps/application/views/application_chat_record.py:52
-#: apps/application/views/application_chat_record.py:53
-#: apps/application/views/application_chat_record.py:54
-msgid "Get the conversation record list by page"
-msgstr ""
-
-#: apps/application/views/application_chat_record.py:76
-#: apps/application/views/application_chat_record.py:77
-#: apps/application/views/application_chat_record.py:78
-msgid "Get conversation record details"
-msgstr ""
-
-#: apps/application/views/application_chat_record.py:100
-#: apps/application/views/application_chat_record.py:101
-#: apps/application/views/application_chat_record.py:102
-msgid "Add to Knowledge Base"
-msgstr ""
-
-#: apps/application/views/application_chat_record.py:119
-#: apps/application/views/application_chat_record.py:120
-#: apps/application/views/application_chat_record.py:121
-msgid "Get the list of marked paragraphs"
-msgstr ""
-
-#: apps/application/views/application_chat_record.py:165
-#: apps/application/views/application_chat_record.py:166
-#: apps/application/views/application_chat_record.py:167
-msgid "Delete a Annotation"
-msgstr ""
-
-#: apps/application/views/application_stats.py:28
-#: apps/application/views/application_stats.py:29
-#: apps/application/views/application_stats.py:30
-msgid "Dialogue-related statistical trends"
-msgstr ""
-
-#: apps/application/views/application_version.py:30
-#: apps/application/views/application_version.py:31
-#: apps/application/views/application_version.py:32
-msgid "Get the application version list"
-msgstr "Get the agent version list"
-
-#: apps/application/views/application_version.py:35
-#: apps/application/views/application_version.py:55
-#: apps/application/views/application_version.py:76
-#: apps/application/views/application_version.py:94
-msgid "Application/Version"
-msgstr "Agent/Version"
-
-#: apps/application/views/application_version.py:50
-#: apps/application/views/application_version.py:51
-#: apps/application/views/application_version.py:52
-msgid "Get the list of application versions by page"
-msgstr "Get the list of agent versions by page"
-
-#: apps/application/views/application_version.py:71
-#: apps/application/views/application_version.py:72
-#: apps/application/views/application_version.py:73
-msgid "Get application version details"
-msgstr "Get agent version details"
-
-#: apps/application/views/application_version.py:88
-#: apps/application/views/application_version.py:89
-#: apps/application/views/application_version.py:90
-msgid "Modify application version information"
-msgstr "Modify agent version information"
-
-#: apps/chat/api/chat_authentication_api.py:38
-#: apps/chat/serializers/chat_authentication.py:28
-#: apps/chat/serializers/chat_authentication.py:54
-#: apps/xpack/serializers/chat_auth.py:25
-msgid "access_token"
-msgstr ""
-
-#: apps/chat/api/chat_embed_api.py:24
-msgid "host"
-msgstr ""
-
-#: apps/chat/api/chat_embed_api.py:31
-#: apps/chat/serializers/chat_embed_serializers.py:25
-msgid "protocol"
-msgstr ""
-
-#: apps/chat/api/chat_embed_api.py:38
-#: apps/chat/serializers/chat_embed_serializers.py:26
-#: apps/users/serializers/login.py:36
-msgid "token"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:42
-msgid "Is the answer in streaming mode"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:43
-msgid "Do you want to reply again"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:48
-msgid "Node id"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:51
-msgid "Runtime node id"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:54
-msgid "Node parameters"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:56
-msgid "Global variables"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:60
-#: apps/common/constants/permission_constants.py:222
-#: apps/common/constants/permission_constants.py:228
-msgid "Other"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:115 apps/chat/serializers/chat.py:320
-msgid "Client id"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:116 apps/chat/serializers/chat.py:321
-msgid "Client Type"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:119 apps/chat/serializers/chat.py:322
-#: apps/common/constants/permission_constants.py:240
-msgid "Debug"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:146
-msgid "The number of visits exceeds today's visits"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:157
-msgid "The current model is not available"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:159
-msgid "The model is downloading, please try again later"
-msgstr ""
-
-#: apps/chat/serializers/chat.py:306 apps/chat/serializers/chat.py:357
-msgid "The application has not been published. Please use it after publishing."
-msgstr "The agent has not been published. Please use it after publishing."
-
-#: apps/chat/serializers/chat_authentication.py:50
-#: apps/xpack/serializers/chat_auth.py:53
-msgid "Invalid access_token"
-msgstr ""
-
-#: apps/chat/serializers/chat_authentication.py:89
-msgid "Illegal User"
-msgstr ""
-
-#: apps/chat/serializers/chat_embed_serializers.py:24
-msgid "Host"
-msgstr ""
-
-#: apps/chat/views/chat.py:37 apps/chat/views/chat.py:38
-#: apps/chat/views/chat.py:39
-msgid "Application Anonymous Certification"
-msgstr "Agent Anonymous Certification"
-
-#: apps/chat/views/chat.py:42 apps/chat/views/chat.py:64
-#: apps/chat/views/chat.py:81 apps/chat/views/chat.py:99
-#: apps/chat/views/chat.py:120 apps/chat/views/chat_embed.py:27
-#: apps/xpack/views/chat_user_auth.py:419
-msgid "Chat"
-msgstr ""
-
-#: apps/chat/views/chat.py:59 apps/chat/views/chat.py:60
-#: apps/chat/views/chat.py:61
-msgid "Get application related information"
-msgstr "Get agent related information"
-
-#: apps/chat/views/chat.py:76 apps/chat/views/chat.py:77
-#: apps/chat/views/chat.py:78
-msgid "Get application authentication information"
-msgstr "Get agent authentication information"
-
-#: apps/chat/views/chat.py:115 apps/chat/views/chat.py:116
-#: apps/chat/views/chat.py:117
-msgid "Get the session id according to the application id"
-msgstr "Get the session id according to the agent id"
-
-#: apps/chat/views/chat.py:131 apps/chat/views/chat.py:132
-#: apps/chat/views/chat.py:133 apps/users/views/login.py:70
-#: apps/users/views/login.py:71 apps/users/views/login.py:72
-msgid "Get captcha"
-msgstr ""
-
-#: apps/chat/views/chat.py:134
-#: apps/common/constants/permission_constants.py:210
-#: apps/users/views/login.py:41 apps/users/views/login.py:58
-#: apps/users/views/login.py:73 apps/users/views/user.py:63
-#: apps/users/views/user.py:77 apps/users/views/user.py:91
-#: apps/users/views/user.py:108 apps/users/views/user.py:123
-#: apps/users/views/user.py:136 apps/users/views/user.py:150
-#: apps/users/views/user.py:164 apps/users/views/user.py:180
-#: apps/users/views/user.py:193 apps/users/views/user.py:206
-#: apps/users/views/user.py:217 apps/users/views/user.py:235
-#: apps/users/views/user.py:251 apps/users/views/user.py:269
-#: apps/users/views/user.py:286 apps/users/views/user.py:303
-#: apps/users/views/user.py:321 apps/users/views/user.py:338
-#: apps/users/views/user.py:356 apps/xpack/views/chat_user_auth.py:206
-msgid "User Management"
-msgstr ""
-
-#: apps/chat/views/chat_embed.py:22 apps/chat/views/chat_embed.py:23
-#: apps/chat/views/chat_embed.py:24
-msgid "Get embedded js"
-msgstr ""
-
-#: apps/common/auth/authenticate.py:80
-msgid "Not logged in, please log in first"
-msgstr ""
-
-#: apps/common/auth/authenticate.py:82 apps/common/auth/authenticate.py:89
-#: apps/common/auth/authenticate.py:95
-msgid "Authentication information is incorrect! illegal user"
-msgstr ""
-
-#: apps/common/auth/authentication.py:98
-msgid "No permission to access"
-msgstr ""
-
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:39
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:41
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:43
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:49
-#: apps/xpack/auth/chat_user_token.py:41 apps/xpack/auth/chat_user_token.py:43
-#: apps/xpack/auth/chat_user_token.py:45 apps/xpack/auth/chat_user_token.py:49
-msgid "Authentication information is incorrect"
-msgstr ""
-
-#: apps/common/auth/handle/impl/user_token.py:265
-msgid "Login expired"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:31
-#: apps/users/serializers/login.py:53
-#: apps/xpack/serializers/chat_user_serializer.py:123
-msgid "The username or password is incorrect"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:32
-msgid "Please log in first and bring the user Token"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:33
-#: apps/users/serializers/user.py:630
-msgid "Email sending failed"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:34
-msgid "Email format error"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:35
-msgid "The email has been registered, please log in directly"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:36
-msgid "The email is not registered, please register first"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:38
-msgid "The verification code is incorrect or the verification code has expired"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:39
-msgid "The username has been registered, please log in directly"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:41
-msgid ""
-"The username cannot be empty and must be between 6 and 20 characters long."
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:43
-msgid "Password and confirmation password are inconsistent"
-msgstr ""
-
-#: apps/common/constants/exception_code_constants.py:44
-msgid "The nickname is already registered"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:209
-msgid "System Setting"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:211
-#: apps/common/constants/permission_constants.py:272
-#: apps/role_setting/views/role_setting.py:44
-#: apps/role_setting/views/role_setting.py:67
-#: apps/role_setting/views/role_setting.py:84
-#: apps/role_setting/views/role_setting.py:103
-#: apps/role_setting/views/role_setting.py:125
-#: apps/role_setting/views/role_setting.py:145
-#: apps/role_setting/views/role_setting.py:167
-#: apps/role_setting/views/role_setting.py:191
-#: apps/role_setting/views/role_setting.py:210
-msgid "Role"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:212
-#: apps/common/constants/permission_constants.py:270
-#: apps/workspace/views/workspace.py:37 apps/workspace/views/workspace.py:49
-#: apps/workspace/views/workspace.py:63 apps/workspace/views/workspace.py:80
-#: apps/workspace/views/workspace.py:101 apps/workspace/views/workspace.py:119
-#: apps/workspace/views/workspace.py:138 apps/workspace/views/workspace.py:155
-#: apps/workspace/views/workspace.py:170 apps/workspace/views/workspace.py:188
-#: apps/workspace/views/workspace.py:207 apps/workspace/views/workspace.py:223
-#: apps/workspace/views/workspace.py:236 apps/workspace/views/workspace.py:250
-msgid "Workspace"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:213
-msgid "Resource Application"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:214
-msgid "Resource Knowledge"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:215
-msgid "Resource Tool"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:216
-msgid "Resource Model"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:217
-msgid "Resource Permission"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:218
-#: apps/shared/views/shared_dataset_lark_views.py:30
-#: apps/shared/views/shared_dataset_lark_views.py:50
-#: apps/shared/views/shared_knowledge.py:33
-#: apps/shared/views/shared_knowledge.py:53
-#: apps/shared/views/shared_knowledge.py:76
-#: apps/shared/views/shared_knowledge.py:91
-#: apps/shared/views/shared_knowledge.py:106
-#: apps/shared/views/shared_knowledge.py:125
-#: apps/shared/views/shared_knowledge.py:151
-#: apps/shared/views/shared_knowledge.py:178
-#: apps/shared/views/shared_knowledge.py:196
-#: apps/shared/views/shared_knowledge.py:214
-#: apps/shared/views/shared_knowledge.py:235
-#: apps/shared/views/shared_knowledge.py:256
-#: apps/shared/views/shared_knowledge.py:276
-#: apps/shared/views/shared_knowledge.py:297
-#: apps/shared/views/shared_knowledge.py:312
-#: apps/shared/views/shared_knowledge.py:331
-#: apps/shared/views/shared_knowledge.py:354
-#: apps/shared/views/shared_knowledge.py:386
-#: apps/shared/views/shared_knowledge.py:407
-msgid "Shared Knowledge"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:219
-#: apps/models_provider/views/model.py:227 apps/shared/views/shared_model.py:58
-#: apps/shared/views/shared_model.py:89 apps/shared/views/shared_model.py:107
-#: apps/shared/views/shared_model.py:124 apps/shared/views/shared_model.py:138
-#: apps/shared/views/shared_model.py:153 apps/shared/views/shared_model.py:166
-#: apps/shared/views/shared_model.py:186 apps/shared/views/shared_model.py:202
-#: apps/shared/views/shared_model.py:219 apps/shared/views/shared_model.py:234
-#: apps/shared/views/shared_model.py:253 apps/shared/views/shared_model.py:270
-msgid "Shared Model"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:220
-#: apps/shared/views/shared_tool.py:30 apps/shared/views/shared_tool.py:49
-#: apps/shared/views/shared_tool.py:68 apps/shared/views/shared_tool.py:83
-#: apps/shared/views/shared_tool.py:98 apps/shared/views/shared_tool.py:116
-#: apps/shared/views/shared_tool.py:139 apps/shared/views/shared_tool.py:157
-#: apps/shared/views/shared_tool.py:175 apps/shared/views/shared_tool.py:194
-#: apps/shared/views/shared_tool.py:218 apps/shared/views/shared_tool.py:239
-#: apps/shared/views/shared_tool.py:254 apps/shared/views/shared_tool.py:273
-#: apps/shared/views/shared_tool.py:294
-msgid "Shared Tool"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:221
-msgid "Operation Log"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:223
-msgid "System Management"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:225
-#: apps/common/constants/permission_constants.py:235
-#: apps/common/constants/permission_constants.py:260
-#: apps/common/constants/permission_constants.py:265
-msgid "Knowledge"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:227
-#: apps/common/constants/permission_constants.py:258
-#: apps/common/constants/permission_constants.py:263
-#: apps/tools/views/tool.py:39 apps/tools/views/tool.py:61
-#: apps/tools/views/tool.py:82 apps/tools/views/tool.py:104
-#: apps/tools/views/tool.py:127 apps/tools/views/tool.py:146
-#: apps/tools/views/tool.py:172 apps/tools/views/tool.py:201
-#: apps/tools/views/tool.py:223 apps/tools/views/tool.py:250
-#: apps/tools/views/tool.py:274
-msgid "Tool"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:229
-msgid "Read"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:230
-msgid "Edit"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:231
-msgid "Create"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:232
-msgid "Delete"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:233
-msgid "Email Setting"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:236
-#: apps/common/constants/permission_constants.py:261
-#: apps/common/constants/permission_constants.py:266
-msgid "Document"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:237
-#: apps/common/constants/permission_constants.py:262
-#: apps/common/constants/permission_constants.py:267
-msgid "Problem"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:238
-msgid "Import"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:239
-msgid "Export"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:241
-msgid "Sync"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:242
-msgid "Generate"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:243
-msgid "Add Member"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:244
-msgid "Remove Member"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:245
-msgid "Vector"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:246
-msgid "Migrate"
-msgstr ""
 
-#: apps/common/constants/permission_constants.py:247
-msgid "Relate"
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:39
+msgid "%(key)s is required"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:249
-msgid "Clear Policy"
+#: apps/trigger/serializers/trigger.py:446
+msgid "%s id does not exist"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:250
-msgid "Login Auth"
+#: apps/knowledge/serializers/knowledge.py:324
+msgid "%s must be a boolean"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:251
-msgid "Display Settings"
+#: apps/trigger/serializers/trigger.py:69
+#: apps/trigger/serializers/trigger.py:92
+msgid "%s must be a dict"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:252
-#: apps/common/constants/permission_constants.py:720
-#: apps/xpack/views/system_api_key.py:23 apps/xpack/views/system_api_key.py:38
-#: apps/xpack/views/system_api_key.py:56 apps/xpack/views/system_api_key.py:71
-msgid "System API Key"
+#: apps/trigger/serializers/trigger.py:132
+msgid "%s must be an array"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:253
-#: apps/xpack/views/system_params.py:26 apps/xpack/views/system_params.py:42
-msgid "Appearance Settings"
+#: apps/trigger/serializers/trigger.py:135
+msgid "%s must not be empty"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:254
-#: apps/common/constants/permission_constants.py:269
-#: apps/xpack/views/system_chat_user.py:339
-#: apps/xpack/views/system_chat_user.py:362
-msgid "Chat User"
+#: apps/trigger/serializers/trigger.py:125
+msgid "%s type requires %s field"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:255
-#: apps/common/constants/permission_constants.py:268
-msgid "User Group"
+#: apps/trigger/serializers/trigger.py:146
+msgid "%s values must be between %s and %s"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:256
-msgid "Chat User Auth"
+#: apps/application/chat_pipeline/step/reset_problem_step/impl/base_reset_problem_step.py:19
+#: apps/application/serializers/common.py:233
+msgid "() contains the user's question. Answer the guessed user's question based on the context ({question}) Requirement: Output a complete question and put it in the <data></data> tag"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:257
-msgid "Overview"
+#: no source
+msgid "\n ------------\n[To be continued, reply \"Continue to answer the question]"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:271
-#: apps/common/constants/permission_constants.py:671
-#: apps/common/constants/permission_constants.py:677
-#: apps/common/constants/permission_constants.py:683
-#: apps/common/constants/permission_constants.py:689
-msgid "Dialogue log"
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:43
+msgid "1 as default"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:641
-msgid "Embed third party"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:52
+msgid "3D cartoon"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:647
-msgid "Access restrictions"
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:102
+msgid "7B dense converter for rapid deployment and easy customization. Small in size yet powerful in a variety of use cases. Supports English and code, as well as 32k context windows."
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:653
-msgid "Display settings"
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:47
+msgid "A better routing strategy is adopted to simultaneously alleviate the problems of load balancing and expert convergence. For long articles, the needle-in-a-haystack index reaches 99.9%"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:659
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:44
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:16
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:75
-msgid "API Key"
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:76
+msgid "A faster, more affordable but still very powerful model that can handle a range of tasks including casual conversation, text analysis, summarization and document question answering."
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:665
-msgid "Public settings"
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:162
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:197
+msgid "A high-performance open embedding model with a large token context window."
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:704
+#: apps/common/constants/permission_constants.py:1291
 msgid "About"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:709
-#: apps/users/views/user.py:88 apps/users/views/user.py:89
-#: apps/users/views/user.py:90
-msgid "Switch Language"
+#: apps/chat/serializers/chat_record.py:122
+msgid "Abstract"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:714
-msgid "Change Password"
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:24
+msgid "accent"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:734
-msgid "Sync users"
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:24
+msgid "Access Key ID"
 msgstr ""
 
-#: apps/common/constants/permission_constants.py:755
-#: apps/common/constants/permission_constants.py:808
-msgid "Set up user groups"
+#: apps/common/constants/permission_constants.py:374
+msgid "Access restrictions"
 msgstr ""
 
-#: apps/common/event/__init__.py:27
-msgid "The download process was interrupted, please try again"
+#: apps/oss/serializers/file.py:198
+msgid "Access to internal IP addresses is blocked"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:90
-#, python-brace-format
-msgid "Query vector data: {paragraph_id_list} error {error} {traceback}"
+#: apps/chat/api/chat_authentication_api.py:45
+#: apps/chat/serializers/chat_authentication.py:27
+#: apps/chat/serializers/chat_authentication.py:53
+msgid "access_token"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:95
-#, python-brace-format
-msgid "Start--->Embedding paragraph: {paragraph_id_list}"
+#: apps/application/serializers/application_chat.py:172
+msgid "accurate"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:107
-#, python-brace-format
-msgid "Vectorized paragraph: {paragraph_id_list} error {error} {traceback}"
+#: apps/application/serializers/application.py:207
+msgid "Acquaintance"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:113
-#, python-brace-format
-msgid "End--->Embedding paragraph: {paragraph_id_list}"
+#: apps/trigger/views/trigger.py:201
+#: apps/trigger/views/trigger.py:202
+#: apps/trigger/views/trigger.py:203
+msgid "Activate trigger in batches"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:122
-#, python-brace-format
-msgid "Start--->Embedding paragraph: {paragraph_id}"
+#: apps/homepage/api/home_page_api.py:385
+msgid "Active model count"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:147
-#, python-brace-format
-msgid "Vectorized paragraph: {paragraph_id} error {error} {traceback}"
+#: apps/homepage/api/home_page_api.py:348
+msgid "Active tool count"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:152
-#, python-brace-format
-msgid "End--->Embedding paragraph: {paragraph_id}"
+#: apps/homepage/serializers/homepage.py:492
+#: apps/homepage/serializers/homepage.py:629
+msgid "active users"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:268
-#, python-brace-format
-msgid "Start--->Embedding document: {document_id}"
+#: no source
+msgid "Add ApiKey"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:288
-#, python-brace-format
-msgid "Vectorized document: {document_id} error {error} {traceback}"
+#: apps/tools/views/tool.py:547
+#: apps/tools/views/tool.py:548
+#: apps/tools/views/tool.py:549
+msgid "Add Appstore tool"
 msgstr ""
 
-#: apps/common/event/listener_manage.py:293
-#, python-brace-format
-msgid "End--->Embedding document: {document_id}"
-msgstr ""
-
-#: apps/common/event/listener_manage.py:304
-#, python-brace-format
-msgid "Start--->Embedding knowledge: {knowledge_id}"
-msgstr ""
-
-#: apps/common/event/listener_manage.py:308
-#, python-brace-format
-msgid "Start--->Embedding document: {document_list}"
-msgstr ""
-
-#: apps/common/event/listener_manage.py:312
-#: apps/knowledge/task/embedding.py:116
-#, python-brace-format
-msgid "Vectorized knowledge: {knowledge_id} error {error} {traceback}"
-msgstr ""
-
-#: apps/common/event/listener_manage.py:315
-#, python-brace-format
-msgid "End--->Embedding knowledge: {knowledge_id}"
-msgstr ""
-
-#: apps/common/exception/handle_exception.py:32
-#: apps/common/handle/handle_exception.py:33
-msgid "Unknown exception"
-msgstr ""
-
-#: apps/common/field/common.py:48
-msgid "not a function"
-msgstr ""
-
-#: apps/common/forms/base_field.py:64
-#, python-brace-format
-msgid "The field {field_label} is required"
-msgstr ""
-
-#: apps/common/forms/slider_field.py:56
-#, python-brace-format
-msgid "The {field_label} cannot be less than {min}"
-msgstr ""
-
-#: apps/common/forms/slider_field.py:62
-#, python-brace-format
-msgid "The {field_label} cannot be greater than {max}"
-msgstr ""
-
-#: apps/common/handle/impl/text/pdf_split_handle.py:281
-#, python-brace-format
-msgid "This document has no preface and is treated as ordinary text: {e}"
-msgstr ""
-
-#: apps/common/job/clean_chat_job.py:23
-msgid "start clean chat log"
-msgstr ""
-
-#: apps/common/job/clean_chat_job.py:69
-msgid "end clean chat log"
-msgstr ""
-
-#: apps/common/job/clean_debug_file_job.py:21
-msgid "start clean debug file"
-msgstr ""
-
-#: apps/common/job/clean_debug_file_job.py:25
-msgid "end clean debug file"
-msgstr ""
-
-#: apps/common/result/api.py:17 apps/common/result/api.py:27
-msgid "response code"
-msgstr ""
-
-#: apps/common/result/api.py:18 apps/common/result/api.py:19
-#: apps/common/result/api.py:28 apps/common/result/api.py:29
-msgid "error prompt"
-msgstr ""
-
-#: apps/common/result/api.py:43
-msgid "total number of data"
-msgstr ""
-
-#: apps/common/result/api.py:44
-msgid "current page"
-msgstr ""
-
-#: apps/common/result/api.py:45
-msgid "page size"
-msgstr ""
-
-#: apps/common/result/result.py:31
-#: apps/xpack/serializers/operate_log_serializer.py:134
-msgid "Success"
-msgstr ""
-
-#: apps/common/utils/common.py:91
-msgid "Text-to-speech node, the text content must be of string type"
-msgstr ""
-
-#: apps/common/utils/common.py:93
-msgid "Text-to-speech node, the text content cannot be empty"
-msgstr ""
-
-#: apps/common/utils/common.py:246
-#, python-brace-format
-msgid "Limit {count} exceeded, please contact us (https://fit2cloud.com/)."
-msgstr ""
-
-#: apps/folders/models/folder.py:6 apps/folders/models/folder.py:17
-#: apps/folders/serializers/folder.py:98
-msgid "folder name"
-msgstr ""
-
-#: apps/folders/models/folder.py:8 apps/folders/models/folder.py:19
-#: apps/folders/serializers/folder.py:99
-msgid "folder description"
-msgstr ""
-
-#: apps/folders/models/folder.py:12 apps/folders/models/folder.py:23
-#: apps/folders/serializers/folder.py:102
-msgid "parent id"
-msgstr ""
-
-#: apps/folders/serializers/folder.py:75
-msgid "Folder depth cannot exceed 5 levels"
-msgstr ""
-
-#: apps/folders/serializers/folder.py:100
-msgid "folder user id"
-msgstr ""
-
-#: apps/folders/serializers/folder.py:105
-#: apps/knowledge/serializers/knowledge.py:112
-#: apps/knowledge/serializers/knowledge.py:207
-#: apps/knowledge/serializers/knowledge.py:447
-#: apps/knowledge/serializers/knowledge.py:559
-#: apps/knowledge/serializers/knowledge.py:637
-#: apps/models_provider/serializers/model_serializer.py:108
-#: apps/models_provider/serializers/model_serializer.py:212
-#: apps/models_provider/serializers/model_serializer.py:252
-#: apps/shared/serializers/shared_knowledge.py:107
-#: apps/shared/serializers/shared_knowledge.py:156
-#: apps/shared/serializers/shared_tool.py:84
-#: apps/system_manage/serializers/user_resource_permission.py:75
-#: apps/tools/serializers/tool.py:187 apps/tools/serializers/tool.py:209
-#: apps/tools/serializers/tool.py:455 apps/users/serializers/user.py:664
-#: apps/xpack/serializers/dataset_lark_serializer.py:46
-#: apps/xpack/serializers/dataset_lark_serializer.py:285
-#: apps/xpack/serializers/system_api_key.py:23
-msgid "user id"
-msgstr ""
-
-#: apps/folders/serializers/folder.py:123
-msgid "Folder name already exists"
-msgstr ""
-
-#: apps/folders/serializers/folder.py:150
-#: apps/folders/serializers/folder.py:182
-msgid "Folder does not exist"
-msgstr ""
-
-#: apps/folders/serializers/folder.py:184
-msgid "Cannot delete root folder"
-msgstr ""
-
-#: apps/folders/views/folder.py:31 apps/folders/views/folder.py:32
-#: apps/folders/views/folder.py:33
-msgid "Create folder"
-msgstr ""
-
-#: apps/folders/views/folder.py:37 apps/folders/views/folder.py:63
-#: apps/folders/views/folder.py:86 apps/folders/views/folder.py:110
-#: apps/folders/views/folder.py:129
-msgid "Folder"
-msgstr ""
-
-#: apps/folders/views/folder.py:58 apps/folders/views/folder.py:59
-#: apps/folders/views/folder.py:60
-msgid "Get folder tree"
-msgstr ""
-
-#: apps/folders/views/folder.py:80 apps/folders/views/folder.py:81
-#: apps/folders/views/folder.py:82
-msgid "Update folder"
-msgstr ""
-
-#: apps/folders/views/folder.py:105 apps/folders/views/folder.py:106
-#: apps/folders/views/folder.py:107
-msgid "Get folder"
-msgstr ""
-
-#: apps/folders/views/folder.py:124 apps/folders/views/folder.py:125
-#: apps/folders/views/folder.py:126
-msgid "Delete folder"
-msgstr ""
-
-#: apps/knowledge/api/problem.py:39 apps/knowledge/api/problem.py:52
-#: apps/knowledge/serializers/problem.py:40
-msgid "problem list"
-msgstr ""
-
-#: apps/knowledge/api/problem.py:40 apps/knowledge/api/problem.py:53
-#: apps/knowledge/serializers/problem.py:41
-msgid "problem"
-msgstr ""
-
-#: apps/knowledge/serializers/common.py:32
-#: apps/knowledge/serializers/knowledge.py:62
-#: apps/shared/serializers/shared_knowledge.py:29
-msgid "source url"
-msgstr ""
-
-#: apps/knowledge/serializers/common.py:33
-#: apps/knowledge/serializers/document.py:152
-msgid "selector"
-msgstr ""
-
-#: apps/knowledge/serializers/common.py:40
-#, python-brace-format
-msgid "URL error, cannot parse [{source_url}]"
-msgstr ""
-
-#: apps/knowledge/serializers/common.py:48
-#: apps/knowledge/serializers/document.py:78
-#: apps/knowledge/serializers/document.py:170
-#: apps/knowledge/serializers/document.py:186
-msgid "id list"
-msgstr ""
-
-#: apps/knowledge/serializers/common.py:58
-#, python-brace-format
-msgid "The following id does not exist: {error_id_list}"
-msgstr ""
-
-#: apps/knowledge/serializers/common.py:74
-#: apps/knowledge/serializers/document.py:166
-#: apps/knowledge/serializers/document.py:171
-#: apps/knowledge/serializers/document.py:178
-msgid "state list"
-msgstr ""
-
-#: apps/knowledge/serializers/common.py:117
-#: apps/knowledge/serializers/common.py:141
-msgid "The knowledge base is inconsistent with the vector model"
-msgstr ""
-
-#: apps/knowledge/serializers/common.py:119
-#: apps/knowledge/serializers/common.py:143
-msgid "Knowledge base setting error, please reset the knowledge base"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:79
-#: apps/knowledge/serializers/document.py:97
-#: apps/knowledge/serializers/document.py:353
-msgid "task type"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:87
-#: apps/knowledge/serializers/document.py:105
-msgid "task type not support"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:91
-#: apps/knowledge/serializers/document.py:110
-#: apps/knowledge/serializers/document.py:350
-msgid "document name"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:93
-msgid "source file id"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:113
-#: apps/knowledge/serializers/document.py:194
-msgid "The type only supports optimization|directly_return"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:115
-#: apps/knowledge/serializers/document.py:187
-#: apps/knowledge/serializers/document.py:351
-msgid "hit handling method"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:118
-#: apps/knowledge/serializers/document.py:189
-msgid "directly return similarity"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:120
-#: apps/knowledge/serializers/document.py:352
-msgid "document is active"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:139
-#: apps/knowledge/serializers/document.py:156
-#: apps/knowledge/serializers/document.py:161
-msgid "file list"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:140
-msgid "limit"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:143
-#: apps/knowledge/serializers/document.py:144
-msgid "patterns"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:146
-msgid "Auto Clean"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:150
-#: apps/knowledge/serializers/document.py:151
-msgid "document url list"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:175
-#: apps/knowledge/serializers/document.py:182
-msgid "document id list"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:176
-#: apps/knowledge/serializers/paragraph.py:58
-#: apps/models_provider/api/model.py:105
-#: apps/models_provider/serializers/model_apply_serializers.py:51
-#: apps/models_provider/serializers/model_serializer.py:107
-#: apps/models_provider/serializers/model_serializer.py:364
-#: apps/shared/api/shared_model.py:61
-#: apps/shared/serializers/shared_model.py:54
-msgid "model id"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:177
-#: apps/knowledge/serializers/paragraph.py:59
-msgid "prompt"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:201
-msgid "The template type only supports excel|csv"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:254
-#: apps/knowledge/serializers/document.py:348
-#: apps/knowledge/serializers/document.py:409
-#: apps/knowledge/serializers/document.py:504
-#: apps/knowledge/serializers/document.py:889
-#: apps/knowledge/serializers/document.py:964
-#: apps/knowledge/serializers/document.py:984
-#: apps/knowledge/serializers/document.py:1167
-#: apps/knowledge/serializers/knowledge.py:209
-#: apps/knowledge/serializers/knowledge.py:558
-#: apps/knowledge/serializers/paragraph.py:70
-#: apps/knowledge/serializers/paragraph.py:138
-#: apps/knowledge/serializers/paragraph.py:239
-#: apps/knowledge/serializers/paragraph.py:321
-#: apps/knowledge/serializers/paragraph.py:347
-#: apps/knowledge/serializers/paragraph.py:398
-#: apps/knowledge/serializers/paragraph.py:439
-#: apps/knowledge/serializers/paragraph.py:559
-#: apps/knowledge/serializers/problem.py:62
-#: apps/knowledge/serializers/problem.py:126
-#: apps/knowledge/serializers/problem.py:177
-#: apps/knowledge/serializers/problem.py:205
-#: apps/shared/api/shared_knowledge.py:196
-#: apps/shared/api/shared_knowledge.py:218
-#: apps/shared/serializers/shared_knowledge.py:158
-#: apps/shared/serializers/shared_knowledge.py:205
-#: apps/xpack/serializers/dataset_lark_serializer.py:104
-#: apps/xpack/serializers/dataset_lark_serializer.py:263
-#: apps/xpack/serializers/dataset_lark_serializer.py:284
-msgid "knowledge id"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:255
-#: apps/knowledge/serializers/paragraph.py:441
-msgid "target knowledge id"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:256
-msgid "document list"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:257
-#: apps/knowledge/serializers/document.py:410
-#: apps/knowledge/serializers/document.py:503
-#: apps/knowledge/serializers/document.py:737
-#: apps/knowledge/serializers/paragraph.py:61
-#: apps/knowledge/serializers/paragraph.py:71
-#: apps/knowledge/serializers/paragraph.py:140
-#: apps/knowledge/serializers/paragraph.py:240
-#: apps/knowledge/serializers/paragraph.py:322
-#: apps/knowledge/serializers/paragraph.py:349
-#: apps/knowledge/serializers/paragraph.py:399
-#: apps/knowledge/serializers/paragraph.py:440
-#: apps/knowledge/serializers/paragraph.py:560
-#: apps/knowledge/serializers/problem.py:36
-#: apps/knowledge/serializers/problem.py:51
-#: apps/xpack/serializers/dataset_lark_serializer.py:160
-msgid "document id"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:354 apps/xpack/api/license.py:25
-#: apps/xpack/serializers/operate_log_serializer.py:60
-#: apps/xpack/serializers/operate_log_serializer.py:174
-msgid "status"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:355
-msgid "order by"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:417
-#: apps/knowledge/serializers/document.py:510
-#: apps/xpack/serializers/dataset_lark_serializer.py:167
-#: apps/xpack/serializers/dataset_lark_serializer.py:189
-msgid "document id not exist"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:419
-#: apps/knowledge/serializers/knowledge.py:570
-msgid "Synchronization is only supported for web site types"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:661
-msgid "The task is being executed, please do not send it repeatedly."
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:674
-msgid "Section title (optional)"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:675
-msgid ""
-"Section content (required, question answer, no more than 4096 characters)"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:676
-msgid "Question (optional, one per line in the cell)"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:742
-msgid "knowledge id not exist"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:898
-msgid "The maximum size of the uploaded file cannot exceed {}MB"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:976
-msgid "space"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:977
-msgid "semicolon"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:977
-msgid "comma"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:978
-msgid "period"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:978
-msgid "enter"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:979
-msgid "blank line"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:1140
-msgid "Hit handling method is required"
-msgstr ""
-
-#: apps/knowledge/serializers/document.py:1142
-msgid "The hit processing method must be directly_return|optimization"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:51
-#: apps/knowledge/serializers/knowledge.py:58
-#: apps/knowledge/serializers/knowledge.py:67
-#: apps/knowledge/serializers/knowledge.py:108
-#: apps/shared/api/shared_knowledge.py:117
-#: apps/shared/api/shared_knowledge.py:150
-#: apps/shared/serializers/shared_knowledge.py:20
-#: apps/shared/serializers/shared_knowledge.py:26
-#: apps/shared/serializers/shared_knowledge.py:59
-#: apps/shared/serializers/shared_knowledge.py:106
-#: apps/xpack/serializers/dataset_lark_serializer.py:51
-#: apps/xpack/serializers/dataset_lark_serializer.py:289
-msgid "knowledge name"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:53
-#: apps/knowledge/serializers/knowledge.py:60
-#: apps/knowledge/serializers/knowledge.py:68
-#: apps/knowledge/serializers/knowledge.py:110
-#: apps/shared/api/shared_knowledge.py:124
-#: apps/shared/api/shared_knowledge.py:157
-#: apps/shared/serializers/shared_knowledge.py:21
-#: apps/shared/serializers/shared_knowledge.py:27
-#: apps/shared/serializers/shared_knowledge.py:60
-#: apps/shared/serializers/shared_knowledge.py:108
-#: apps/xpack/serializers/dataset_lark_serializer.py:53
-#: apps/xpack/serializers/dataset_lark_serializer.py:291
-msgid "knowledge description"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:54
-#: apps/knowledge/serializers/knowledge.py:61
-#: apps/shared/serializers/shared_knowledge.py:22
-#: apps/shared/serializers/shared_knowledge.py:28
-msgid "knowledge embedding"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:63
-#: apps/shared/serializers/shared_knowledge.py:30
-msgid "knowledge selector"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:73
-#: apps/xpack/serializers/dataset_lark_serializer.py:296
-msgid "application id list"
-msgstr "Agent ID list"
-
-#: apps/knowledge/serializers/knowledge.py:75
-msgid "file size limit"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:76
-msgid "file count limit"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:95
-#: apps/knowledge/serializers/knowledge.py:638
-msgid "query text"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:96
-#: apps/knowledge/serializers/knowledge.py:639
-msgid "top number"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:98
-#: apps/knowledge/serializers/knowledge.py:641
-msgid "search mode"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:113
-msgid "knowledge scope"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:169
-#: apps/tools/serializers/tool.py:434 apps/tools/serializers/tool.py:464
-msgid "Folder not found"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:236
-#: apps/knowledge/serializers/knowledge.py:265
-msgid "Failed to send the vectorization task, please try again later!"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:315
-#: apps/knowledge/serializers/knowledge.py:471
-#: apps/knowledge/serializers/knowledge.py:533
-#: apps/xpack/serializers/dataset_lark_serializer.py:82
-#: apps/xpack/serializers/dataset_lark_serializer.py:340
-msgid "Knowledge base name duplicate!"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:341
-#: apps/xpack/serializers/dataset_lark_serializer.py:359
-#, python-brace-format
-msgid "Unknown application id {knowledge_id}, cannot be associated"
-msgstr "Unknown Agent ID {knowledge_id}, cannot be associated"
-
-#: apps/knowledge/serializers/knowledge.py:449
-#: apps/shared/serializers/shared_knowledge.py:62
-#: apps/shared/serializers/shared_knowledge.py:110
-#: apps/shared/serializers/shared_tool.py:46
-#: apps/shared/serializers/shared_tool.py:87 apps/tools/serializers/tool.py:456
-#: apps/xpack/serializers/dataset_lark_serializer.py:47
-msgid "scope"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:460
-msgid ""
-"The community version supports up to 50 knowledge bases. If you need more "
-"knowledge bases, please contact us (https://fit2cloud.com/)."
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:560
-msgid "sync type"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:562
-msgid "The synchronization type only supports:replace|complete"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:568
-#: apps/knowledge/serializers/knowledge.py:649
-msgid "id does not exist"
-msgstr ""
-
-#: apps/knowledge/serializers/knowledge.py:636 apps/users/api/user.py:76
-msgid "id"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:39
-#: apps/knowledge/serializers/problem.py:27
-#: apps/knowledge/serializers/problem.py:31
-#: apps/knowledge/serializers/problem.py:206
-msgid "content"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:41
-#: apps/knowledge/serializers/paragraph.py:48
-#: apps/knowledge/serializers/paragraph.py:51
-#: apps/knowledge/serializers/paragraph.py:65
-#: apps/knowledge/serializers/paragraph.py:67
-#: apps/knowledge/serializers/paragraph.py:323
-msgid "section title"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:44
-#: apps/tools/serializers/tool.py:152 apps/tools/serializers/tool.py:164
-#: apps/xpack/serializers/system_api_key.py:11
-msgid "Is active"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:56
-#: apps/knowledge/serializers/paragraph.py:443
-msgid "paragraph id list"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:57
-#: apps/knowledge/serializers/paragraph.py:72
-#: apps/knowledge/serializers/paragraph.py:136
-#: apps/knowledge/serializers/paragraph.py:350
-#: apps/knowledge/serializers/paragraph.py:444
-#: apps/knowledge/serializers/paragraph.py:561
-#: apps/knowledge/serializers/problem.py:35
-#: apps/knowledge/serializers/problem.py:50
-msgid "paragraph id"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:77
-#: apps/knowledge/serializers/paragraph.py:145
-msgid "Paragraph id does not exist"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:108
-msgid "Already associated, please do not associate again"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:181
-msgid "Problem id does not exist"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:348
-#: apps/knowledge/serializers/problem.py:26
-#: apps/knowledge/serializers/problem.py:46
-#: apps/knowledge/serializers/problem.py:56
-#: apps/knowledge/serializers/problem.py:127
-msgid "problem id"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:358
-msgid "Paragraph does not exist"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:360
-msgid "Problem does not exist"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:435
-msgid "The task is being executed, please do not send it again."
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:442
-msgid "target document id"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:453
-msgid "The document to be migrated is consistent with the target document"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:455
-#, python-brace-format
-msgid "The document id does not exist [{document_id}]"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:459
-#, python-brace-format
-msgid "The target document id does not exist [{document_id}]"
-msgstr ""
-
-#: apps/knowledge/serializers/paragraph.py:573
-msgid "new_position must be an integer"
-msgstr ""
-
-#: apps/knowledge/serializers/problem.py:45
-#: apps/knowledge/serializers/problem.py:55
-msgid "problem id list"
-msgstr ""
-
-#: apps/knowledge/task/embedding.py:24 apps/knowledge/task/embedding.py:74
-#, python-brace-format
-msgid "Failed to obtain vector model: {error} {traceback}"
-msgstr ""
-
-#: apps/knowledge/task/embedding.py:103
-#, python-brace-format
-msgid "Start--->Vectorized knowledge: {knowledge_id}"
-msgstr ""
-
-#: apps/knowledge/task/embedding.py:107
-#, python-brace-format
-msgid "Knowledge documentation: {document_names}"
-msgstr ""
-
-#: apps/knowledge/task/embedding.py:120
-#, python-brace-format
-msgid "End--->Vectorized knowledge: {knowledge_id}"
-msgstr ""
-
-#: apps/knowledge/task/generate.py:106
-#, python-brace-format
-msgid ""
-"Generate issue based on document: {document_id} error {error}{traceback}"
-msgstr ""
-
-#: apps/knowledge/task/generate.py:110
-#, python-brace-format
-msgid "End--->Generate problem: {document_id}"
-msgstr ""
-
-#: apps/knowledge/task/handler.py:121
-#, python-brace-format
-msgid "Association problem failed {error}"
-msgstr ""
-
-#: apps/knowledge/task/sync.py:30 apps/knowledge/task/sync.py:47
-#, python-brace-format
-msgid "Start--->Start synchronization web knowledge base:{knowledge_id}"
-msgstr ""
-
-#: apps/knowledge/task/sync.py:35 apps/knowledge/task/sync.py:51
-#, python-brace-format
-msgid "End--->End synchronization web knowledge base:{knowledge_id}"
-msgstr ""
-
-#: apps/knowledge/task/sync.py:37 apps/knowledge/task/sync.py:53
-#, python-brace-format
-msgid "Synchronize web knowledge base:{knowledge_id} error{error}{traceback}"
-msgstr ""
-
-#: apps/knowledge/views/document.py:28 apps/knowledge/views/document.py:29
-#: apps/knowledge/views/document.py:30
-msgid "Create document"
-msgstr ""
-
-#: apps/knowledge/views/document.py:34 apps/knowledge/views/document.py:57
-#: apps/knowledge/views/document.py:84 apps/knowledge/views/document.py:104
-#: apps/knowledge/views/document.py:128 apps/knowledge/views/document.py:160
-#: apps/knowledge/views/document.py:191 apps/knowledge/views/document.py:209
-#: apps/knowledge/views/document.py:238 apps/knowledge/views/document.py:267
-#: apps/knowledge/views/document.py:295 apps/knowledge/views/document.py:323
-#: apps/knowledge/views/document.py:352 apps/knowledge/views/document.py:382
-#: apps/knowledge/views/document.py:412 apps/knowledge/views/document.py:441
-#: apps/knowledge/views/document.py:472 apps/knowledge/views/document.py:501
-#: apps/knowledge/views/document.py:527 apps/knowledge/views/document.py:553
-#: apps/knowledge/views/document.py:579 apps/knowledge/views/document.py:599
-#: apps/knowledge/views/document.py:633 apps/knowledge/views/document.py:664
-#: apps/knowledge/views/document.py:695 apps/knowledge/views/document.py:723
-#: apps/knowledge/views/document.py:737
-#: apps/xpack/views/dataset_lark_views.py:72
-#: apps/xpack/views/dataset_lark_views.py:91
-#: apps/xpack/views/dataset_lark_views.py:111
-#: apps/xpack/views/dataset_lark_views.py:132
-msgid "Knowledge Base/Documentation"
-msgstr ""
-
-#: apps/knowledge/views/document.py:52 apps/knowledge/views/document.py:53
-#: apps/knowledge/views/document.py:54
-msgid "Get document"
-msgstr ""
-
-#: apps/knowledge/views/document.py:79 apps/knowledge/views/document.py:80
-#: apps/knowledge/views/document.py:81
-msgid "Get document details"
-msgstr ""
-
-#: apps/knowledge/views/document.py:98 apps/knowledge/views/document.py:99
-#: apps/knowledge/views/document.py:100
-msgid "Modify document"
-msgstr ""
-
-#: apps/knowledge/views/document.py:123 apps/knowledge/views/document.py:124
-#: apps/knowledge/views/document.py:125
-msgid "Delete document"
-msgstr ""
-
-#: apps/knowledge/views/document.py:154 apps/knowledge/views/document.py:155
-#: apps/knowledge/views/document.py:156
-msgid "Segmented document"
-msgstr ""
-
-#: apps/knowledge/views/document.py:186 apps/knowledge/views/document.py:187
-#: apps/knowledge/views/document.py:188
-msgid "Get a list of segment IDs"
-msgstr ""
-
-#: apps/knowledge/views/document.py:203 apps/knowledge/views/document.py:204
-#: apps/knowledge/views/document.py:205
-msgid "Modify document hit processing methods in batches"
-msgstr ""
-
-#: apps/knowledge/views/document.py:232 apps/knowledge/views/document.py:233
-#: apps/knowledge/views/document.py:234
-msgid "Synchronize web site types"
-msgstr ""
-
-#: apps/knowledge/views/document.py:261 apps/knowledge/views/document.py:262
-#: apps/knowledge/views/document.py:263
-msgid "Refresh document vector library"
-msgstr ""
-
-#: apps/knowledge/views/document.py:289 apps/knowledge/views/document.py:290
-#: apps/knowledge/views/document.py:291
-msgid "Cancel task"
-msgstr ""
-
-#: apps/knowledge/views/document.py:317 apps/knowledge/views/document.py:318
-#: apps/knowledge/views/document.py:319
-msgid "Cancel tasks in batches"
-msgstr ""
-
-#: apps/knowledge/views/document.py:346 apps/knowledge/views/document.py:347
-#: apps/knowledge/views/document.py:348
-msgid "Create documents in batches"
-msgstr ""
-
-#: apps/knowledge/views/document.py:376 apps/knowledge/views/document.py:377
-#: apps/knowledge/views/document.py:378
-msgid "Batch sync documents"
-msgstr ""
-
-#: apps/knowledge/views/document.py:406 apps/knowledge/views/document.py:407
-#: apps/knowledge/views/document.py:408
-msgid "Delete documents in batches"
-msgstr ""
-
-#: apps/knowledge/views/document.py:436 apps/knowledge/views/document.py:437
-msgid "Batch refresh document vector library"
-msgstr ""
-
-#: apps/knowledge/views/document.py:466 apps/knowledge/views/document.py:467
-#: apps/knowledge/views/document.py:468
-msgid "Batch generate related problems"
-msgstr ""
-
-#: apps/knowledge/views/document.py:496 apps/knowledge/views/document.py:497
-#: apps/knowledge/views/document.py:498
-msgid "Get document by pagination"
-msgstr ""
-
-#: apps/knowledge/views/document.py:523 apps/knowledge/views/document.py:524
-msgid "Export document"
-msgstr ""
-
-#: apps/knowledge/views/document.py:549 apps/knowledge/views/document.py:550
-msgid "Export Zip document"
-msgstr ""
-
-#: apps/knowledge/views/document.py:575 apps/knowledge/views/document.py:576
-msgid "Download source file"
-msgstr ""
-
-#: apps/knowledge/views/document.py:594 apps/knowledge/views/document.py:595
-msgid "Migrate documents in batches"
-msgstr ""
-
-#: apps/knowledge/views/document.py:627 apps/knowledge/views/document.py:628
-#: apps/knowledge/views/document.py:629
-#: apps/shared/views/shared_document.py:570
-msgid "Create Web site documents"
-msgstr ""
-
-#: apps/knowledge/views/document.py:658 apps/knowledge/views/document.py:659
-#: apps/knowledge/views/document.py:660
-msgid "Import QA and create documentation"
-msgstr ""
-
-#: apps/knowledge/views/document.py:689 apps/knowledge/views/document.py:690
-#: apps/knowledge/views/document.py:691
-msgid "Import tables and create documents"
-msgstr ""
-
-#: apps/knowledge/views/document.py:719 apps/knowledge/views/document.py:720
-msgid "Get QA template"
-msgstr ""
-
-#: apps/knowledge/views/document.py:733 apps/knowledge/views/document.py:734
-msgid "Get form template"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:25 apps/knowledge/views/knowledge.py:26
-#: apps/knowledge/views/knowledge.py:27
-msgid "Get knowledge by folder"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:30 apps/knowledge/views/knowledge.py:59
-#: apps/knowledge/views/knowledge.py:83 apps/knowledge/views/knowledge.py:106
-#: apps/knowledge/views/knowledge.py:127 apps/knowledge/views/knowledge.py:156
-#: apps/knowledge/views/knowledge.py:188 apps/knowledge/views/knowledge.py:218
-#: apps/knowledge/views/knowledge.py:242 apps/knowledge/views/knowledge.py:266
-#: apps/knowledge/views/knowledge.py:293 apps/knowledge/views/knowledge.py:319
-#: apps/knowledge/views/knowledge.py:343 apps/knowledge/views/knowledge.py:369
-#: apps/knowledge/views/knowledge.py:397
-#: apps/xpack/views/dataset_lark_views.py:29
-#: apps/xpack/views/dataset_lark_views.py:50
-msgid "Knowledge Base"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:53 apps/knowledge/views/knowledge.py:54
-#: apps/knowledge/views/knowledge.py:55
-msgid "Edit knowledge"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:77 apps/knowledge/views/knowledge.py:78
-#: apps/knowledge/views/knowledge.py:79
-msgid "Delete knowledge"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:101 apps/knowledge/views/knowledge.py:102
-#: apps/knowledge/views/knowledge.py:103
-msgid "Get knowledge"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:122 apps/knowledge/views/knowledge.py:123
-#: apps/knowledge/views/knowledge.py:124
-msgid "Get the knowledge base paginated list"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:150 apps/knowledge/views/knowledge.py:151
-#: apps/knowledge/views/knowledge.py:152
-msgid "Synchronize the knowledge base of the website"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:182 apps/knowledge/views/knowledge.py:183
-#: apps/knowledge/views/knowledge.py:184
-msgid "Hit test list"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:212 apps/knowledge/views/knowledge.py:213
-#: apps/knowledge/views/knowledge.py:214
-msgid "Re-vectorize"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:238 apps/knowledge/views/knowledge.py:239
-msgid "Export knowledge base"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:262 apps/knowledge/views/knowledge.py:263
-msgid "Export knowledge base containing images"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:287 apps/knowledge/views/knowledge.py:288
-#: apps/knowledge/views/knowledge.py:289
-msgid "Generate related"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:314 apps/knowledge/views/knowledge.py:315
-#: apps/knowledge/views/knowledge.py:316
-msgid "Get model for knowledge base"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:338 apps/knowledge/views/knowledge.py:339
-#: apps/knowledge/views/knowledge.py:340
-msgid "Get embedding model for knowledge base"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:363 apps/knowledge/views/knowledge.py:364
-#: apps/knowledge/views/knowledge.py:365
-msgid "Create base knowledge"
-msgstr ""
-
-#: apps/knowledge/views/knowledge.py:391 apps/knowledge/views/knowledge.py:392
-#: apps/knowledge/views/knowledge.py:393
-msgid "Create web knowledge"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:24 apps/knowledge/views/paragraph.py:25
-#: apps/knowledge/views/paragraph.py:26
-msgid "Paragraph list"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:29 apps/knowledge/views/paragraph.py:53
-#: apps/knowledge/views/paragraph.py:82 apps/knowledge/views/paragraph.py:102
-#: apps/knowledge/views/paragraph.py:138 apps/knowledge/views/paragraph.py:167
-#: apps/knowledge/views/paragraph.py:199 apps/knowledge/views/paragraph.py:224
-#: apps/knowledge/views/paragraph.py:259 apps/knowledge/views/paragraph.py:289
-#: apps/knowledge/views/paragraph.py:316 apps/knowledge/views/paragraph.py:351
-#: apps/knowledge/views/paragraph.py:385 apps/knowledge/views/paragraph.py:415
-msgid "Knowledge Base/Documentation/Paragraph"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:48 apps/knowledge/views/paragraph.py:49
-msgid "Create Paragraph"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:76 apps/knowledge/views/paragraph.py:77
-#: apps/knowledge/views/paragraph.py:78
-msgid "Batch Paragraph"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:97 apps/knowledge/views/paragraph.py:98
-msgid "Migrate paragraphs in batches"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:132 apps/knowledge/views/paragraph.py:133
-#: apps/knowledge/views/paragraph.py:134
-msgid "Batch Generate Related"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:161 apps/knowledge/views/paragraph.py:162
-#: apps/knowledge/views/paragraph.py:163
-msgid "Modify paragraph data"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:194 apps/knowledge/views/paragraph.py:195
-#: apps/knowledge/views/paragraph.py:196
-msgid "Get paragraph details"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:219 apps/knowledge/views/paragraph.py:220
-#: apps/knowledge/views/paragraph.py:221
-msgid "Delete paragraph"
-msgstr ""
-
-#: apps/knowledge/views/paragraph.py:253 apps/knowledge/views/paragraph.py:254
-#: apps/knowledge/views/paragraph.py:255
+#: apps/knowledge/views/paragraph.py:276
+#: apps/knowledge/views/paragraph.py:277
+#: apps/knowledge/views/paragraph.py:278
 msgid "Add associated questions"
 msgstr ""
 
-#: apps/knowledge/views/paragraph.py:284 apps/knowledge/views/paragraph.py:285
-#: apps/knowledge/views/paragraph.py:286
-msgid "Get a list of paragraph questions"
+#: apps/knowledge/views/document.py:1039
+#: apps/knowledge/views/document.py:1040
+#: apps/knowledge/views/document.py:1041
+msgid "Add document tags"
 msgstr ""
 
-#: apps/knowledge/views/paragraph.py:310 apps/knowledge/views/paragraph.py:311
-#: apps/knowledge/views/paragraph.py:312
-msgid "Disassociation issue"
+#: apps/tools/views/tool.py:500
+#: apps/tools/views/tool.py:501
+#: apps/tools/views/tool.py:502
+msgid "Add internal tool"
 msgstr ""
 
-#: apps/knowledge/views/paragraph.py:345 apps/knowledge/views/paragraph.py:346
-#: apps/knowledge/views/paragraph.py:347
-msgid "Related questions"
+#: apps/common/constants/permission_constants.py:365
+msgid "Add Member"
 msgstr ""
 
-#: apps/knowledge/views/paragraph.py:380 apps/knowledge/views/paragraph.py:381
-#: apps/knowledge/views/paragraph.py:382
-msgid "Get paragraph list by pagination"
+#: no source
+msgid "Add member to chat user group"
 msgstr ""
 
-#: apps/knowledge/views/paragraph.py:409 apps/knowledge/views/paragraph.py:410
-#: apps/knowledge/views/paragraph.py:411
-#: apps/resource_manage/views/paragraph.py:364
-#: apps/resource_manage/views/paragraph.py:365
-#: apps/resource_manage/views/paragraph.py:366
-#: apps/shared/views/shared_paragraph.py:365
-#: apps/shared/views/shared_paragraph.py:366
-#: apps/shared/views/shared_paragraph.py:367
+#: no source
+msgid "Add member to system role"
+msgstr ""
+
+#: no source
+msgid "Add member to system workspace"
+msgstr ""
+
+#: no source
+msgid "Add member to user group"
+msgstr ""
+
+#: no source
+msgid "Add member to workspace"
+msgstr ""
+
+#: no source
+msgid "Add member to workspace role"
+msgstr ""
+
+#: no source
+msgid "Add or modify authentication configuration"
+msgstr ""
+
+#: no source
+msgid "Add or modify Chat/Authentication Configuration"
+msgstr ""
+
+#: no source
+msgid "Add personal system API_KEY"
+msgstr ""
+
+#: no source
+msgid "Add shared associated questions"
+msgstr ""
+
+#: no source
+msgid "Add system associated questions"
+msgstr ""
+
+#: apps/application/views/application_chat_record.py:116
+#: apps/application/views/application_chat_record.py:117
+#: apps/application/views/application_chat_record.py:118
+#: apps/common/constants/permission_constants.py:382
+msgid "Add to Knowledge Base"
+msgstr ""
+
+#: no source
+msgid "Add user"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:446
+#: apps/knowledge/views/paragraph.py:447
+#: apps/knowledge/views/paragraph.py:448
 msgid "Adjust paragraph position"
 msgstr ""
 
-#: apps/knowledge/views/problem.py:23 apps/knowledge/views/problem.py:24
-#: apps/knowledge/views/problem.py:25
-msgid "Question list"
+#: no source
+msgid "ADMIN"
+msgstr "System Administrator"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:108
+msgid "Advanced Mistral AI large-scale language model capable of handling any language task, including complex multilingual reasoning, text understanding, transformation, and code generation."
 msgstr ""
 
-#: apps/knowledge/views/problem.py:28 apps/knowledge/views/problem.py:53
-#: apps/knowledge/views/problem.py:78 apps/knowledge/views/problem.py:104
-#: apps/knowledge/views/problem.py:131 apps/knowledge/views/problem.py:157
-#: apps/knowledge/views/problem.py:186 apps/knowledge/views/problem.py:216
-msgid "Knowledge Base/Documentation/Paragraph/Question"
+#: apps/application/serializers/application.py:468
+#: apps/application/serializers/application.py:468
+msgid "Affiliation user"
 msgstr ""
 
-#: apps/knowledge/views/problem.py:47 apps/knowledge/views/problem.py:48
-#: apps/knowledge/views/problem.py:49
-msgid "Create question"
+#: no source
+msgid "Agent ID is required"
 msgstr ""
 
-#: apps/knowledge/views/problem.py:73 apps/knowledge/views/problem.py:74
-#: apps/knowledge/views/problem.py:75
-msgid "Get a list of associated paragraphs"
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:417
+#: apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py:386
+msgid "Agent Key is required for agent tool 【{name}】"
 msgstr ""
 
-#: apps/knowledge/views/problem.py:98 apps/knowledge/views/problem.py:99
-#: apps/knowledge/views/problem.py:100
-msgid "Batch associated paragraphs"
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:411
+#: apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py:380
+msgid "Agent 【{name}】 access token authentication is not supported for agent tool"
 msgstr ""
 
-#: apps/knowledge/views/problem.py:125 apps/knowledge/views/problem.py:126
-#: apps/knowledge/views/problem.py:127
-msgid "Batch deletion issues"
+#: no source
+msgid "AI reply: "
 msgstr ""
 
-#: apps/knowledge/views/problem.py:152 apps/knowledge/views/problem.py:153
-#: apps/knowledge/views/problem.py:154
-msgid "Delete question"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:240
+msgid "Alibaba Cloud Bailian"
 msgstr ""
 
-#: apps/knowledge/views/problem.py:180 apps/knowledge/views/problem.py:181
-#: apps/knowledge/views/problem.py:182
-msgid "Modify question"
+#: no source
+msgid "Allow cross domain"
 msgstr ""
 
-#: apps/knowledge/views/problem.py:211 apps/knowledge/views/problem.py:212
-#: apps/knowledge/views/problem.py:213
-msgid "Get the list of questions by page"
+#: apps/knowledge/serializers/paragraph.py:167
+msgid "Already associated, please do not associate again"
 msgstr ""
 
-#: apps/maxkb/settings/base.py:101
-msgid "Intelligent customer service platform"
+#: apps/chat/serializers/chat_record.py:94
+msgid "Already voted, please cancel first and then vote again"
 msgstr ""
 
-#: apps/models_provider/api/model.py:37 apps/models_provider/api/provide.py:17
-#: apps/models_provider/api/provide.py:23
-#: apps/models_provider/api/provide.py:28
-#: apps/models_provider/api/provide.py:30
-#: apps/models_provider/api/provide.py:82
-#: apps/models_provider/serializers/model_serializer.py:40
-#: apps/models_provider/serializers/model_serializer.py:215
-#: apps/models_provider/serializers/model_serializer.py:253
-#: apps/models_provider/serializers/model_serializer.py:318
-#: apps/models_provider/serializers/model_serializer.py:393
-#: apps/shared/api/shared_model.py:18
-#: apps/shared/serializers/shared_model.py:111
-msgid "model name"
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:96
+msgid "Amazon Titan Text Express has context lengths of up to 8,000 tokens, making it ideal for a variety of high-level general language tasks, such as open-ended text generation and conversational chat, as well as support in retrieval-augmented generation (RAG). At launch, the model is optimized for English, but other languages are supported."
 msgstr ""
 
-#: apps/models_provider/api/model.py:44 apps/models_provider/api/provide.py:29
-#: apps/models_provider/api/provide.py:70
-#: apps/models_provider/api/provide.py:98
-#: apps/models_provider/serializers/model_serializer.py:42
-#: apps/models_provider/serializers/model_serializer.py:217
-#: apps/models_provider/serializers/model_serializer.py:255
-#: apps/models_provider/serializers/model_serializer.py:319
-#: apps/models_provider/serializers/model_serializer.py:394
-#: apps/shared/api/shared_model.py:25
-#: apps/shared/serializers/shared_model.py:112
-msgid "model type"
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:90
+msgid "Amazon Titan Text Lite is a lightweight, efficient model ideal for fine-tuning English-language tasks, including summarization and copywriting, where customers require smaller, more cost-effective, and highly customizable models."
 msgstr ""
 
-#: apps/models_provider/api/model.py:51
-#: apps/models_provider/serializers/model_serializer.py:43
-#: apps/models_provider/serializers/model_serializer.py:219
-#: apps/models_provider/serializers/model_serializer.py:256
-#: apps/models_provider/serializers/model_serializer.py:320
-#: apps/models_provider/serializers/model_serializer.py:395
-#: apps/shared/api/shared_model.py:32
-#: apps/shared/serializers/shared_model.py:113
-msgid "base model"
+#: no source
+msgid "An error occurred while processing the GET request {e}"
 msgstr ""
 
-#: apps/models_provider/api/model.py:58 apps/models_provider/api/provide.py:18
-#: apps/models_provider/api/provide.py:38
-#: apps/models_provider/api/provide.py:76
-#: apps/models_provider/api/provide.py:104
-#: apps/models_provider/api/provide.py:126
-#: apps/models_provider/serializers/model_serializer.py:41
-#: apps/models_provider/serializers/model_serializer.py:254
-#: apps/models_provider/serializers/model_serializer.py:321
-#: apps/models_provider/serializers/model_serializer.py:396
-#: apps/shared/api/shared_model.py:39
-#: apps/shared/serializers/shared_model.py:114
-msgid "provider"
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:41
+msgid "An update to Claude 2 that doubles the context window and improves reliability, hallucination rates, and evidence-based accuracy in long documents and RAG contexts."
 msgstr ""
 
-#: apps/models_provider/api/model.py:65
-#: apps/models_provider/serializers/model_serializer.py:322
-#: apps/models_provider/serializers/model_serializer.py:397
-#: apps/shared/api/shared_model.py:46
-#: apps/shared/serializers/shared_model.py:115
-msgid "create user"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:53
+msgid "animation"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:19
-#: apps/xpack/serializers/application_setting_serializer.py:41
-#: apps/xpack/serializers/system_params.py:21
-msgid "icon"
+#: no source
+msgid "Animation 1.3.0-Vincent Picture"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:34 apps/tools/serializers/tool.py:134
-msgid "input type"
+#: no source
+msgid "Animation 1.3.1-Vincent Picture"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:35
-msgid "label"
+#: apps/application/serializers/application_chat.py:220
+#: apps/application/views/application_chat_record.py:165
+#: apps/application/views/application_chat_record.py:166
+#: apps/application/views/application_chat_record.py:167
+#: apps/common/constants/permission_constants.py:370
+msgid "Annotation"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:36
-msgid "text field"
+#: apps/application/serializers/application_chat.py:216
+msgid "answer"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:37
-msgid "value field"
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:48
+msgid "Anthropic is a powerful model that can handle a variety of tasks, from complex dialogue and creative content generation to detailed command obedience."
 msgstr ""
 
-#: apps/models_provider/api/provide.py:39
-msgid "method"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:21
+msgid "API"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:40 apps/tools/serializers/tool.py:119
-#: apps/tools/serializers/tool.py:133
-msgid "required"
+#: apps/application/serializers/application_chat.py:289
+msgid "API Call"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:41
-msgid "default value"
+#: no source
+msgid "API Details"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:42
-msgid "relation show field dict"
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:43
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:48
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:45
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:42
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:43
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:24
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:44
+msgid "API domain name is invalid"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:43
-msgid "relation trigger field dict"
+#: apps/application/flow/step_node/application_node/i_application_node.py:18
+msgid "API Input Fields"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:44
-msgid "trigger type"
+#: apps/common/constants/permission_constants.py:376
+msgid "API KEY"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:43
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:14
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:31
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:21
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:35
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:74
+msgid "API Key"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:95
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:87
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:44
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:42
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:31
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:13
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:30
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:20
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:70
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:83
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:47
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:34
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:73
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:74
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:52
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:29
+msgid "API URL"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:20
+msgid "API Version"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:106
+msgid "APIKey does not exist"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:76
+msgid "ApiKeyId"
+msgstr ""
+
+#: no source
+msgid "App ID is required"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:47
+msgid "App IDs"
+msgstr ""
+
+#: no source
+msgid "App Key is required"
+msgstr ""
+
+#: no source
+msgid "App Secret is required"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:404
+msgid "Appearance Settings"
+msgstr ""
+
+#: apps/application/views/application.py:61
+#: apps/application/views/application.py:80
+#: apps/application/views/application.py:99
+#: apps/application/views/application.py:121
+#: apps/application/views/application.py:148
+#: apps/application/views/application.py:175
+#: apps/application/views/application.py:201
+#: apps/application/views/application.py:227
+#: apps/application/views/application.py:251
+#: apps/application/views/application.py:278
+#: apps/application/views/application.py:303
+#: apps/application/views/application.py:322
+#: apps/application/views/application.py:359
+#: apps/application/views/application.py:398
+#: apps/application/views/application.py:441
+#: apps/application/views/application.py:467
+#: apps/application/views/application.py:493
+#: apps/application/views/application.py:520
+#: apps/application/views/application_access_token.py:43
+#: apps/application/views/application_access_token.py:65
+#: apps/application/views/application_chat.py:126
+#: apps/application/views/application_chat.py:152
+#: apps/application/views/application_chat.py:168
+#: apps/application/views/application_stats.py:33
+#: apps/application/views/application_stats.py:61
+#: apps/application/views/application_stats.py:88
+#: apps/chat/serializers/chat.py:157
+#: apps/chat/views/chat.py:264
+#: apps/common/constants/permission_constants.py:340
+#: apps/common/constants/permission_constants.py:353
+#: apps/common/constants/permission_constants.py:434
+#: apps/common/constants/permission_constants.py:438
+msgid "Application"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:396
+#: apps/common/constants/permission_constants.py:440
+msgid "Application Access"
+msgstr "Agent Access"
+
+#: apps/chat/views/chat.py:101
+#: apps/chat/views/chat.py:102
+#: apps/chat/views/chat.py:103
+msgid "Application Anonymous Certification"
+msgstr "Agent Anonymous Certification"
+
+#: apps/application/views/application_api_key.py:37
+#: apps/application/views/application_api_key.py:64
+#: apps/application/views/application_api_key.py:89
+#: apps/application/views/application_api_key.py:115
+msgid "Application Api Key"
+msgstr "Agent Api Key"
+
+#: apps/application/serializers/application_chat_record.py:61
+msgid "Application authentication information does not exist"
+msgstr "Agent authentication information does not exist"
+
+#: apps/homepage/views/homepage.py:259
+#: apps/homepage/views/homepage.py:260
+msgid "Application data aggregation"
+msgstr ""
+
+#: apps/application/serializers/application.py:345
+msgid "application describe"
+msgstr "Agent description"
+
+#: apps/application/api/application_api.py:82
+#: apps/application/serializers/application.py:296
+#: apps/application/serializers/application.py:449
+#: apps/application/serializers/application.py:463
+#: apps/application/serializers/application.py:463
+#: apps/application/serializers/application.py:593
+msgid "Application Description"
+msgstr "Agent Description"
+
+#: apps/application/serializers/application.py:1736
+#: apps/chat/serializers/chat.py:487
+#: apps/chat/serializers/chat.py:548
+#: apps/oss/serializers/file.py:222
+msgid "Application does not exist"
+msgstr "Agent does not exist"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:15
+#: apps/application/serializers/application.py:993
+#: apps/application/serializers/application_access_token.py:47
+#: apps/application/serializers/application_chat.py:40
+#: apps/application/serializers/application_chat.py:58
+#: apps/application/serializers/application_chat_link.py:57
+#: apps/application/serializers/application_chat_record.py:47
+#: apps/application/serializers/application_chat_record.py:92
+#: apps/application/serializers/application_chat_record.py:201
+#: apps/application/serializers/application_chat_record.py:249
+#: apps/application/serializers/application_stats.py:39
+#: apps/application/serializers/application_version.py:21
+#: apps/application/serializers/application_version.py:69
+#: apps/chat/serializers/chat.py:218
+#: apps/chat/serializers/chat.py:290
+#: apps/chat/serializers/chat.py:604
+#: apps/chat/serializers/chat.py:616
+#: apps/chat/serializers/chat_authentication.py:93
+#: apps/chat/serializers/chat_record.py:102
+#: apps/chat/serializers/chat_record.py:126
+#: apps/chat/serializers/chat_record.py:154
+#: apps/chat/serializers/chat_record.py:166
+#: apps/homepage/api/home_page_api.py:163
+#: apps/homepage/api/home_page_api.py:193
+#: apps/homepage/serializers/homepage.py:656
+msgid "Application ID"
+msgstr "Agent ID"
+
+#: apps/application/serializers/application_api_key.py:38
+#: apps/application/serializers/application_api_key.py:75
+#: apps/knowledge/serializers/knowledge.py:134
+msgid "application id"
+msgstr "Agent id"
+
+#: apps/application/serializers/application_chat_record.py:379
+msgid "Application id"
+msgstr ""
+
+#: apps/application/serializers/application.py:1004
+#: apps/application/serializers/application_access_token.py:57
+#: apps/application/serializers/application_api_key.py:48
+#: apps/application/serializers/application_api_key.py:85
+#: apps/application/serializers/application_chat.py:75
+#: apps/application/serializers/application_chat_record.py:57
+#: apps/application/serializers/application_chat_record.py:103
+#: apps/application/serializers/application_chat_record.py:215
+#: apps/application/serializers/application_chat_record.py:262
+#: apps/application/serializers/application_chat_record.py:390
+#: apps/application/serializers/application_stats.py:50
+#: apps/application/serializers/application_version.py:80
+#: apps/chat/serializers/chat.py:167
+msgid "Application id does not exist"
+msgstr "Agent id does not exist"
+
+#: apps/knowledge/serializers/knowledge.py:135
+msgid "application id list"
+msgstr "Agent ID list"
+
+#: apps/application/api/application_api.py:75
+#: apps/application/serializers/application.py:289
+#: apps/application/serializers/application.py:448
+#: apps/application/serializers/application.py:461
+#: apps/application/serializers/application.py:461
+#: apps/application/serializers/application.py:586
+#: apps/homepage/serializers/homepage.py:389
+#: apps/homepage/serializers/homepage.py:489
+#: apps/homepage/serializers/homepage.py:516
+#: apps/homepage/serializers/homepage.py:625
+msgid "Application Name"
+msgstr "Agent Name"
+
+#: apps/application/serializers/application.py:338
+msgid "application name"
+msgstr "Agent name"
+
+#: apps/homepage/api/home_page_api.py:164
+#: apps/homepage/api/home_page_api.py:194
+msgid "Application name"
+msgstr ""
+
+#: no source
+msgid "Application Password Certification"
+msgstr "Agent Password Certification"
+
+#: apps/homepage/api/home_page_api.py:189
+msgid "Application question ranking list"
+msgstr ""
+
+#: apps/application/views/application_stats.py:56
+#: apps/application/views/application_stats.py:57
+#: apps/application/views/application_stats.py:58
+msgid "Application token usage statistics"
+msgstr "Agent token usage statistics"
+
+#: apps/homepage/api/home_page_api.py:159
+msgid "Application tokens ranking list"
+msgstr ""
+
+#: apps/application/views/application_stats.py:83
+#: apps/application/views/application_stats.py:84
+#: apps/application/views/application_stats.py:85
+msgid "Application top question statistics"
+msgstr "Agent top question statistics"
+
+#: apps/application/serializers/application.py:373
+msgid "Application Type"
+msgstr "Agent Type"
+
+#: apps/application/serializers/application.py:466
+#: apps/application/serializers/application.py:466
+msgid "Application type"
+msgstr "Agent type"
+
+#: apps/application/serializers/application.py:377
+msgid "Application type only supports SIMPLE|WORK_FLOW"
+msgstr "Agent type only supports SIMPLE|WORK_FLOW"
+
+#: apps/application/serializers/application_version.py:71
+msgid "Application version ID"
+msgstr ""
+
+#: no source
+msgid "Application/application access"
+msgstr "Agent/agent access"
+
+#: apps/application/views/application_chat.py:50
+#: apps/application/views/application_chat.py:75
+#: apps/application/views/application_chat.py:101
+#: apps/application/views/application_chat_record.py:37
+#: apps/application/views/application_chat_record.py:63
+#: apps/application/views/application_chat_record.py:92
+#: apps/application/views/application_chat_record.py:122
+#: apps/application/views/application_chat_record.py:146
+#: apps/application/views/application_chat_record.py:171
+#: apps/application/views/application_chat_record.py:202
+msgid "Application/Conversation Log"
+msgstr "Agent/Conversation Log"
+
+#: no source
+msgid "Application/Get platform status"
+msgstr "Agent/Get platform status"
+
+#: apps/application/views/application_version.py:35
+#: apps/application/views/application_version.py:59
+#: apps/application/views/application_version.py:84
+#: apps/application/views/application_version.py:106
+msgid "Application/Version"
+msgstr "Agent/Version"
+
+#: no source
+msgid "Applications Resource"
+msgstr ""
+
+#: no source
+msgid "app_id is required"
+msgstr ""
+
+#: no source
+msgid "app_secret is required"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:32
+msgid "Arabic"
+msgstr ""
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:22
+msgid "array"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:226
+msgid "Asker user information"
+msgstr ""
+
+#: apps/knowledge/task/handler.py:134
+msgid "Association problem failed {error}"
 msgstr ""
 
 #: apps/models_provider/api/provide.py:45
 msgid "attrs"
 msgstr ""
 
-#: apps/models_provider/api/provide.py:46
-msgid "props info"
+#: apps/application/flow/step_node/application_node/i_application_node.py:23
+#: apps/chat/serializers/chat.py:94
+msgid "Audio"
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:60
-msgid "Model type cannot be empty"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:23
+msgid "Audio file recognition - Tongyi Qwen"
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:85
-msgid "The current platform does not support downloading models"
+#: no source
+msgid "Auth Type"
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:143
-msgid "LLM"
+#: no source
+msgid "Authentication Configuration"
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:144
-msgid "Embedding Model"
+#: apps/models_provider/impl/xf_model_provider/model/tts/super_humanoid_tts.py:114
+msgid "Authentication failed (HTTP 401). Please check: 1) API URL is correct for TTS service; 2) APP ID, API Key, and API Secret are correct; 3) Your iFlytek account has TTS service enabled."
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:145
-msgid "Speech2Text"
+#: no source
+msgid "Authentication failed. Please verify that the parameters are correct"
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:146
-msgid "TTS"
+#: apps/chat/serializers/chat.py:67
+#: apps/chat/serializers/chat.py:69
+#: apps/chat/serializers/chat.py:71
+msgid "Authentication failed. Please verify that the parameters are correct."
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:147
-msgid "Vision Model"
+#: apps/common/auth/handle/impl/application_key.py:34
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:40
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:42
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:44
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:48
+#: apps/common/auth/handle/impl/user_token.py:317
+#: apps/trigger/handler/impl/trigger/event_trigger.py:120
+#: apps/trigger/handler/impl/trigger/event_trigger.py:123
+msgid "Authentication information is incorrect"
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:148
-msgid "Image Generation"
+#: apps/common/auth/authenticate.py:84
+#: apps/common/auth/authenticate.py:91
+#: apps/common/auth/authenticate.py:97
+#: apps/common/auth/authenticate.py:110
+#: apps/common/auth/authenticate.py:117
+#: apps/common/auth/authenticate.py:123
+#: apps/common/auth/authenticate.py:136
+#: apps/common/auth/authenticate.py:143
+#: apps/common/auth/authenticate.py:149
+msgid "Authentication information is incorrect! illegal user"
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:149
-msgid "Rerank"
+#: no source
+msgid "authentication type"
 msgstr ""
 
-#: apps/models_provider/base_model_provider.py:223
-msgid "The model does not support"
+#: no source
+msgid "Authorization address cannot be empty"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:42
-msgid ""
-"With the GTE-Rerank text sorting series model developed by Alibaba Tongyi "
-"Lab, developers can integrate high-quality text retrieval and sorting "
-"through the LlamaIndex framework."
+#: no source
+msgid "Authorization knowledge workspace"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:45
-msgid ""
-"Chinese (including various dialects such as Cantonese), English, Japanese, "
-"and Korean support free switching between multiple languages."
+#: no source
+msgid "Authorization knowledge workspace "
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:48
-msgid ""
-"CosyVoice is based on a new generation of large generative speech models, "
-"which can predict emotions, intonation, rhythm, etc. based on context, and "
-"has better anthropomorphic effects."
+#: no source
+msgid "Authorization model workspace"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:51
-msgid ""
-"Universal text vector is Tongyi Lab's multi-language text unified vector "
-"model based on the LLM base. It provides high-level vector services for "
-"multiple mainstream languages around the world and helps developers quickly "
-"convert text data into high-quality vector data."
+#: no source
+msgid "Authorization model workspace "
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:69
-msgid ""
-"Tongyi Wanxiang - a large image model for text generation, supports "
-"bilingual input in Chinese and English, and supports the input of reference "
-"pictures for reference content or reference style migration. Key styles "
-"include but are not limited to watercolor, oil painting, Chinese painting, "
-"sketch, flat illustration, two-dimensional, and 3D. Cartoon."
+#: no source
+msgid "Authorization tool workspace"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:95
-msgid "Alibaba Cloud Bailian"
+#: no source
+msgid "Authorization tool workspace "
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:53
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:50
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:74
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:77
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:61
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tti.py:43
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py:37
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:33
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:34
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:53
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:37
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:40
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:69
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:32
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/gemini_model_provider/model/stt.py:43
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:37
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:37
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:44
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:35
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:35
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:58
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:37
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:58
-#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:23
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:37
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:51
-#: apps/models_provider/impl/tencent_model_provider/model/tti.py:54
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:50
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:32
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/volcanic_engine_model_provider/model/tts.py:77
-#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:60
-#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:76
-#: apps/models_provider/impl/xf_model_provider/model/tts.py:101
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:32
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:50
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:34
-#: apps/models_provider/impl/xinference_model_provider/model/tts.py:44
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:31
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:56
-#: apps/models_provider/impl/zhipu_model_provider/model/tti.py:49
-msgid "Hello"
+#: no source
+msgid "Authorized pagination list for obtaining resources"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:36
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:46
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt.py:44
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:96
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:89
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:23
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:21
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:40
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:30
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/azure_model_provider/credential/stt.py:23
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:58
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:41
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:22
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:21
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:28
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/ollama_model_provider/credential/image.py:19
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:44
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:27
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:31
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:25
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:48
-#: apps/models_provider/impl/openai_model_provider/credential/stt.py:22
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:61
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:40
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:25
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:28
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:22
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:61
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:22
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:19
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:28
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:78
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/vllm_model_provider/credential/image.py:22
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:39
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:22
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:25
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:41
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:51
-#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:46
-#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:29
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/xf_model_provider/credential/stt.py:24
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:47
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:19
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:22
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:39
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:25
-#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:21
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:59
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:39
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:21
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:40
-#, python-brace-format
-msgid "{model_type} Model type is not supported"
+#: apps/knowledge/serializers/document.py:202
+msgid "Auto Clean"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:44
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:67
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:55
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt.py:53
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:105
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:98
-#, python-brace-format
-msgid "{key} is required"
+#: apps/application/serializers/application_api_key.py:23
+msgid "Availability"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:60
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:85
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:69
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt.py:67
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:121
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:113
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:43
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:65
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:42
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:61
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:50
-#: apps/models_provider/impl/azure_model_provider/credential/stt.py:40
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:77
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:58
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:65
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:42
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:38
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:64
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:44
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:45
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:51
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:45
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:67
-#: apps/models_provider/impl/openai_model_provider/credential/stt.py:39
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:80
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:58
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:45
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:44
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:39
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:80
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:40
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:30
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:47
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:104
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/vllm_model_provider/credential/image.py:42
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:55
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:42
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:42
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:58
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:68
-#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:38
-#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:38
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:50
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:84
-#: apps/models_provider/impl/xf_model_provider/credential/stt.py:41
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:65
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:41
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:40
-#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:37
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:77
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:56
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:41
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:64
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:59
-#, python-brace-format
-msgid ""
-"Verification failed, please check whether the parameters are correct: {error}"
+#: no source
+msgid "avatar"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:17
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:14
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:20
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:14
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:41
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:22
-msgid "Temperature"
+#: no source
+msgid "avatar url"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:18
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:21
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:16
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:42
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:16
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:23
-msgid ""
-"Higher values make the output more random, while lower values make it more "
-"focused and deterministic"
+#: apps/homepage/serializers/homepage.py:493
+msgid "Average Number of Conversation Turns per Person"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:30
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:43
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:29
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:50
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:31
-msgid "Output the maximum Tokens"
+#: apps/homepage/serializers/homepage.py:306
+#: apps/homepage/serializers/homepage.py:630
+msgid "Average tokens per request"
 msgstr ""
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:31
-msgid "Specify the maximum number of tokens that the model can generate."
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:43
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:15
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:74
-msgid "API URL"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:14
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:15
-msgid "Image size"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:15
-msgid "Specify the size of the generated image, such as: 1024x1024"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:34
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:40
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:43
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:43
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:41
-msgid "Number of pictures"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:34
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:40
-msgid "Specify the number of generated images"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:44
-msgid "Style"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:44
-msgid "Specify the style of generated images"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:48
-msgid "Default value, the image style is randomly output by the model"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:49
-msgid "photography"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:50
-msgid "Portraits"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:51
-msgid "3D cartoon"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:52
-msgid "animation"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:53
-msgid "painting"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:54
-msgid "watercolor"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:55
-msgid "sketch"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:56
-msgid "Chinese painting"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:57
-msgid "flat illustration"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:20
-msgid "Timbre"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:20
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:15
-msgid "Chinese sounds can support mixed scenes of Chinese and English"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:26
-msgid "Long Xiaochun"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:27
-msgid "Long Xiaoxia"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:28
-msgid "Long Xiaochen"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:29
-msgid "Long Xiaobai"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:30
-msgid "Long Laotie"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:31
-msgid "Long Shu"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:32
-msgid "Long Shuo"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:33
-msgid "Long Jing"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:34
-msgid "Long Miao"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:35
-msgid "Long Yue"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:36
-msgid "Long Yuan"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:37
-msgid "Long Fei"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:38
-msgid "Long Jielidou"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:39
-msgid "Long Tong"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:40
-msgid "Long Xiang"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:47
-msgid "Speaking speed"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:47
-msgid "[0.5, 2], the default is 1, usually one decimal place is enough"
-msgstr ""
-
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:28
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:32
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:35
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:64
-#: apps/models_provider/impl/azure_model_provider/credential/stt.py:28
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:63
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:46
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:27
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:26
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:32
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:46
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:62
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:63
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:30
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:53
-#: apps/models_provider/impl/openai_model_provider/credential/stt.py:27
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:66
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:45
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:30
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:32
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:27
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:66
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:27
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:32
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/vllm_model_provider/credential/image.py:27
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:65
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:27
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:30
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:46
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:56
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:55
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:72
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:34
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:71
-#: apps/models_provider/impl/xf_model_provider/credential/stt.py:29
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:52
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:40
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:27
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:29
-#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:26
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:64
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:44
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:26
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:51
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:45
-#, python-brace-format
-msgid "{key}  is required"
-msgstr ""
-
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:33
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:44
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:30
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:33
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:25
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:51
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:25
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:32
-msgid "Specify the maximum number of tokens that the model can generate"
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:36
-msgid ""
-"An update to Claude 2 that doubles the context window and improves "
-"reliability, hallucination rates, and evidence-based accuracy in long "
-"documents and RAG contexts."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:43
-msgid ""
-"Anthropic is a powerful model that can handle a variety of tasks, from "
-"complex dialogue and creative content generation to detailed command "
-"obedience."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:50
-msgid ""
-"The Claude 3 Haiku is Anthropic's fastest and most compact model, with near-"
-"instant responsiveness. The model can answer simple queries and requests "
-"quickly. Customers will be able to build seamless AI experiences that mimic "
-"human interactions. Claude 3 Haiku can process images and return text "
-"output, and provides 200K context windows."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:57
-msgid ""
-"The Claude 3 Sonnet model from Anthropic strikes the ideal balance between "
-"intelligence and speed, especially when it comes to handling enterprise "
-"workloads. This model offers maximum utility while being priced lower than "
-"competing products, and it's been engineered to be a solid choice for "
-"deploying AI at scale."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:64
-msgid ""
-"The Claude 3.5 Sonnet raises the industry standard for intelligence, "
-"outperforming competing models and the Claude 3 Opus in extensive "
-"evaluations, with the speed and cost-effectiveness of our mid-range models."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:71
-msgid ""
-"A faster, more affordable but still very powerful model that can handle a "
-"range of tasks including casual conversation, text analysis, summarization "
-"and document question answering."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:78
-msgid ""
-"Titan Text Premier is the most powerful and advanced model in the Titan Text "
-"series, designed to deliver exceptional performance for a variety of "
-"enterprise applications. With its cutting-edge features, it delivers greater "
-"accuracy and outstanding results, making it an excellent choice for "
-"organizations looking for a top-notch text processing solution."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:85
-msgid ""
-"Amazon Titan Text Lite is a lightweight, efficient model ideal for fine-"
-"tuning English-language tasks, including summarization and copywriting, "
-"where customers require smaller, more cost-effective, and highly "
-"customizable models."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:91
-msgid ""
-"Amazon Titan Text Express has context lengths of up to 8,000 tokens, making "
-"it ideal for a variety of high-level general language tasks, such as open-"
-"ended text generation and conversational chat, as well as support in "
-"retrieval-augmented generation (RAG). At launch, the model is optimized for "
-"English, but other languages are supported."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:97
-msgid ""
-"7B dense converter for rapid deployment and easy customization. Small in "
-"size yet powerful in a variety of use cases. Supports English and code, as "
-"well as 32k context windows."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:103
-msgid ""
-"Advanced Mistral AI large-scale language model capable of handling any "
-"language task, including complex multilingual reasoning, text understanding, "
-"transformation, and code generation."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:109
-msgid ""
-"Ideal for content creation, conversational AI, language understanding, R&D, "
-"and enterprise applications"
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:115
-msgid ""
-"Ideal for limited computing power and resources, edge devices, and faster "
-"training times."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:123
-msgid ""
-"Titan Embed Text is the largest embedding model in the Amazon Titan Embed "
-"series and can handle various text embedding tasks, such as text "
-"classification, text similarity calculation, etc."
-msgstr ""
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:28
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:47
-#, python-brace-format
-msgid "The following fields are required: {keys}"
-msgstr ""
-
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:44
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:76
-msgid "Verification failed, please check whether the parameters are correct"
-msgstr ""
-
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:28
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:29
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:29
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:28
-msgid "Picture quality"
-msgstr ""
-
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:17
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:17
-msgid ""
-"Try out the different sounds (Alloy, Echo, Fable, Onyx, Nova, and Sparkle) "
-"to find one that suits your desired tone and audience. The current voiceover "
-"is optimized for English."
-msgstr ""
-
-#: apps/models_provider/impl/deepseek_model_provider/deepseek_model_provider.py:24
-msgid "Good at common conversational tasks, supports 32K contexts"
-msgstr ""
-
-#: apps/models_provider/impl/deepseek_model_provider/deepseek_model_provider.py:29
-msgid "Good at handling programming tasks, supports 16K contexts"
-msgstr ""
-
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:32
-msgid "Latest Gemini 1.0 Pro model, updated with Google update"
-msgstr ""
-
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:36
-msgid "Latest Gemini 1.0 Pro Vision model, updated with Google update"
-msgstr ""
-
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:43
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:47
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:54
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:58
-msgid "Latest Gemini 1.5 Flash model, updated with Google updates"
-msgstr ""
-
-#: apps/models_provider/impl/gemini_model_provider/model/stt.py:53
-msgid "convert audio to text"
-msgstr ""
-
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:53
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:54
-msgid "Model catalog"
-msgstr ""
-
-#: apps/models_provider/impl/local_model_provider/local_model_provider.py:39
-msgid "local model"
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:30
-#: apps/models_provider/impl/ollama_model_provider/credential/image.py:23
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:48
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:35
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:43
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:24
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:44
-msgid "API domain name is invalid"
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:35
-#: apps/models_provider/impl/ollama_model_provider/credential/image.py:28
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:53
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:40
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:30
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:48
-msgid "The model does not exist, please download the model first"
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:56
-msgid ""
-"Llama 2 is a set of pretrained and fine-tuned generative text models ranging "
-"in size from 7 billion to 70 billion. This is a repository of 7B pretrained "
-"models. Links to other models can be found in the index at the bottom."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:60
-msgid ""
-"Llama 2 is a set of pretrained and fine-tuned generative text models ranging "
-"in size from 7 billion to 70 billion. This is a repository of 13B pretrained "
-"models. Links to other models can be found in the index at the bottom."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:64
-msgid ""
-"Llama 2 is a set of pretrained and fine-tuned generative text models ranging "
-"in size from 7 billion to 70 billion. This is a repository of 70B pretrained "
-"models. Links to other models can be found in the index at the bottom."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:68
-msgid ""
-"Since the Chinese alignment of Llama2 itself is weak, we use the Chinese "
-"instruction set to fine-tune meta-llama/Llama-2-13b-chat-hf with LoRA so "
-"that it has strong Chinese conversation capabilities."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:72
-msgid ""
-"Meta Llama 3: The most capable public product LLM to date. 8 billion "
-"parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:76
-msgid ""
-"Meta Llama 3: The most capable public product LLM to date. 70 billion "
-"parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:80
-msgid ""
-"Compared with previous versions, qwen 1.5 0.5b has significantly enhanced "
-"the model's alignment with human preferences and its multi-language "
-"processing capabilities. Models of all sizes support a context length of "
-"32768 tokens. 500 million parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:84
-msgid ""
-"Compared with previous versions, qwen 1.5 1.8b has significantly enhanced "
-"the model's alignment with human preferences and its multi-language "
-"processing capabilities. Models of all sizes support a context length of "
-"32768 tokens. 1.8 billion parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:88
-msgid ""
-"Compared with previous versions, qwen 1.5 4b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"4 billion parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:93
-msgid ""
-"Compared with previous versions, qwen 1.5 7b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"7 billion parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:97
-msgid ""
-"Compared with previous versions, qwen 1.5 14b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"14 billion parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:101
-msgid ""
-"Compared with previous versions, qwen 1.5 32b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"32 billion parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:105
-msgid ""
-"Compared with previous versions, qwen 1.5 72b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"72 billion parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:109
-msgid ""
-"Compared with previous versions, qwen 1.5 110b has significantly enhanced "
-"the model's alignment with human preferences and its multi-language "
-"processing capabilities. Models of all sizes support a context length of "
-"32768 tokens. 110 billion parameters."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:153
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:193
-msgid ""
-"Phi-3 Mini is Microsoft's 3.8B parameter, lightweight, state-of-the-art open "
-"model."
-msgstr ""
-
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:162
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:197
-msgid ""
-"A high-performance open embedding model with a large token context window."
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:16
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:16
-msgid ""
-"The image generation endpoint allows you to create raw images based on text "
-"prompts. When using the DALL·E 3, the image size can be 1024x1024, 1024x1792 "
-"or 1792x1024 pixels."
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:29
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:29
-msgid ""
-"\n"
-"By default, images are produced in standard quality, but with DALL·E 3 you "
-"can set quality: \"hd\" to enhance detail. Square, standard quality images "
-"are generated fastest.\n"
-"        "
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:44
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:44
-msgid ""
-"You can use DALL·E 3 to request 1 image at a time (requesting more images by "
-"issuing parallel requests), or use DALL·E 2 with the n parameter to request "
-"up to 10 images at a time."
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:35
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:119
-#: apps/models_provider/impl/siliconCloud_model_provider/siliconCloud_model_provider.py:118
-msgid "The latest gpt-3.5-turbo, updated with OpenAI adjustments"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:38
-msgid "Latest gpt-4, updated with OpenAI adjustments"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:40
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:99
-msgid ""
-"The latest GPT-4o, cheaper and faster than gpt-4-turbo, updated with OpenAI "
-"adjustments"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:43
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:102
-msgid ""
-"The latest gpt-4o-mini, cheaper and faster than gpt-4o, updated with OpenAI "
-"adjustments"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:46
-msgid "The latest gpt-4-turbo, updated with OpenAI adjustments"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:49
-msgid "The latest gpt-4-turbo-preview, updated with OpenAI adjustments"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:53
-msgid ""
-"gpt-3.5-turbo snapshot on January 25, 2024, supporting context length 16,385 "
-"tokens"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:57
-msgid ""
-"gpt-3.5-turbo snapshot on November 6, 2023, supporting context length 16,385 "
-"tokens"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:61
-msgid ""
-"[Legacy] gpt-3.5-turbo snapshot on June 13, 2023, will be deprecated on June "
-"13, 2024"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:65
-msgid ""
-"gpt-4o snapshot on May 13, 2024, supporting context length 128,000 tokens"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:69
-msgid ""
-"gpt-4-turbo snapshot on April 9, 2024, supporting context length 128,000 "
-"tokens"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:72
-msgid ""
-"gpt-4-turbo snapshot on January 25, 2024, supporting context length 128,000 "
-"tokens"
-msgstr ""
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:75
-msgid ""
-"gpt-4-turbo snapshot on November 6, 2023, supporting context length 128,000 "
-"tokens"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_cloud_model_provider/tencent_cloud_model_provider.py:58
-msgid "Tencent Cloud"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:41
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:88
-#, python-brace-format
-msgid "{keys} is required"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:14
-msgid "painting style"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:14
-msgid "If not passed, the default value is 201 (Japanese anime style)"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:18
-msgid "Not limited to style"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:19
-msgid "ink painting"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:20
-msgid "concept art"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:21
-msgid "Oil painting 1"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:22
-msgid "Oil Painting 2 (Van Gogh)"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:23
-msgid "watercolor painting"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:24
-msgid "pixel art"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:25
-msgid "impasto style"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:26
-msgid "illustration"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:27
-msgid "paper cut style"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:28
-msgid "Impressionism 1 (Monet)"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:29
-msgid "Impressionism 2"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:31
-msgid "classical portraiture"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:32
-msgid "black and white sketch"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:33
-msgid "cyberpunk"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:34
-msgid "science fiction style"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:35
-msgid "dark style"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:37
-msgid "vaporwave"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:38
-msgid "Japanese animation"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:39
-msgid "monster style"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:40
-msgid "Beautiful ancient style"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:41
-msgid "retro anime"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:42
-msgid "Game cartoon hand drawing"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:43
-msgid "Universal realistic style"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:50
-msgid "Generate image resolution"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:50
-msgid "If not transmitted, the default value is 768:768."
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:38
-msgid ""
-"The most effective version of the current hybrid model, the trillion-level "
-"parameter scale MOE-32K long article model. Reaching the absolute leading "
-"level on various benchmarks, with complex instructions and reasoning, "
-"complex mathematical capabilities, support for function call, and "
-"application focus optimization in fields such as multi-language translation, "
-"finance, law, and medical care"
-msgstr ""
-"The most effective version of the current hybrid model, the trillion-level "
-"parameter scale MOE-32K long article model. Reaching the absolute leading "
-"level on various benchmarks, with complex instructions and reasoning, "
-"complex mathematical capabilities, support for function call, and "
-"agent focus optimization in fields such as multi-language translation, "
-"finance, law, and medical care"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:45
-msgid ""
-"A better routing strategy is adopted to simultaneously alleviate the "
-"problems of load balancing and expert convergence. For long articles, the "
-"needle-in-a-haystack index reaches 99.9%"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:51
-msgid ""
-"Upgraded to MOE structure, the context window is 256k, leading many open "
-"source models in multiple evaluation sets such as NLP, code, mathematics, "
-"industry, etc."
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:57
-msgid ""
-"Hunyuan's latest version of the role-playing model, a role-playing model "
-"launched by Hunyuan's official fine-tuning training, is based on the Hunyuan "
-"model combined with the role-playing scene data set for additional training, "
-"and has better basic effects in role-playing scenes."
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:63
-msgid ""
-"Hunyuan's latest MOE architecture FunctionCall model has been trained with "
-"high-quality FunctionCall data and has a context window of 32K, leading in "
-"multiple dimensions of evaluation indicators."
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:69
-msgid ""
-"Hunyuan's latest code generation model, after training the base model with "
-"200B high-quality code data, and iterating on high-quality SFT data for half "
-"a year, the context long window length has been increased to 8K, and it "
-"ranks among the top in the automatic evaluation indicators of code "
-"generation in the five major languages; the five major languages In the "
-"manual high-quality evaluation of 10 comprehensive code tasks that consider "
-"all aspects, the performance is in the first echelon."
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:77
-msgid ""
-"Tencent's Hunyuan Embedding interface can convert text into high-quality "
-"vector data. The vector dimension is 1024 dimensions."
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:87
-msgid "Mixed element visual model"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:94
-msgid "Hunyuan graph model"
-msgstr ""
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:125
-msgid "Tencent Hunyuan"
-msgstr ""
-
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:24
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:42
-msgid "Facebook’s 125M parameter model"
-msgstr ""
-
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:25
-msgid "BAAI’s 7B parameter model"
-msgstr ""
-
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:26
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:35
 msgid "BAAI’s 13B parameter mode"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:16
-msgid ""
-"If the gap between width, height and 512 is too large, the picture rendering "
-"effect will be poor and the probability of excessive delay will increase "
-"significantly. Recommended ratio and corresponding width and height before "
-"super score: width*height"
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:33
+msgid "BAAI’s 7B parameter model"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:15
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:15
-msgid "timbre"
+#: no source
+msgid "Base DN cannot be empty"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:28
-msgid "speaking speed"
+#: apps/models_provider/api/model.py:51
+#: apps/models_provider/serializers/model_serializer.py:66
+#: apps/models_provider/serializers/model_serializer.py:252
+#: apps/models_provider/serializers/model_serializer.py:288
+#: apps/models_provider/serializers/model_serializer.py:361
+#: apps/models_provider/serializers/model_serializer.py:544
+msgid "base model"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:31
-msgid "[0.2,3], the default is 1, usually one decimal place is enough"
+#: apps/models_provider/serializers/model_serializer.py:264
+#: apps/models_provider/serializers/model_serializer.py:301
+msgid "base model【{model_name}】already exists"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:39
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:44
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:88
-msgid ""
-"The user goes to the model inference page of Volcano Ark to create an "
-"inference access point. Here, you need to enter ep-xxxxxxxxxx-yyyy to call "
-"it."
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:27
+msgid "Base URL"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:59
-msgid "Universal 2.0-Vincent Diagram"
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:21
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:21
+msgid "Base Url"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:64
-msgid "Universal 2.0Pro-Vincent Chart"
+#: apps/application/flow/common.py:282
+msgid "Basic information node is required"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:69
-msgid "Universal 1.4-Vincent Chart"
+#: no source
+msgid "Batch add chat user to group"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:74
-msgid "Animation 1.3.0-Vincent Picture"
+#: apps/knowledge/views/document.py:711
+#: apps/knowledge/views/document.py:712
+msgid "Batch add tags to documents"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:79
-msgid "Animation 1.3.1-Vincent Picture"
+#: no source
+msgid "Batch add user to group"
 msgstr ""
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:113
-msgid "volcano engine"
+#: apps/knowledge/views/problem.py:107
+#: apps/knowledge/views/problem.py:108
+#: apps/knowledge/views/problem.py:109
+msgid "Batch associated paragraphs"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:51
-#, python-brace-format
-msgid "{model_name} The model does not support"
+#: no source
+msgid "Batch associated shared paragraphs"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:24
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:53
-msgid ""
-"ERNIE-Bot-4 is a large language model independently developed by Baidu. It "
-"covers massive Chinese data and has stronger capabilities in dialogue Q&A, "
-"content creation and generation."
+#: no source
+msgid "Batch associated system paragraphs"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:27
-msgid ""
-"ERNIE-Bot is a large language model independently developed by Baidu. It "
-"covers massive Chinese data and has stronger capabilities in dialogue Q&A, "
-"content creation and generation."
+#: apps/common/constants/permission_constants.py:392
+msgid "Batch delete"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:30
-msgid ""
-"ERNIE-Bot-turbo is a large language model independently developed by Baidu. "
-"It covers massive Chinese data, has stronger capabilities in dialogue Q&A, "
-"content creation and generation, and has a faster response speed."
+#: apps/knowledge/views/tag.py:128
+msgid "Batch Delete a knowledge tag"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:33
-msgid ""
-"BLOOMZ-7B is a well-known large language model in the industry. It was "
-"developed and open sourced by BigScience and can output text in 46 languages "
-"and 13 programming languages."
+#: apps/application/views/application.py:316
+#: apps/application/views/application.py:317
+#: apps/application/views/application.py:318
+msgid "Batch delete applications"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:39
-msgid ""
-"Llama-2-13b-chat was developed by Meta AI and is open source. It performs "
-"well in scenarios such as coding, reasoning and knowledge application. "
-"Llama-2-13b-chat is a native open source version with balanced performance "
-"and effect, suitable for conversation scenarios."
+#: no source
+msgid "Batch delete chat user"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:42
-msgid ""
-"Llama-2-70b-chat was developed by Meta AI and is open source. It performs "
-"well in scenarios such as coding, reasoning, and knowledge application. "
-"Llama-2-70b-chat is a native open source version with high-precision effects."
+#: apps/knowledge/views/document.py:1114
+#: apps/knowledge/views/document.py:1115
+msgid "Batch Delete Documents Tag"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:45
-msgid ""
-"The Chinese enhanced version developed by the Qianfan team based on "
-"Llama-2-7b has performed well on Chinese knowledge bases such as CMMLU and C-"
-"EVAL."
+#: apps/chat/views/chat_record.py:107
+#: apps/chat/views/chat_record.py:108
+#: apps/chat/views/chat_record.py:109
+msgid "Batch delete history conversation"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:49
-msgid ""
-"Embedding-V1 is a text representation model based on Baidu Wenxin large "
-"model technology. It can convert text into a vector form represented by "
-"numerical values and can be used in text retrieval, information "
-"recommendation, knowledge mining and other scenarios. Embedding-V1 provides "
-"the Embeddings interface, which can generate corresponding vector "
-"representations based on input content. You can call this interface to input "
-"text into the model and obtain the corresponding vector representation for "
-"subsequent text processing and analysis."
+#: apps/knowledge/views/knowledge.py:143
+#: apps/knowledge/views/knowledge.py:144
+#: apps/knowledge/views/knowledge.py:145
+msgid "Batch delete knowledge"
 msgstr ""
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:66
-msgid "Thousand sails large model"
+#: apps/knowledge/views/tag.py:127
+msgid "Batch Delete Knowledge Tag"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:42
-msgid "Please outline this picture"
+#: apps/tools/views/tool.py:205
+#: apps/tools/views/tool.py:206
+#: apps/tools/views/tool.py:207
+msgid "Batch delete tools"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:15
-msgid "Speaker"
+#: apps/users/views/user.py:249
+#: apps/users/views/user.py:250
+#: apps/users/views/user.py:251
+msgid "Batch delete user"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:16
-msgid ""
-"Speaker, optional value: Please go to the console to add a trial or purchase "
-"speaker. After adding, the speaker parameter value will be displayed."
+#: apps/knowledge/views/problem.py:137
+#: apps/knowledge/views/problem.py:138
+#: apps/knowledge/views/problem.py:139
+#: apps/knowledge/views/termbase.py:93
+#: apps/knowledge/views/termbase.py:94
+#: apps/knowledge/views/termbase.py:95
+msgid "Batch deletion issues"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:21
-msgid "iFlytek Xiaoyan"
+#: no source
+msgid "Batch deletion shared issues"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:22
-msgid "iFlytek Xujiu"
+#: no source
+msgid "Batch deletion system issues"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:23
-msgid "iFlytek Xiaoping"
+#: apps/knowledge/views/termbase.py:128
+#: apps/knowledge/views/termbase.py:129
+#: apps/knowledge/views/termbase.py:130
+msgid "Batch export termbase"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:24
-msgid "iFlytek Xiaojing"
+#: apps/knowledge/views/paragraph.py:143
+#: apps/knowledge/views/paragraph.py:144
+#: apps/knowledge/views/paragraph.py:145
+msgid "Batch Generate Related"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:25
-msgid "iFlytek Xuxiaobao"
+#: no source
+msgid "Batch generate related"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:28
-msgid "Speech speed, optional value: [0-100], default is 50"
+#: apps/knowledge/views/document.py:748
+#: apps/knowledge/views/document.py:749
+#: apps/knowledge/views/document.py:750
+msgid "Batch generate related problems"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:39
-#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:50
-msgid "Chinese and English recognition"
+#: no source
+msgid "Batch generate related shared problems"
 msgstr ""
 
-#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:66
-msgid "iFlytek Spark"
+#: no source
+msgid "Batch generate related system problems"
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:15
-msgid ""
-"The image generation endpoint allows you to create raw images based on text "
-"prompts. The dimensions of the image can be 1024x1024, 1024x1792, or "
-"1792x1024 pixels."
+#: no source
+msgid "Batch generate shared related"
+msgstr ""
+
+#: no source
+msgid "Batch generate system related"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:393
+msgid "Batch move"
+msgstr ""
+
+#: apps/application/views/application.py:353
+#: apps/application/views/application.py:354
+#: apps/application/views/application.py:355
+msgid "Batch move applications"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:181
+#: apps/knowledge/views/knowledge.py:182
+#: apps/knowledge/views/knowledge.py:183
+msgid "Batch move knowledge"
+msgstr ""
+
+#: apps/tools/views/tool.py:243
+#: apps/tools/views/tool.py:244
+#: apps/tools/views/tool.py:245
+msgid "Batch move tools"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:81
+#: apps/knowledge/views/paragraph.py:82
+#: apps/knowledge/views/paragraph.py:83
+msgid "Batch Paragraph"
+msgstr ""
+
+#: apps/knowledge/views/document.py:633
+#: apps/knowledge/views/document.py:634
+msgid "Batch refresh document vector library"
+msgstr ""
+
+#: no source
+msgid "Batch refresh shared document vector library"
+msgstr ""
+
+#: no source
+msgid "Batch refresh system document vector library"
+msgstr ""
+
+#: no source
+msgid "Batch Remove Documents from Tag"
+msgstr ""
+
+#: no source
+msgid "Batch set user roles"
+msgstr ""
+
+#: no source
+msgid "Batch shared paragraph"
+msgstr ""
+
+#: apps/knowledge/views/document.py:553
+#: apps/knowledge/views/document.py:554
+#: apps/knowledge/views/document.py:555
+msgid "Batch sync documents"
+msgstr ""
+
+#: no source
+msgid "Batch sync shared documents"
+msgstr ""
+
+#: no source
+msgid "Batch sync system knowledges"
+msgstr ""
+
+#: no source
+msgid "Batch synchronize lark document"
+msgstr ""
+
+#: no source
+msgid "Batch system paragraph"
+msgstr ""
+
+#: apps/knowledge/views/document.py:672
+#: apps/knowledge/views/document.py:673
+msgid "Batch tokenize document library"
+msgstr ""
+
+#: apps/application/views/application.py:392
+#: apps/application/views/application.py:393
+#: apps/application/views/application.py:394
+msgid "Batch update application chat log clear policy"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:39
+msgid "Beautiful ancient style"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:27
+msgid "Bidding Status"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:31
+msgid "black and white sketch"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1310
+msgid "blank line"
+msgstr ""
+
+#: apps/oss/serializers/file.py:247
+msgid "Blocked unsafe redirect to internal host"
+msgstr ""
+
+#: no source
+msgid "BLOOMZ-7B is a well-known large language model in the industry. It was developed and open sourced by BigScience and can output text in 46 languages and 13 programming languages."
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:244
+msgid "body must be an array"
+msgstr ""
+
+#: no source
+msgid "Bot User Token is required"
+msgstr ""
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:25
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:13
+msgid "Branch id"
+msgstr ""
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:26
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:15
+msgid "Branch Type"
 msgstr ""
 
 #: apps/models_provider/impl/xinference_model_provider/credential/tti.py:29
-msgid ""
-"By default, images are generated in standard quality, you can set quality: "
-"\"hd\" to enhance detail. Square, standard quality images are generated "
-"fastest."
+msgid "By default, images are generated in standard quality, you can set quality: \"hd\" to enhance detail. Square, standard quality images are generated fastest."
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:42
-msgid ""
-"You can request 1 image at a time (requesting more images by making parallel "
-"requests), or up to 10 images at a time using the n parameter."
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:28
+msgid "\nBy default, images are produced in standard quality, but with DALL·E 3 you can set quality: \"hd\" to enhance detail. Square, standard quality images are generated fastest.\n        "
+msgstr ""
+
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:28
+msgid "       \nBy default, images are produced in standard quality.\n        "
+msgstr ""
+
+#: no source
+msgid "Callback URL is required"
+msgstr ""
+
+#: no source
+msgid "callback_url is required"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:199
+#: apps/knowledge/views/knowledge_workflow.py:200
+#: apps/knowledge/views/knowledge_workflow.py:201
+msgid "Cancel knowledge workflow action"
+msgstr ""
+
+#: no source
+msgid "Cancel shared task"
+msgstr ""
+
+#: no source
+msgid "Cancel shared tasks in batches"
+msgstr ""
+
+#: no source
+msgid "Cancel system task"
+msgstr ""
+
+#: no source
+msgid "Cancel system tasks in batches"
+msgstr ""
+
+#: apps/knowledge/views/document.py:438
+#: apps/knowledge/views/document.py:439
+#: apps/knowledge/views/document.py:440
+msgid "Cancel task"
+msgstr ""
+
+#: apps/knowledge/views/document.py:475
+#: apps/knowledge/views/document.py:476
+#: apps/knowledge/views/document.py:477
+msgid "Cancel tasks in batches"
+msgstr ""
+
+#: apps/users/serializers/user.py:671
+#: apps/users/serializers/user.py:674
+#: apps/users/serializers/user.py:685
+msgid "Cannot delete built-in role"
+msgstr ""
+
+#: apps/folders/serializers/folder.py:247
+msgid "Cannot delete root folder"
+msgstr ""
+
+#: apps/users/serializers/user.py:504
+msgid "Cannot modify administrator status"
+msgstr ""
+
+#: no source
+msgid "Cannot modify built-in role"
+msgstr ""
+
+#: no source
+msgid "Cannot remove member from built-in role"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:22
+msgid "Cantonese"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:23
+msgid "Cantonese female"
+msgstr ""
+
+#: apps/users/serializers/login.py:35
+#: apps/users/serializers/login.py:268
+msgid "captcha"
+msgstr ""
+
+#: apps/users/serializers/login.py:207
+msgid "Captcha code error or expiration"
+msgstr ""
+
+#: apps/users/serializers/login.py:200
+msgid "Captcha is required"
+msgstr ""
+
+#: no source
+msgid "CAS authentication failed"
+msgstr ""
+
+#: no source
+msgid "CAS Log in"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:68
+#: apps/models_provider/serializers/model_serializer.py:254
+#: apps/models_provider/serializers/model_serializer.py:290
+msgid "certification information"
+msgstr ""
+
+#: no source
+msgid "Change chat user password"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:1306
+msgid "Change Password"
+msgstr ""
+
+#: apps/users/serializers/user.py:1146
+#: apps/users/views/user.py:265
+#: apps/users/views/user.py:266
+#: apps/users/views/user.py:267
+#: apps/users/views/user.py:300
+#: apps/users/views/user.py:301
+#: apps/users/views/user.py:302
+msgid "Change password"
+msgstr ""
+
+#: apps/chat/views/chat.py:79
+#: apps/chat/views/chat.py:106
+#: apps/chat/views/chat.py:128
+#: apps/chat/views/chat.py:145
+#: apps/chat/views/chat.py:163
+#: apps/chat/views/chat.py:189
+#: apps/chat/views/chat.py:207
+#: apps/chat/views/chat.py:225
+#: apps/chat/views/chat.py:244
+#: apps/chat/views/chat_embed.py:27
+#: apps/chat/views/chat_record.py:35
+#: apps/chat/views/chat_record.py:54
+#: apps/chat/views/chat_record.py:74
+#: apps/chat/views/chat_record.py:92
+#: apps/chat/views/chat_record.py:112
+#: apps/chat/views/chat_record.py:130
+#: apps/chat/views/chat_record.py:150
+#: apps/chat/views/chat_record.py:170
+#: apps/chat/views/chat_record.py:191
+#: apps/oss/views/file.py:80
+msgid "Chat"
+msgstr ""
+
+#: no source
+msgid "chat background"
+msgstr ""
+
+#: no source
+msgid "chat background url"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:55
+msgid "Chat context"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:131
+msgid "Chat has been deleted"
+msgstr ""
+
+#: apps/application/api/application_chat_link.py:38
+#: apps/application/api/application_chat_record.py:46
+#: apps/application/api/application_chat_record.py:115
+#: apps/application/serializers/application_chat.py:49
+#: apps/application/serializers/application_chat_record.py:93
+#: apps/chat/api/vote_api.py:27
+#: apps/chat/serializers/chat_record.py:128
+#: apps/chat/serializers/chat_record.py:167
+msgid "Chat ID"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:35
+msgid "chat id"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:67
+msgid "Chat id does not exist"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:48
+msgid "Chat ID List"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:135
+msgid "Chat is not exist"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:34
+msgid "Chat record aggregation"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:33
+msgid "Chat record data aggregation"
+msgstr ""
+
+#: apps/application/api/application_chat_record.py:122
+#: apps/chat/api/vote_api.py:34
+msgid "Chat Record ID"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:72
+msgid "Chat record id"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:46
+msgid "Chat record IDs"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:52
+msgid "Chat record ids can not be empty"
+msgstr ""
+
+#: apps/application/views/application_chat_link.py:30
+#: apps/application/views/application_chat_link.py:50
+msgid "Chat record link"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:405
+#: apps/common/constants/permission_constants.py:431
+msgid "Chat User"
+msgstr ""
+
+#: no source
+msgid "Chat user"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:407
+msgid "Chat User Auth"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:71
+msgid "Chat user id"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:37
+#: apps/chat/serializers/chat_record.py:103
+#: apps/chat/serializers/chat_record.py:127
+#: apps/chat/serializers/chat_record.py:155
+#: apps/chat/serializers/chat_record.py:168
+msgid "Chat User ID"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:217
+msgid "Chat user ID"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:74
+msgid "Chat user Type"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:38
+msgid "Chat User Type"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:219
+msgid "Chat user type"
+msgstr ""
+
+#: no source
+msgid "Chat User/Authentication Configuration"
+msgstr ""
+
+#: no source
+msgid "Chat User/login"
+msgstr ""
+
+#: no source
+msgid "Chat User/login authentication"
+msgstr ""
+
+#: no source
+msgid "Chat User/logout"
+msgstr ""
+
+#: no source
+msgid "Chat User/Three-party login"
+msgstr ""
+
+#: apps/tools/views/tool.py:403
+#: apps/tools/views/tool.py:404
+#: apps/tools/views/tool.py:405
+msgid "Check code"
+msgstr ""
+
+#: no source
+msgid "Check if the fields are correct"
+msgstr ""
+
+#: apps/system_manage/serializers/valid_serializers.py:41
+msgid "check quantity"
+msgstr ""
+
+#: no source
+msgid "Check shared code"
+msgstr ""
+
+#: no source
+msgid "Check system code"
+msgstr ""
+
+#: apps/users/views/user.py:339
+#: apps/users/views/user.py:340
+#: apps/users/views/user.py:341
+msgid "Check whether the verification code is correct"
+msgstr ""
+
+#: no source
+msgid "Check workspace can it be deleted"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:26
+#: apps/chat/serializers/chat.py:97
+msgid "Child Nodes"
+msgstr ""
+
+#: no source
+msgid "Children"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:80
+msgid "Chinese (including various dialects such as Cantonese), English, Japanese, and Korean support free switching between multiple languages."
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:50
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:52
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:67
+msgid "Chinese and English recognition"
 msgstr ""
 
 #: apps/models_provider/impl/xinference_model_provider/credential/tts.py:20
@@ -4754,12 +1441,1367 @@ msgstr ""
 msgid "Chinese male"
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:22
-msgid "Japanese male"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:20
+msgid "Chinese medical"
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:23
-msgid "Cantonese female"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:57
+msgid "Chinese painting"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:21
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:14
+msgid "Chinese sounds can support mixed scenes of Chinese and English"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:16
+msgid "Chinese telephone universal"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:19
+msgid "Chinese, English, and Guangdong"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:45
+msgid "chunk size"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:50
+msgid "chunk size reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:47
+msgid "chunk size type"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:30
+msgid "classical portraiture"
+msgstr ""
+
+#: apps/application/serializers/application.py:1746
+msgid "Clean time"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:371
+msgid "Clear Policy"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:219
+#: apps/chat/serializers/chat.py:287
+#: apps/chat/serializers/chat.py:534
+msgid "Client id"
+msgstr ""
+
+#: no source
+msgid "Client ID cannot be empty"
+msgstr ""
+
+#: no source
+msgid "Client ID is required"
+msgstr ""
+
+#: no source
+msgid "Client secret cannot be empty"
+msgstr ""
+
+#: no source
+msgid "Client Secret is required"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:220
+#: apps/chat/serializers/chat.py:288
+#: apps/chat/serializers/chat.py:535
+msgid "Client Type"
+msgstr ""
+
+#: apps/users/serializers/user.py:974
+msgid "Code"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:44
+msgid "\nCode Llama Instruct is a fine-tuned version of Code Llama's instructions, designed to perform specific tasks.\n        "
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:37
+msgid "Code Llama is a language model specifically designed for code generation."
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:53
+msgid "Code Llama Python is a language model specifically designed for Python code generation."
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:67
+msgid "CodeQwen 1.5 Chat is a chat model version of CodeQwen 1.5."
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:60
+msgid "CodeQwen 1.5 is a language model for code generation with high performance."
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1307
+msgid "comma"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:18
+msgid "Commonly used in Chinese"
+msgstr ""
+
+#: apps/application/api/application_chat.py:88
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:19
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:20
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:19
+#: apps/application/serializers/application_chat.py:63
+msgid "Comparator"
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:80
+msgid "Compared with previous versions, qwen 1.5 0.5b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 500 million parameters."
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:84
+msgid "Compared with previous versions, qwen 1.5 1.8b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 1.8 billion parameters."
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:109
+msgid "Compared with previous versions, qwen 1.5 110b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 110 billion parameters."
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:97
+msgid "Compared with previous versions, qwen 1.5 14b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 14 billion parameters."
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:101
+msgid "Compared with previous versions, qwen 1.5 32b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 32 billion parameters."
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:88
+msgid "Compared with previous versions, qwen 1.5 4b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 4 billion parameters."
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:105
+msgid "Compared with previous versions, qwen 1.5 72b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 72 billion parameters."
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:93
+msgid "Compared with previous versions, qwen 1.5 7b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 7 billion parameters."
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:172
+msgid "complete"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:44
+msgid "Completion problem"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:68
+msgid "Completion Question"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:19
+msgid "concept art"
+msgstr ""
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:27
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:26
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:25
+msgid "Condition or|and"
+msgstr ""
+
+#: no source
+msgid "Config"
+msgstr ""
+
+#: no source
+msgid "Configuration information is wrong and failed to save"
+msgstr ""
+
+#: no source
+msgid "Confirm Password"
+msgstr ""
+
+#: no source
+msgid "Connection failed"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:220
+msgid "Consuming tokens"
+msgstr ""
+
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:14
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:38
+#: apps/chat/serializers/chat.py:206
+#: apps/knowledge/serializers/paragraph.py:70
+#: apps/knowledge/serializers/problem.py:28
+#: apps/knowledge/serializers/problem.py:32
+#: apps/knowledge/serializers/problem.py:236
+#: apps/knowledge/serializers/termbase.py:22
+#: apps/knowledge/serializers/termbase.py:29
+#: apps/knowledge/serializers/termbase.py:141
+msgid "content"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:50
+msgid "Content"
+msgstr ""
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:37
+msgid "Content cannot be empty"
+msgstr ""
+
+#: no source
+msgid "Content generated by AI"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:37
+msgid "Context Type"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:78
+#: apps/chat/serializers/chat.py:301
+#: apps/chat/serializers/chat.py:484
+msgid "Conversation does not exist"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:60
+#: apps/application/serializers/application_chat.py:214
+#: apps/application/serializers/application_chat.py:263
+#: apps/application/serializers/application_chat_link.py:56
+#: apps/application/serializers/application_chat_record.py:45
+#: apps/application/serializers/application_chat_record.py:203
+#: apps/application/serializers/application_chat_record.py:253
+#: apps/application/serializers/application_chat_record.py:371
+#: apps/application/serializers/application_chat_record.py:471
+#: apps/chat/serializers/chat.py:136
+#: apps/chat/serializers/chat.py:212
+#: apps/chat/serializers/chat.py:286
+#: apps/chat/serializers/chat_record.py:45
+msgid "Conversation ID"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:55
+msgid "Conversation list"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:398
+#: apps/common/constants/permission_constants.py:442
+msgid "Conversation log"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:224
+#: apps/application/serializers/application_chat_record.py:436
+#: apps/application/serializers/application_chat_record.py:514
+#: apps/chat/serializers/chat.py:388
+msgid "Conversation record does not exist"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:48
+#: apps/application/serializers/application_chat_record.py:206
+#: apps/application/serializers/application_chat_record.py:374
+#: apps/application/serializers/application_chat_record.py:474
+#: apps/chat/serializers/chat.py:80
+#: apps/chat/serializers/chat_record.py:48
+msgid "Conversation record id"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:302
+msgid "Conversation records that do not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:26
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:27
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:24
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:26
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:23
+msgid "Conversation storage type"
+msgstr ""
+
+#: no source
+msgid "convert audio to text"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:348
+msgid "Copy"
+msgstr ""
+
+#: no source
+msgid "Corp ID is required"
+msgstr ""
+
+#: no source
+msgid "corporation"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:89
+msgid "CosyVoice is based on a new generation of large generative speech models, which can predict emotions, intonation, rhythm, etc. based on context, and has better anthropomorphic effects."
+msgstr ""
+
+#: no source
+msgid "count"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:350
+msgid "Create"
+msgstr ""
+
+#: no source
+msgid "Create a lark knowledge base"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:21
+msgid "Create a new knowledge tag"
+msgstr ""
+
+#: no source
+msgid "Create a web site knowledge base"
+msgstr ""
+
+#: apps/application/views/application.py:55
+#: apps/application/views/application.py:56
+#: apps/application/views/application.py:57
+msgid "Create an application"
+msgstr ""
+
+#: apps/application/views/application_api_key.py:31
+#: apps/application/views/application_api_key.py:32
+#: apps/application/views/application_api_key.py:33
+msgid "Create application ApiKey"
+msgstr "Create agent ApiKey"
+
+#: apps/application/views/application_api_key.py:60
+#: apps/application/views/application_api_key.py:61
+msgid "Create application ApiKey List"
+msgstr "Create agent ApiKey List"
+
+#: apps/knowledge/views/knowledge.py:594
+#: apps/knowledge/views/knowledge.py:595
+#: apps/knowledge/views/knowledge.py:596
+msgid "Create base knowledge"
+msgstr ""
+
+#: no source
+msgid "Create chat user"
+msgstr ""
+
+#: apps/knowledge/views/document.py:53
+#: apps/knowledge/views/document.py:54
+#: apps/knowledge/views/document.py:55
+msgid "Create document"
+msgstr ""
+
+#: apps/knowledge/views/document.py:513
+#: apps/knowledge/views/document.py:514
+#: apps/knowledge/views/document.py:515
+msgid "Create documents in batches"
+msgstr ""
+
+#: apps/folders/views/folder.py:32
+#: apps/folders/views/folder.py:33
+#: apps/folders/views/folder.py:34
+msgid "Create folder"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:20
+msgid "Create Knowledge Tag"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:229
+#: apps/knowledge/views/knowledge_workflow.py:230
+#: apps/knowledge/views/knowledge_workflow.py:231
+msgid "Create knowledge workflow"
+msgstr ""
+
+#: apps/models_provider/views/model.py:61
+#: apps/models_provider/views/model.py:62
+#: apps/models_provider/views/model.py:63
+msgid "Create model"
+msgstr ""
+
+#: no source
+msgid "Create or update Chat User Group"
+msgstr ""
+
+#: apps/system_manage/views/email_setting.py:50
+#: apps/system_manage/views/email_setting.py:51
+#: apps/system_manage/views/email_setting.py:52
+msgid "Create or update email settings"
+msgstr ""
+
+#: no source
+msgid "Create or update role"
+msgstr ""
+
+#: no source
+msgid "Create or update role permission"
+msgstr ""
+
+#: no source
+msgid "Create or update user group"
+msgstr ""
+
+#: no source
+msgid "Create or update workspace"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:50
+#: apps/knowledge/views/paragraph.py:51
+msgid "Create Paragraph"
+msgstr ""
+
+#: apps/knowledge/views/problem.py:50
+#: apps/knowledge/views/problem.py:51
+#: apps/knowledge/views/problem.py:52
+msgid "Create question"
+msgstr ""
+
+#: no source
+msgid "Create shared base knowledge"
+msgstr ""
+
+#: no source
+msgid "Create shared document"
+msgstr ""
+
+#: no source
+msgid "Create shared documents in batches"
+msgstr ""
+
+#: no source
+msgid "Create shared paragraph"
+msgstr ""
+
+#: no source
+msgid "Create shared question"
+msgstr ""
+
+#: no source
+msgid "Create shared tool"
+msgstr ""
+
+#: no source
+msgid "Create shared web knowledge"
+msgstr ""
+
+#: no source
+msgid "Create system knowledge"
+msgstr ""
+
+#: no source
+msgid "Create system knowledges in batches"
+msgstr ""
+
+#: no source
+msgid "Create system paragraph"
+msgstr ""
+
+#: no source
+msgid "Create system question"
+msgstr ""
+
+#: no source
+msgid "Create SystemAPIKey"
+msgstr ""
+
+#: apps/knowledge/views/termbase.py:58
+#: apps/knowledge/views/termbase.py:59
+#: apps/knowledge/views/termbase.py:60
+msgid "Create termbase"
+msgstr ""
+
+#: apps/tools/views/tool.py:44
+#: apps/tools/views/tool.py:45
+#: apps/tools/views/tool.py:46
+msgid "Create tool"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:388
+msgid "Create Trigger"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:57
+#: apps/trigger/views/trigger.py:58
+#: apps/trigger/views/trigger.py:59
+msgid "Create trigger"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:254
+#: apps/trigger/views/trigger.py:255
+#: apps/trigger/views/trigger.py:256
+msgid "Create trigger in source"
+msgstr ""
+
+#: apps/application/serializers/application.py:456
+#: apps/knowledge/serializers/knowledge.py:190
+#: apps/models_provider/api/model.py:65
+#: apps/models_provider/serializers/model_serializer.py:363
+#: apps/models_provider/serializers/model_serializer.py:546
+#: apps/tools/serializers/tool.py:347
+#: apps/tools/serializers/tool.py:1695
+msgid "create user"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:643
+#: apps/users/views/user.py:175
+#: apps/users/views/user.py:176
+#: apps/users/views/user.py:177
+msgid "Create user"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:622
+#: apps/knowledge/views/knowledge.py:623
+#: apps/knowledge/views/knowledge.py:624
+msgid "Create web knowledge"
+msgstr ""
+
+#: apps/knowledge/views/document.py:1197
+#: apps/knowledge/views/document.py:1198
+#: apps/knowledge/views/document.py:1199
+msgid "Create Web site documents"
+msgstr ""
+
+#: no source
+msgid "Create Web site shared documents"
+msgstr ""
+
+#: apps/application/serializers/application.py:469
+#: apps/application/serializers/application.py:469
+msgid "Creation time"
+msgstr ""
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:32
+#: apps/system_manage/serializers/resource_mapping_serializers.py:114
+msgid "creator"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:230
+msgid "cron type requires cron_expression field"
+msgstr ""
+
+#: no source
+msgid "Cross domain list"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:30
+msgid "Cross-domain address"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:31
+msgid "Cross-domain list"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:13
+msgid "CueWord"
+msgstr ""
+
+#: apps/application/api/application_api.py:54
+#: apps/application/api/application_chat.py:110
+#: apps/application/api/application_chat_record.py:74
+#: apps/homepage/api/home_page_api.py:96
+#: apps/system_manage/api/resource_mapping.py:56
+#: apps/system_manage/api/user_resource_permission.py:207
+#: apps/system_manage/api/user_resource_permission.py:273
+#: apps/trigger/api/trigger.py:93
+#: apps/trigger/api/trigger_task.py:102
+msgid "Current page"
+msgstr ""
+
+#: apps/common/result/api.py:44
+msgid "current page"
+msgstr ""
+
+#: no source
+msgid "Currently only text messages are supported"
+msgstr ""
+
+#: no source
+msgid "Custom role"
+msgstr ""
+
+#: no source
+msgid "Custom theme field type error"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:32
+msgid "cyberpunk"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:34
+msgid "dark style"
+msgstr ""
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:83
+msgid "data source web node:{node_id} error{error}{traceback}"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:30
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:39
+msgid "Dataset id list"
+msgstr ""
+
+#: apps/application/serializers/application.py:606
+msgid "Dataset settings"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge_workflow.py:88
+msgid "datasource data"
+msgstr ""
+
+#: apps/application/serializers/application_stats.py:31
+msgid "date"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:291
+#: apps/chat/serializers/chat.py:536
+msgid "Debug"
+msgstr ""
+
+#: no source
+msgid "Debug shared Tool"
+msgstr ""
+
+#: no source
+msgid "Debug system tool"
+msgstr ""
+
+#: apps/tools/views/tool.py:99
+#: apps/tools/views/tool.py:100
+#: apps/tools/views/tool.py:101
+msgid "Debug Tool"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:74
+msgid "Deepseek is a large-scale language model with 13 billion parameters."
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:216
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:72
+msgid "default"
+msgstr ""
+
+#: no source
+msgid "Default user group cannot be deleted"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:41
+msgid "default value"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:49
+msgid "Default value, the image style is randomly output by the model"
+msgstr ""
+
+#: no source
+msgid "Default workspace cannot be deleted"
+msgstr ""
+
+#: apps/users/serializers/user.py:71
+msgid "defaultPermission"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:351
+msgid "Delete"
+msgstr ""
+
+#: apps/application/views/application_chat_record.py:196
+#: apps/application/views/application_chat_record.py:197
+#: apps/application/views/application_chat_record.py:198
+msgid "Delete a Annotation"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:101
+msgid "Delete a knowledge tag"
+msgstr ""
+
+#: apps/application/views/application_api_key.py:109
+#: apps/application/views/application_api_key.py:110
+#: apps/application/views/application_api_key.py:111
+msgid "Delete Application API_KEY"
+msgstr "Delete Agent API_KEY"
+
+#: no source
+msgid "Delete application API_KEY"
+msgstr "Delete agent API_KEY"
+
+#: no source
+msgid "Delete chat user"
+msgstr ""
+
+#: no source
+msgid "Delete chat user group"
+msgstr ""
+
+#: apps/knowledge/views/document.py:186
+#: apps/knowledge/views/document.py:187
+#: apps/knowledge/views/document.py:188
+msgid "Delete document"
+msgstr ""
+
+#: apps/knowledge/views/document.py:1072
+#: apps/knowledge/views/document.py:1073
+#: apps/knowledge/views/document.py:1074
+msgid "Delete document tags"
+msgstr ""
+
+#: apps/knowledge/views/document.py:593
+#: apps/knowledge/views/document.py:594
+#: apps/knowledge/views/document.py:595
+msgid "Delete documents in batches"
+msgstr ""
+
+#: apps/oss/views/file.py:59
+#: apps/oss/views/file.py:60
+#: apps/oss/views/file.py:61
+msgid "Delete file"
+msgstr ""
+
+#: apps/folders/views/folder.py:146
+#: apps/folders/views/folder.py:147
+#: apps/folders/views/folder.py:148
+msgid "Delete folder"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:87
+#: apps/chat/views/chat_record.py:88
+#: apps/chat/views/chat_record.py:89
+msgid "Delete history conversation"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:92
+#: apps/knowledge/views/knowledge.py:93
+#: apps/knowledge/views/knowledge.py:94
+msgid "Delete knowledge"
+msgstr ""
+
+#: no source
+msgid "Delete knowledge base"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:100
+msgid "Delete Knowledge Tag"
+msgstr ""
+
+#: apps/models_provider/views/model.py:138
+#: apps/models_provider/views/model.py:139
+#: apps/models_provider/views/model.py:140
+msgid "Delete model"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:239
+#: apps/knowledge/views/paragraph.py:240
+#: apps/knowledge/views/paragraph.py:241
+msgid "Delete paragraph"
+msgstr ""
+
+#: no source
+msgid "Delete personal system API_KEY"
+msgstr ""
+
+#: apps/knowledge/views/problem.py:167
+#: apps/knowledge/views/problem.py:168
+#: apps/knowledge/views/problem.py:169
+msgid "Delete question"
+msgstr ""
+
+#: no source
+msgid "Delete role"
+msgstr ""
+
+#: no source
+msgid "Delete shared document"
+msgstr ""
+
+#: no source
+msgid "Delete shared documents in batches"
+msgstr ""
+
+#: no source
+msgid "Delete shared knowledge"
+msgstr ""
+
+#: no source
+msgid "Delete shared paragraph"
+msgstr ""
+
+#: no source
+msgid "Delete shared question"
+msgstr ""
+
+#: no source
+msgid "Delete shared tool"
+msgstr ""
+
+#: no source
+msgid "Delete system document"
+msgstr ""
+
+#: no source
+msgid "Delete system document in batches"
+msgstr ""
+
+#: no source
+msgid "Delete system knowledge"
+msgstr ""
+
+#: no source
+msgid "Delete system knowledge in batches"
+msgstr ""
+
+#: no source
+msgid "Delete system paragraph"
+msgstr ""
+
+#: no source
+msgid "Delete system question"
+msgstr ""
+
+#: no source
+msgid "Delete system tool"
+msgstr ""
+
+#: no source
+msgid "Delete SystemAPIKey"
+msgstr ""
+
+#: apps/knowledge/views/termbase.py:163
+#: apps/knowledge/views/termbase.py:164
+#: apps/knowledge/views/termbase.py:165
+msgid "Delete termbase"
+msgstr ""
+
+#: no source
+msgid "Delete the System task source trigger"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:375
+#: apps/trigger/views/trigger.py:376
+#: apps/trigger/views/trigger.py:377
+msgid "Delete the task source trigger"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:150
+#: apps/trigger/views/trigger.py:151
+#: apps/trigger/views/trigger.py:152
+msgid "Delete the trigger"
+msgstr ""
+
+#: apps/tools/views/tool.py:175
+#: apps/tools/views/tool.py:176
+#: apps/tools/views/tool.py:177
+msgid "Delete tool"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:390
+msgid "Delete Trigger"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:175
+#: apps/trigger/views/trigger.py:176
+#: apps/trigger/views/trigger.py:177
+msgid "Delete trigger in batches"
+msgstr ""
+
+#: apps/users/views/user.py:206
+#: apps/users/views/user.py:207
+#: apps/users/views/user.py:208
+msgid "Delete user"
+msgstr ""
+
+#: no source
+msgid "Delete user group"
+msgstr ""
+
+#: no source
+msgid "Delete workspace"
+msgstr ""
+
+#: apps/application/views/application.py:170
+#: apps/application/views/application.py:171
+#: apps/application/views/application.py:172
+msgid "Deleting application"
+msgstr ""
+
+#: apps/application/views/application_chat.py:146
+#: apps/application/views/application_chat.py:147
+#: apps/application/views/application_chat.py:148
+#: apps/chat/views/chat.py:157
+#: apps/chat/views/chat.py:158
+#: apps/chat/views/chat.py:159
+msgid "dialogue"
+msgstr ""
+
+#: no source
+msgid "Dialogue log"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:397
+#: apps/common/constants/permission_constants.py:399
+#: apps/common/constants/permission_constants.py:419
+#: apps/common/constants/permission_constants.py:429
+#: apps/common/constants/permission_constants.py:441
+msgid "Dialogue users"
+msgstr ""
+
+#: apps/application/views/application_stats.py:28
+#: apps/application/views/application_stats.py:29
+#: apps/application/views/application_stats.py:30
+#: apps/homepage/views/homepage.py:232
+#: apps/homepage/views/homepage.py:233
+msgid "Dialogue-related statistical trends"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:24
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:22
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:22
+msgid "Dimensions"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:380
+msgid "Dingding"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:293
+msgid "DingTalk"
+msgstr "DingTalk App"
+
+#: no source
+msgid "dingtalk"
+msgstr "DingTalk"
+
+#: no source
+msgid "DingTalk application: {user}"
+msgstr ""
+
+#: no source
+msgid "DingTalk callback"
+msgstr ""
+
+#: no source
+msgid "DingTalk OAuth2 callback"
+msgstr ""
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:24
+msgid "Direct answer content"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:174
+#: apps/knowledge/serializers/document.py:250
+msgid "directly return similarity"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:771
+msgid "Directly return similarity"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:339
+#: apps/knowledge/views/paragraph.py:340
+#: apps/knowledge/views/paragraph.py:341
+msgid "Disassociation issue"
+msgstr ""
+
+#: no source
+msgid "Disassociation shared issue"
+msgstr ""
+
+#: no source
+msgid "Disassociation system issue"
+msgstr ""
+
+#: no source
+msgid "disclaimer"
+msgstr ""
+
+#: no source
+msgid "disclaimer value"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:38
+msgid "Display execution details"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:375
+#: apps/common/constants/permission_constants.py:402
+msgid "Display Settings"
+msgstr ""
+
+#: no source
+msgid "Display settings"
+msgstr ""
+
+#: no source
+msgid "Displaying knowledge sources is not enabled"
+msgstr ""
+
+#: apps/users/serializers/user.py:1104
+msgid "Do not send emails again within {seconds} seconds"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:78
+msgid "Do you want to reply again"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:22
+#: apps/application/flow/step_node/document_extract_node/i_document_extract_node.py:13
+#: apps/chat/serializers/chat.py:93
+msgid "document"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:355
+#: apps/common/constants/permission_constants.py:413
+#: apps/common/constants/permission_constants.py:423
+msgid "Document"
+msgstr ""
+
+#: no source
+msgid "Document does not belong to current knowledge"
+msgstr ""
+
+#: apps/application/api/application_chat_record.py:136
+msgid "Document ID"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:251
+#: apps/application/serializers/application_chat_record.py:378
+#: apps/application/serializers/application_chat_record.py:478
+msgid "Document id"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:358
+#: apps/knowledge/serializers/document.py:588
+#: apps/knowledge/serializers/document.py:685
+#: apps/knowledge/serializers/document.py:1002
+#: apps/knowledge/serializers/document.py:1699
+#: apps/knowledge/serializers/document.py:1774
+#: apps/knowledge/serializers/document.py:1815
+#: apps/knowledge/serializers/document.py:1880
+#: apps/knowledge/serializers/paragraph.py:97
+#: apps/knowledge/serializers/paragraph.py:109
+#: apps/knowledge/serializers/paragraph.py:206
+#: apps/knowledge/serializers/paragraph.py:340
+#: apps/knowledge/serializers/paragraph.py:438
+#: apps/knowledge/serializers/paragraph.py:475
+#: apps/knowledge/serializers/paragraph.py:554
+#: apps/knowledge/serializers/paragraph.py:603
+#: apps/knowledge/serializers/paragraph.py:780
+#: apps/knowledge/serializers/problem.py:37
+#: apps/knowledge/serializers/problem.py:52
+msgid "document id"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1871
+msgid "Document id does not belong to current knowledge"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1715
+#: apps/knowledge/serializers/document.py:1792
+#: apps/knowledge/serializers/document.py:1833
+#: apps/knowledge/serializers/document.py:1896
+msgid "Document id does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:236
+#: apps/knowledge/serializers/document.py:243
+msgid "document id list"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:601
+#: apps/knowledge/serializers/document.py:699
+msgid "document id not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:177
+#: apps/knowledge/serializers/document.py:480
+msgid "document is active"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:13
+#: apps/application/flow/step_node/knowledge_write_node/i_knowledge_write_node.py:20
+#: apps/knowledge/serializers/document.py:358
+msgid "document list"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:775
+msgid "Document meta"
+msgstr ""
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:53
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:54
+#: apps/knowledge/serializers/document.py:138
+#: apps/knowledge/serializers/document.py:138
+#: apps/knowledge/serializers/document.py:159
+#: apps/knowledge/serializers/document.py:159
+#: apps/knowledge/serializers/document.py:475
+msgid "document name"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:32
+msgid "document name relate problem"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:35
+msgid "document name relate problem reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:28
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:39
+msgid "document name relate problem type"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:774
+msgid "Document type"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:208
+#: apps/knowledge/serializers/document.py:209
+msgid "document url list"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:19
+msgid "domain"
+msgstr ""
+
+#: no source
+msgid "Download"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1378
+msgid "download callback url"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:372
+msgid "Download Original Document"
+msgstr ""
+
+#: no source
+msgid "Download shared source file"
+msgstr ""
+
+#: apps/knowledge/views/document.py:952
+#: apps/knowledge/views/document.py:953
+msgid "Download source file"
+msgstr ""
+
+#: no source
+msgid "Download system source file"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1377
+msgid "download url"
+msgstr ""
+
+#: no source
+msgid "draggable"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:43
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:43
+msgid "Duration"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:347
+msgid "Edit"
+msgstr ""
+
+#: no source
+msgid "Edit folder"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:65
+#: apps/knowledge/views/knowledge.py:66
+#: apps/knowledge/views/knowledge.py:67
+msgid "Edit knowledge"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:366
+#: apps/knowledge/views/knowledge_workflow.py:367
+#: apps/knowledge/views/knowledge_workflow.py:368
+msgid "Edit knowledge workflow"
+msgstr ""
+
+#: no source
+msgid "Edit Resource chat user group List"
+msgstr ""
+
+#: no source
+msgid "Edit Resource chat user List"
+msgstr ""
+
+#: no source
+msgid "Edit shared tool icon"
+msgstr ""
+
+#: no source
+msgid "Edit system tool icon"
+msgstr ""
+
+#: apps/tools/views/tool.py:428
+#: apps/tools/views/tool.py:429
+#: apps/tools/views/tool.py:430
+msgid "Edit tool icon"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:68
+#: apps/tools/views/tool_workflow.py:69
+#: apps/tools/views/tool_workflow.py:70
+msgid "Edit tool workflow"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:389
+msgid "Edit Trigger"
+msgstr ""
+
+#: apps/system_manage/views/user_resource_permission.py:142
+#: apps/system_manage/views/user_resource_permission.py:143
+#: apps/system_manage/views/user_resource_permission.py:144
+msgid "Edit user authorization status of resource"
+msgstr ""
+
+#: no source
+msgid "edition"
+msgstr ""
+
+#: apps/users/serializers/user.py:67
+#: apps/users/serializers/user.py:165
+#: apps/users/serializers/user.py:248
+#: apps/users/serializers/user.py:388
+#: apps/users/serializers/user.py:970
+#: apps/users/serializers/user.py:1085
+#: apps/users/serializers/user.py:1164
+msgid "Email"
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:34
+msgid "Email format error"
+msgstr ""
+
+#: apps/users/serializers/user.py:424
+msgid "Email is already in use"
+msgstr ""
+
+#: apps/users/api/user.py:154
+msgid "Email or Username"
+msgstr ""
+
+#: no source
+msgid "Email or username"
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:33
+#: apps/common/constants/exception_code_constants.py:45
+msgid "Email sending failed"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:352
+msgid "Email Setting"
+msgstr ""
+
+#: apps/system_manage/views/email_setting.py:55
+#: apps/system_manage/views/email_setting.py:70
+#: apps/system_manage/views/email_setting.py:86
+msgid "Email Settings"
+msgstr ""
+
+#: no source
+msgid "Email settings"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:52
+msgid "Email verification failed"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:373
+msgid "Embed third party"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:148
+msgid "Embedding Model"
+msgstr ""
+
+#: no source
+msgid "embedding model"
+msgstr ""
+
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:46
+msgid "Embedding-V1 is a text representation model based on Baidu Wenxin large model technology. It can convert text into a vector form represented by numerical values and can be used in text retrieval, information recommendation, knowledge mining and other scenarios. Embedding-V1 provides the Embeddings interface, which can generate corresponding vector representations based on input content. You can call this interface to input text into the model and obtain the corresponding vector representation for subsequent text processing and analysis."
+msgstr ""
+
+#: no source
+msgid "Enable"
+msgstr ""
+
+#: apps/users/serializers/login.py:37
+msgid "encryptedData"
+msgstr ""
+
+#: apps/common/job/clean_chat_job.py:45
+msgid "end clean chat log"
+msgstr ""
+
+#: apps/common/job/clean_debug_file_job.py:30
+msgid "end clean debug file"
+msgstr ""
+
+#: apps/application/serializers/application.py:278
+msgid "End of thinking process marker"
+msgstr ""
+
+#: apps/common/job/client_access_num_job.py:27
+msgid "end reset access_num"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:57
+#: apps/application/serializers/application_stats.py:41
+#: apps/homepage/serializers/homepage.py:92
+#: apps/homepage/serializers/homepage.py:153
+#: apps/homepage/serializers/homepage.py:219
+#: apps/homepage/serializers/homepage.py:391
+#: apps/homepage/serializers/homepage.py:518
+#: apps/homepage/serializers/homepage.py:658
+msgid "End time"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:411
+msgid "End--->Embedding document: {document_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:436
+msgid "End--->Embedding knowledge: {knowledge_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:147
+msgid "End--->Embedding paragraph: {paragraph_id_list}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:197
+msgid "End--->Embedding paragraph: {paragraph_id}"
+msgstr ""
+
+#: apps/knowledge/task/sync.py:33
+#: apps/knowledge/task/sync.py:55
+msgid "End--->End synchronization web knowledge base:{knowledge_id}"
+msgstr ""
+
+#: apps/knowledge/task/generate.py:107
+msgid "End--->Generate problem: {document_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:569
+msgid "End--->Tokenize document: {document_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:250
+msgid "End--->Tokenize paragraph: {paragraph_id}"
+msgstr ""
+
+#: apps/knowledge/task/embedding.py:137
+msgid "End--->Vectorized knowledge: {knowledge_id}"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:12
+msgid "Engine model type"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:21
+msgid "English"
 msgstr ""
 
 #: apps/models_provider/impl/xinference_model_provider/credential/tts.py:24
@@ -4770,226 +2812,640 @@ msgstr ""
 msgid "English male"
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:26
-msgid "Korean female"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:17
+msgid "English telephone universal"
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:37
-msgid ""
-"Code Llama is a language model specifically designed for code generation."
+#: apps/knowledge/serializers/document.py:1309
+msgid "enter"
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:44
-msgid ""
-"\n"
-"Code Llama Instruct is a fine-tuned version of Code Llama's instructions, "
-"designed to perform specific tasks.\n"
-"        "
+#: apps/application/serializers/application_chat.py:290
+msgid "Enterprise WeChat"
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:53
-msgid ""
-"Code Llama Python is a language model specifically designed for Python code "
-"generation."
+#: no source
+msgid "Enterprise WeChat customer service: "
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:60
-msgid ""
-"CodeQwen 1.5 is a language model for code generation with high performance."
+#: apps/application/serializers/application_chat.py:294
+msgid "Enterprise WeChat Robot"
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:67
-msgid "CodeQwen 1.5 Chat is a chat model version of CodeQwen 1.5."
+#: no source
+msgid "Enterprise WeChat user: "
 msgstr ""
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:74
-msgid "Deepseek is a large-scale language model with 13 billion parameters."
+#: apps/common/constants/permission_constants.py:378
+msgid "Enterprise WeiXin"
 msgstr ""
 
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:16
-msgid ""
-"Image size, only cogview-3-plus supports this parameter. Optional range: "
-"[1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440], the "
-"default is 1024x1024."
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:31
+msgid "ERNIE-Bot is a large language model independently developed by Baidu. It covers massive Chinese data and has stronger capabilities in dialogue Q&A, content creation and generation."
 msgstr ""
 
-#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:34
-msgid ""
-"Have strong multi-modal understanding capabilities. Able to understand up to "
-"five images simultaneously and supports video content understanding"
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:28
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:59
+msgid "ERNIE-Bot-4 is a large language model independently developed by Baidu. It covers massive Chinese data and has stronger capabilities in dialogue Q&A, content creation and generation."
+msgstr ""
+
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:34
+msgid "ERNIE-Bot-turbo is a large language model independently developed by Baidu. It covers massive Chinese data, has stronger capabilities in dialogue Q&A, content creation and generation, and has a faster response speed."
+msgstr ""
+
+#: apps/common/result/api.py:18
+#: apps/common/result/api.py:19
+#: apps/common/result/api.py:28
+#: apps/common/result/api.py:29
+msgid "error prompt"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:418
+#: apps/trigger/serializers/trigger.py:442
+msgid "Error source type"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:117
+msgid "Error trigger type"
+msgstr ""
+
+#: apps/trigger/handler/impl/trigger/event_trigger.py:80
+#: apps/trigger/handler/impl/trigger/event_trigger.py:81
+#: apps/trigger/handler/impl/trigger/event_trigger.py:82
+msgid "Event Trigger WebHook"
+msgstr ""
+
+#: apps/models_provider/views/provide.py:57
+#: apps/models_provider/views/provide.py:58
+#: apps/models_provider/views/provide.py:59
+msgid "Example of obtaining model list"
+msgstr ""
+
+#: apps/application/flow/step_node/loop_node/impl/base_loop_node.py:150
+msgid "Exceeding the maximum number of cycles"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:33
+msgid "Expiration time"
+msgstr ""
+
+#: no source
+msgid "expired"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:362
+msgid "Export"
+msgstr ""
+
+#: apps/application/views/application.py:142
+#: apps/application/views/application.py:143
+#: apps/application/views/application.py:144
+msgid "Export application"
+msgstr ""
+
+#: no source
+msgid "Export Application"
+msgstr ""
+
+#: apps/application/views/application_chat.py:95
+#: apps/application/views/application_chat.py:96
+#: apps/application/views/application_chat.py:97
+msgid "Export conversation"
+msgstr ""
+
+#: apps/knowledge/views/document.py:886
+#: apps/knowledge/views/document.py:887
+msgid "Export document"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:363
+#: apps/knowledge/views/knowledge.py:364
+msgid "Export knowledge base"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:390
+#: apps/knowledge/views/knowledge.py:391
+msgid "Export knowledge base containing images"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:417
+#: apps/knowledge/views/knowledge.py:418
+msgid "Export knowledge bundle"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:292
+#: apps/knowledge/views/knowledge_workflow.py:293
+#: apps/knowledge/views/knowledge_workflow.py:294
+msgid "Export knowledge workflow"
+msgstr ""
+
+#: no source
+msgid "Export operate log"
+msgstr ""
+
+#: no source
+msgid "Export shared document"
+msgstr ""
+
+#: no source
+msgid "Export shared knowledge base"
+msgstr ""
+
+#: no source
+msgid "Export shared knowledge base containing images"
+msgstr ""
+
+#: no source
+msgid "Export shared knowledge bundle"
+msgstr ""
+
+#: no source
+msgid "Export shared tool"
+msgstr ""
+
+#: no source
+msgid "Export system knowledge"
+msgstr ""
+
+#: no source
+msgid "Export system knowledge base"
+msgstr ""
+
+#: no source
+msgid "Export system knowledge base containing images"
+msgstr ""
+
+#: no source
+msgid "Export system knowledge bundle"
+msgstr ""
+
+#: no source
+msgid "Export system tool"
+msgstr ""
+
+#: apps/tools/views/tool.py:374
+#: apps/tools/views/tool.py:375
+#: apps/tools/views/tool.py:376
+msgid "Export tool"
+msgstr ""
+
+#: apps/knowledge/views/document.py:919
+#: apps/knowledge/views/document.py:920
+msgid "Export Zip document"
+msgstr ""
+
+#: no source
+msgid "Export Zip shared document"
+msgstr ""
+
+#: no source
+msgid "Export Zip system knowledge"
+msgstr ""
+
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:31
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:64
+msgid "Facebook’s 125M parameter model"
+msgstr ""
+
+#: no source
+msgid "Fail"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:312
+msgid "Failed document count"
+msgstr ""
+
+#: apps/users/views/user.py:402
+msgid "Failed to change password"
+msgstr ""
+
+#: apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py:65
+#: apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py:59
+msgid "Failed to generate video"
+msgstr ""
+
+#: no source
+msgid "Failed to get Lark collaborators"
+msgstr ""
+
+#: no source
+msgid "Failed to get lark document list!"
+msgstr ""
+
+#: no source
+msgid "Failed to get Lark user details"
+msgstr ""
+
+#: no source
+msgid "Failed to get WeCom access token"
+msgstr ""
+
+#: no source
+msgid "Failed to get WeCom agent info"
+msgstr ""
+
+#: no source
+msgid "Failed to get WeCom department users"
+msgstr ""
+
+#: no source
+msgid "Failed to get WeCom user info"
+msgstr ""
+
+#: apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py:92
+msgid "Failed to obtain the image"
+msgstr ""
+
+#: no source
+msgid "Failed to obtain user information"
+msgstr ""
+
+#: apps/knowledge/task/embedding.py:28
+#: apps/knowledge/task/embedding.py:85
+msgid "Failed to obtain vector model: {error} {traceback}"
+msgstr ""
+
+#: apps/oss/serializers/file.py:202
+msgid "Failed to resolve host: {error}"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:358
+#: apps/knowledge/serializers/knowledge.py:387
+msgid "Failed to send the vectorization task, please try again later!"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:80
+msgid "Faster, more affordable TTS model"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:216
+msgid "Feedback reason"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:379
+msgid "Feishu"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:601
+msgid "field has no value set"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:273
+msgid "field label"
+msgstr ""
+
+#: no source
+msgid "Field mapping cannot be empty"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:272
+msgid "field name"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:56
+msgid "Field: {name} No value set"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:613
+msgid "Field: {name} Type: {type} Value: {value} Type conversion error"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:98
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:74
+msgid "Field: {name} Type: {_type} is required"
+msgstr ""
+
+#: no source
+msgid "Field: {name} Type: {_type} Value: {value} Type conversion error"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:81
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:112
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:57
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:88
+#: apps/trigger/handler/impl/trigger/event_trigger.py:48
+msgid "Field: {name} Type: {_type} Value: {value} Type error"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:76
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:52
+#: apps/trigger/handler/impl/trigger/event_trigger.py:43
+msgid "Field: {name} Type: {_type} Value: {value} Unsupported this type"
+msgstr ""
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:21
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:22
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:21
+msgid "Fields"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:255
+msgid "fields only support string|int|dict|array|float"
+msgstr ""
+
+#: apps/application/serializers/application.py:581
+#: apps/application/serializers/application.py:976
+#: apps/knowledge/serializers/document.py:216
+#: apps/knowledge/serializers/document.py:222
+#: apps/knowledge/serializers/document.py:1881
+#: apps/knowledge/serializers/knowledge.py:116
+#: apps/knowledge/serializers/knowledge_workflow.py:93
+#: apps/oss/serializers/file.py:69
+#: apps/tools/serializers/tool.py:908
+#: apps/tools/serializers/tool.py:1529
+#: apps/tools/serializers/tool_workflow.py:124
+msgid "file"
+msgstr ""
+
+#: apps/oss/views/file.py:23
+#: apps/oss/views/file.py:44
+#: apps/oss/views/file.py:64
+msgid "File"
+msgstr ""
+
+#: apps/application/serializers/application.py:1748
+msgid "File clean time"
+msgstr ""
+
+#: apps/application/serializers/application.py:1756
+msgid "File clean time cannot exceed clean time"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:138
+msgid "file count limit"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:197
+#: apps/knowledge/serializers/document.py:216
+#: apps/knowledge/serializers/document.py:222
+msgid "file list"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:764
+msgid "File not exist. Only manually uploaded documents are supported"
+msgstr ""
+
+#: apps/oss/serializers/file.py:109
+msgid "File not found"
+msgstr ""
+
+#: apps/oss/serializers/file.py:250
+msgid "File size exceeds limit"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:137
+msgid "file size limit"
+msgstr ""
+
+#: apps/oss/serializers/file.py:224
+msgid "File upload is not enabled"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:28
+msgid "Filipino language"
+msgstr ""
+
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:35
+msgid "First frame url"
+msgstr ""
+
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:53
+msgid "First frame url cannot be empty"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:58
+msgid "flat illustration"
+msgstr ""
+
+#: no source
+msgid "float icon"
+msgstr ""
+
+#: no source
+msgid "float icon url"
+msgstr ""
+
+#: no source
+msgid "Float location field type error"
+msgstr ""
+
+#: no source
+msgid "float location type"
+msgstr ""
+
+#: no source
+msgid "float location value"
+msgstr ""
+
+#: no source
+msgid "float location x"
+msgstr ""
+
+#: no source
+msgid "float location y"
 msgstr ""
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:37
-msgid ""
-"Focus on single picture understanding. Suitable for scenarios requiring "
-"efficient image analysis"
+msgid "Focus on single picture understanding. Suitable for scenarios requiring efficient image analysis"
 msgstr ""
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:40
-msgid ""
-"Focus on single picture understanding. Suitable for scenarios requiring "
-"efficient image analysis (free)"
+msgid "Focus on single picture understanding. Suitable for scenarios requiring efficient image analysis (free)"
 msgstr ""
 
-#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:46
-msgid ""
-"Quickly and accurately generate images based on user text descriptions. "
-"Resolution supports 1024x1024"
+#: apps/common/constants/permission_constants.py:443
+#: apps/common/constants/permission_constants.py:444
+#: apps/common/constants/permission_constants.py:445
+#: apps/folders/views/folder.py:38
+#: apps/folders/views/folder.py:72
+#: apps/folders/views/folder.py:99
+#: apps/folders/views/folder.py:131
+#: apps/folders/views/folder.py:151
+msgid "Folder"
+msgstr ""
+
+#: no source
+msgid "folder"
+msgstr "Folder"
+
+#: apps/folders/serializers/folder.py:98
+msgid "Folder depth cannot exceed 10000 levels"
+msgstr ""
+
+#: no source
+msgid "Folder depth cannot exceed 5 levels"
+msgstr ""
+
+#: apps/folders/models/folder.py:8
+#: apps/folders/models/folder.py:19
+#: apps/folders/serializers/folder.py:128
+msgid "folder description"
+msgstr ""
+
+#: apps/folders/serializers/folder.py:188
+#: apps/folders/serializers/folder.py:245
+msgid "Folder does not exist"
+msgstr ""
+
+#: apps/application/api/application_api.py:68
+#: apps/application/serializers/application.py:302
+#: apps/application/serializers/application.py:347
+#: apps/application/serializers/application.py:447
+#: apps/folders/serializers/folder.py:126
+#: apps/folders/serializers/folder.py:176
+#: apps/knowledge/serializers/common.py:66
+#: apps/knowledge/serializers/knowledge.py:110
+#: apps/knowledge/serializers/knowledge.py:121
+#: apps/knowledge/serializers/knowledge.py:176
+#: apps/knowledge/serializers/knowledge.py:885
+#: apps/tools/serializers/tool.py:319
+#: apps/tools/serializers/tool.py:342
+#: apps/tools/serializers/tool.py:911
+#: apps/tools/serializers/tool.py:1687
+msgid "folder id"
+msgstr ""
+
+#: apps/application/serializers/application.py:582
+msgid "Folder ID"
+msgstr ""
+
+#: apps/folders/models/folder.py:6
+#: apps/folders/models/folder.py:17
+#: apps/folders/serializers/folder.py:127
+msgid "folder name"
+msgstr ""
+
+#: apps/folders/serializers/folder.py:153
+#: apps/folders/serializers/folder.py:201
+#: apps/folders/serializers/folder.py:222
+msgid "Folder name already exists"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:261
+#: apps/knowledge/serializers/knowledge.py:292
+#: apps/tools/serializers/tool.py:1703
+msgid "Folder not found"
+msgstr ""
+
+#: no source
+msgid "Folder token"
+msgstr ""
+
+#: no source
+msgid "folder token"
+msgstr ""
+
+#: apps/folders/serializers/folder.py:129
+msgid "folder user id"
+msgstr ""
+
+#: apps/application/flow/step_node/form_node/i_form_node.py:20
+msgid "Form Configuration"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:27
+#: apps/application/flow/step_node/form_node/i_form_node.py:22
+msgid "Form Data"
+msgstr ""
+
+#: apps/application/flow/step_node/form_node/i_form_node.py:21
+msgid "Form output content"
+msgstr ""
+
+#: no source
+msgid "forum url"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:35
+msgid "French"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:46
+msgid "function"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:336
+msgid "function content"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1169
+msgid "Function does not exist"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1150
+msgid "function ID"
+msgstr ""
+
+#: no source
+msgid "Function {name} is unavailable"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge_workflow.py:302
+msgid "function_name"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:41
+msgid "Game cartoon hand drawing"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:364
+msgid "Generate"
 msgstr ""
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:49
-msgid ""
-"Generate high-quality images based on user text descriptions, supporting "
-"multiple image sizes"
+msgid "Generate high-quality images based on user text descriptions, supporting multiple image sizes"
 msgstr ""
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:52
-msgid ""
-"Generate high-quality images based on user text descriptions, supporting "
-"multiple image sizes (free)"
+msgid "Generate high-quality images based on user text descriptions, supporting multiple image sizes (free)"
 msgstr ""
 
-#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:75
-msgid "zhipu AI"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:49
+msgid "Generate image resolution"
 msgstr ""
 
-#: apps/models_provider/serializers/model_apply_serializers.py:32
-#: apps/models_provider/serializers/model_apply_serializers.py:37
-msgid "vector text"
+#: apps/knowledge/task/generate.py:103
+msgid "Generate issue based on document: {document_id} error {error}{traceback}"
 msgstr ""
 
-#: apps/models_provider/serializers/model_apply_serializers.py:33
-msgid "vector text list"
+#: apps/application/views/application_chat.py:162
+#: apps/application/views/application_chat.py:163
+#: apps/application/views/application_chat.py:164
+msgid "generate prompt"
 msgstr ""
 
-#: apps/models_provider/serializers/model_apply_serializers.py:41
-msgid "text"
+#: apps/knowledge/views/knowledge.py:482
+#: apps/knowledge/views/knowledge.py:483
+#: apps/knowledge/views/knowledge.py:484
+msgid "Generate related"
 msgstr ""
 
-#: apps/models_provider/serializers/model_apply_serializers.py:42
-msgid "metadata"
+#: no source
+msgid "Generate related documents"
 msgstr ""
 
-#: apps/models_provider/serializers/model_apply_serializers.py:47
-msgid "query"
+#: apps/application/views/application_chat_link.py:24
+#: apps/application/views/application_chat_link.py:25
+#: apps/application/views/application_chat_link.py:26
+msgid "Generate share link"
 msgstr ""
 
-#: apps/models_provider/serializers/model_serializer.py:44
-#: apps/models_provider/serializers/model_serializer.py:257
-msgid "parameter configuration"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:36
+msgid "German"
 msgstr ""
 
-#: apps/models_provider/serializers/model_serializer.py:45
-#: apps/models_provider/serializers/model_serializer.py:222
-#: apps/models_provider/serializers/model_serializer.py:258
-msgid "certification information"
+#: apps/knowledge/views/problem.py:79
+#: apps/knowledge/views/problem.py:80
+#: apps/knowledge/views/problem.py:81
+msgid "Get a list of associated paragraphs"
 msgstr ""
 
-#: apps/models_provider/serializers/model_serializer.py:118
-msgid "Shared models cannot be deleted or modified"
+#: no source
+msgid "Get a list of associated shared paragraphs"
 msgstr ""
 
-#: apps/models_provider/serializers/model_serializer.py:230
-#: apps/models_provider/serializers/model_serializer.py:269
-#, python-brace-format
-msgid "base model【{model_name}】already exists"
-msgstr ""
-
-#: apps/models_provider/serializers/model_serializer.py:309
-msgid "Model saving failed"
-msgstr ""
-
-#: apps/models_provider/views/model.py:60
-#: apps/models_provider/views/model.py:61
-#: apps/models_provider/views/model.py:62 apps/shared/views/shared_model.py:55
-#: apps/shared/views/shared_model.py:56 apps/shared/views/shared_model.py:57
-msgid "Create model"
-msgstr ""
-
-#: apps/models_provider/views/model.py:90
-#: apps/models_provider/views/model.py:91
-#: apps/models_provider/views/model.py:92 apps/shared/views/shared_model.py:84
-#: apps/shared/views/shared_model.py:85 apps/shared/views/shared_model.py:86
-msgid "Query model list"
-msgstr ""
-
-#: apps/models_provider/views/model.py:107
-#: apps/models_provider/views/model.py:108
-#: apps/models_provider/views/model.py:109
-#: apps/shared/views/shared_model.py:101 apps/shared/views/shared_model.py:102
-#: apps/shared/views/shared_model.py:103
-msgid "Update model"
-msgstr ""
-
-#: apps/models_provider/views/model.py:125
-#: apps/models_provider/views/model.py:126
-#: apps/models_provider/views/model.py:127
-#: apps/shared/views/shared_model.py:119 apps/shared/views/shared_model.py:120
-#: apps/shared/views/shared_model.py:121
-msgid "Delete model"
-msgstr ""
-
-#: apps/models_provider/views/model.py:140
-#: apps/models_provider/views/model.py:141
-#: apps/models_provider/views/model.py:142
-#: apps/shared/views/shared_model.py:133 apps/shared/views/shared_model.py:134
-#: apps/shared/views/shared_model.py:135
-msgid "Query model details"
-msgstr ""
-
-#: apps/models_provider/views/model.py:155
-#: apps/models_provider/views/model.py:156
-#: apps/models_provider/views/model.py:157
-#: apps/shared/views/shared_model.py:148 apps/shared/views/shared_model.py:149
-#: apps/shared/views/shared_model.py:150
-msgid "Get model parameter form"
-msgstr ""
-
-#: apps/models_provider/views/model.py:167
-#: apps/models_provider/views/model.py:168
-#: apps/models_provider/views/model.py:169
-#: apps/shared/views/shared_model.py:160 apps/shared/views/shared_model.py:161
-#: apps/shared/views/shared_model.py:162
-msgid "Save model parameter form"
-msgstr ""
-
-#: apps/models_provider/views/model.py:187
-#: apps/models_provider/views/model.py:189
-#: apps/models_provider/views/model.py:191
-#: apps/shared/views/shared_model.py:179 apps/shared/views/shared_model.py:181
-#: apps/shared/views/shared_model.py:183
-msgid ""
-"Query model meta information, this interface does not carry authentication "
-"information"
-msgstr ""
-
-#: apps/models_provider/views/model.py:204
-#: apps/models_provider/views/model.py:205
-#: apps/models_provider/views/model.py:206
-#: apps/shared/views/shared_model.py:196 apps/shared/views/shared_model.py:197
-#: apps/shared/views/shared_model.py:198
-msgid "Pause model download"
-msgstr ""
-
-#: apps/models_provider/views/model.py:222
-#: apps/models_provider/views/model.py:223
-#: apps/models_provider/views/model.py:224
-msgid "Get Share model"
-msgstr ""
-
-#: apps/models_provider/views/model_apply.py:25
-#: apps/models_provider/views/model_apply.py:26
-#: apps/models_provider/views/model_apply.py:27
-#: apps/models_provider/views/model_apply.py:37
-#: apps/models_provider/views/model_apply.py:38
-#: apps/models_provider/views/model_apply.py:39
-msgid "Vectorization documentation"
-msgstr ""
-
-#: apps/models_provider/views/model_apply.py:49
-#: apps/models_provider/views/model_apply.py:50
-#: apps/models_provider/views/model_apply.py:51
-msgid "Reorder documents"
+#: no source
+msgid "Get a list of associated system paragraphs"
 msgstr ""
 
 #: apps/models_provider/views/provide.py:21
@@ -5004,1479 +3460,220 @@ msgstr ""
 msgid "Get a list of model types"
 msgstr ""
 
-#: apps/models_provider/views/provide.py:57
-#: apps/models_provider/views/provide.py:58
-#: apps/models_provider/views/provide.py:59
-msgid "Example of obtaining model list"
+#: apps/knowledge/views/paragraph.py:310
+#: apps/knowledge/views/paragraph.py:311
+#: apps/knowledge/views/paragraph.py:312
+msgid "Get a list of paragraph questions"
 msgstr ""
 
-#: apps/models_provider/views/provide.py:75
-#: apps/models_provider/views/provide.py:76
-#: apps/models_provider/views/provide.py:77
-msgid "Get model default parameters"
+#: apps/knowledge/views/document.py:268
+#: apps/knowledge/views/document.py:269
+#: apps/knowledge/views/document.py:270
+msgid "Get a list of segment IDs"
 msgstr ""
 
-#: apps/models_provider/views/provide.py:92
-#: apps/models_provider/views/provide.py:93
-#: apps/models_provider/views/provide.py:94
-msgid "Get the model creation form"
-msgstr ""
-
-#: apps/oss/serializers/file.py:80
-msgid "File not found"
-msgstr ""
-
-#: apps/oss/views/file.py:21 apps/oss/views/file.py:22
-#: apps/oss/views/file.py:23
-msgid "Upload file"
-msgstr ""
-
-#: apps/oss/views/file.py:27 apps/oss/views/file.py:41
-#: apps/oss/views/file.py:53
-msgid "File"
-msgstr ""
-
-#: apps/oss/views/file.py:36 apps/oss/views/file.py:37
-#: apps/oss/views/file.py:38
-msgid "Get file"
-msgstr ""
-
-#: apps/oss/views/file.py:48 apps/oss/views/file.py:49
-#: apps/oss/views/file.py:50
-msgid "Delete file"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:30
-#: apps/resource_manage/views/document.py:31
-#: apps/resource_manage/views/document.py:32
-msgid "Create system knowledge"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:36
-#: apps/resource_manage/views/document.py:56
-#: apps/resource_manage/views/document.py:83
-#: apps/resource_manage/views/document.py:113
-#: apps/resource_manage/views/document.py:130
-#: apps/resource_manage/views/document.py:155
-#: apps/resource_manage/views/document.py:183
-#: apps/resource_manage/views/document.py:210
-#: apps/resource_manage/views/document.py:237
-#: apps/resource_manage/views/document.py:267
-#: apps/resource_manage/views/document.py:296
-#: apps/resource_manage/views/document.py:317
-#: apps/resource_manage/views/document.py:345
-#: apps/resource_manage/views/document.py:362
-#: apps/resource_manage/views/document.py:383
-#: apps/resource_manage/views/document.py:411
-#: apps/resource_manage/views/document.py:435
-#: apps/resource_manage/views/document.py:460
-#: apps/resource_manage/views/document.py:485
-#: apps/resource_manage/views/document.py:507
-#: apps/resource_manage/views/document.py:530
-#: apps/resource_manage/views/document.py:553
-#: apps/resource_manage/views/document.py:571
-#: apps/resource_manage/views/document.py:585
-msgid "System Knowledge/Documentation"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:51
-#: apps/resource_manage/views/document.py:52
-#: apps/resource_manage/views/document.py:53
-msgid "Get system document"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:77
-#: apps/resource_manage/views/document.py:78
-#: apps/resource_manage/views/document.py:79
-msgid "Segmented system document"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:108
-#: apps/resource_manage/views/document.py:109
-#: apps/resource_manage/views/document.py:110
-msgid "Get a list of system segment IDs"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:124
-#: apps/resource_manage/views/document.py:125
-#: apps/resource_manage/views/document.py:126
-msgid "Cancel system tasks in batches"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:149
-#: apps/resource_manage/views/document.py:150
-#: apps/resource_manage/views/document.py:151
-msgid "Create system knowledges in batches"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:177
-#: apps/resource_manage/views/document.py:178
-#: apps/resource_manage/views/document.py:179
-msgid "Batch sync system knowledges"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:204
-#: apps/resource_manage/views/document.py:206
-msgid "Delete system document in batches"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:205
-msgid "Delete system knowledge in batches"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:232
-#: apps/resource_manage/views/document.py:233
-msgid "Batch refresh system document vector library"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:261
-#: apps/resource_manage/views/document.py:262
-#: apps/resource_manage/views/document.py:263
-msgid "Batch generate related system problems"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:290
-#: apps/resource_manage/views/document.py:291
-#: apps/resource_manage/views/document.py:292
-msgid "Modify system document hit processing methods in batches"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:312
-#: apps/resource_manage/views/document.py:313
-msgid "Migrate system knowledges in batches"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:340
-#: apps/resource_manage/views/document.py:341
-#: apps/resource_manage/views/document.py:342
-msgid "Get system document details"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:356
-#: apps/resource_manage/views/document.py:357
-#: apps/resource_manage/views/document.py:358
-msgid "Modify system document"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:378
-#: apps/resource_manage/views/document.py:379
-#: apps/resource_manage/views/document.py:380
-msgid "Delete system document"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:405
-#: apps/resource_manage/views/document.py:406
-#: apps/resource_manage/views/document.py:407
-msgid "Synchronize system web site types"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:429
-#: apps/resource_manage/views/document.py:430
-#: apps/resource_manage/views/document.py:431
-msgid "Refresh system knowledge vector library"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:454
-#: apps/resource_manage/views/document.py:455
-#: apps/resource_manage/views/document.py:456
-msgid "Cancel system task"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:480
-#: apps/resource_manage/views/document.py:481
-#: apps/resource_manage/views/document.py:482
-msgid "Get system document by pagination"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:503
-#: apps/resource_manage/views/document.py:504
-msgid "Export system knowledge"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:526
-#: apps/resource_manage/views/document.py:527
-msgid "Export Zip system knowledge"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:549
-#: apps/resource_manage/views/document.py:550
-msgid "Download system source file"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:567
-#: apps/resource_manage/views/document.py:568
-msgid "Get system QA template"
-msgstr ""
-
-#: apps/resource_manage/views/document.py:581
-#: apps/resource_manage/views/document.py:582
-msgid "Get system form template"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:26
-#: apps/resource_manage/views/knowledge.py:27
-#: apps/resource_manage/views/knowledge.py:28
-msgid "Get system knowledge list"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:31
-#: apps/resource_manage/views/knowledge.py:50
-#: apps/resource_manage/views/knowledge.py:72
-#: apps/resource_manage/views/knowledge.py:87
-#: apps/resource_manage/views/knowledge.py:102
-#: apps/resource_manage/views/knowledge.py:121
-#: apps/resource_manage/views/knowledge.py:147
-#: apps/resource_manage/views/knowledge.py:174
-#: apps/resource_manage/views/knowledge.py:192
-#: apps/resource_manage/views/knowledge.py:210
-#: apps/resource_manage/views/knowledge.py:231
-#: apps/resource_manage/views/knowledge.py:252
-#: apps/resource_manage/views/knowledge.py:272
-msgid "System Knowledge"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:45
-#: apps/resource_manage/views/knowledge.py:46
-#: apps/resource_manage/views/knowledge.py:47
-msgid "Get system knowledge list by pagination"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:66
-#: apps/resource_manage/views/knowledge.py:67
-#: apps/resource_manage/views/knowledge.py:68
-msgid "Update system knowledge"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:82
-#: apps/resource_manage/views/knowledge.py:83
-#: apps/resource_manage/views/knowledge.py:84
-msgid "Get system knowledge"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:97
-#: apps/resource_manage/views/knowledge.py:98
-#: apps/resource_manage/views/knowledge.py:99
-msgid "Delete system knowledge"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:115
-#: apps/resource_manage/views/knowledge.py:116
-#: apps/resource_manage/views/knowledge.py:117
-msgid "Synchronize the system knowledge base of the website"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:141
-#: apps/resource_manage/views/knowledge.py:142
-#: apps/resource_manage/views/knowledge.py:143
-msgid "System Hit test list"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:168
-#: apps/resource_manage/views/knowledge.py:169
-#: apps/resource_manage/views/knowledge.py:170
-msgid "System Re-vectorize"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:188
-#: apps/resource_manage/views/knowledge.py:189
-msgid "Export system knowledge base"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:206
-#: apps/resource_manage/views/knowledge.py:207
-msgid "Export system knowledge base containing images"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:225
-#: apps/resource_manage/views/knowledge.py:226
-#: apps/resource_manage/views/knowledge.py:227
-msgid "System generate related"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:247
-#: apps/resource_manage/views/knowledge.py:248
-#: apps/resource_manage/views/knowledge.py:249
-msgid "Get model for system knowledge base"
-msgstr ""
-
-#: apps/resource_manage/views/knowledge.py:267
-#: apps/resource_manage/views/knowledge.py:268
-#: apps/resource_manage/views/knowledge.py:269
-msgid "Get embedding model for system knowledge base"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:24
-#: apps/resource_manage/views/paragraph.py:25
-#: apps/resource_manage/views/paragraph.py:26
-msgid "System paragraph list"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:29
-#: apps/resource_manage/views/paragraph.py:50
-#: apps/resource_manage/views/paragraph.py:76
-#: apps/resource_manage/views/paragraph.py:93
-#: apps/resource_manage/views/paragraph.py:125
-#: apps/resource_manage/views/paragraph.py:151
-#: apps/resource_manage/views/paragraph.py:179
-#: apps/resource_manage/views/paragraph.py:201
-#: apps/resource_manage/views/paragraph.py:233
-#: apps/resource_manage/views/paragraph.py:259
-#: apps/resource_manage/views/paragraph.py:283
-#: apps/resource_manage/views/paragraph.py:314
-#: apps/resource_manage/views/paragraph.py:344
-#: apps/resource_manage/views/paragraph.py:370
-msgid "System Knowledge/Documentation/Paragraph"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:45
-#: apps/resource_manage/views/paragraph.py:46
-msgid "Create system paragraph"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:70
-#: apps/resource_manage/views/paragraph.py:71
-#: apps/resource_manage/views/paragraph.py:72
-msgid "Batch system paragraph"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:88
-#: apps/resource_manage/views/paragraph.py:89
-msgid "Migrate system paragraphs in batches"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:119
-#: apps/resource_manage/views/paragraph.py:120
-#: apps/resource_manage/views/paragraph.py:121
-msgid "Batch generate system related"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:145
-#: apps/resource_manage/views/paragraph.py:146
-#: apps/resource_manage/views/paragraph.py:147
-msgid "Modify system paragraph data"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:174
-#: apps/resource_manage/views/paragraph.py:175
-#: apps/resource_manage/views/paragraph.py:176
-msgid "Get system paragraph details"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:196
-#: apps/resource_manage/views/paragraph.py:197
-#: apps/resource_manage/views/paragraph.py:198
-msgid "Delete system paragraph"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:227
-#: apps/resource_manage/views/paragraph.py:228
-#: apps/resource_manage/views/paragraph.py:229
-msgid "Add system associated questions"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:254
-#: apps/resource_manage/views/paragraph.py:255
-#: apps/resource_manage/views/paragraph.py:256
-msgid "Get a list of system paragraph questions"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:277
-#: apps/resource_manage/views/paragraph.py:278
-#: apps/resource_manage/views/paragraph.py:279
-msgid "Disassociation system issue"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:308
-#: apps/resource_manage/views/paragraph.py:309
-#: apps/resource_manage/views/paragraph.py:310
-msgid "Related system questions"
-msgstr ""
-
-#: apps/resource_manage/views/paragraph.py:339
-#: apps/resource_manage/views/paragraph.py:340
-#: apps/resource_manage/views/paragraph.py:341
-msgid "Get system paragraph list by pagination"
-msgstr ""
-
-#: apps/resource_manage/views/problem.py:23
-#: apps/resource_manage/views/problem.py:24
-#: apps/resource_manage/views/problem.py:25
-msgid "System question list"
-msgstr ""
-
-#: apps/resource_manage/views/problem.py:28
-#: apps/resource_manage/views/problem.py:50
-#: apps/resource_manage/views/problem.py:71
-#: apps/resource_manage/views/problem.py:94
-#: apps/resource_manage/views/problem.py:115
-#: apps/resource_manage/views/problem.py:135
-#: apps/resource_manage/views/problem.py:158
-#: apps/resource_manage/views/problem.py:182
-msgid "System Knowledge/Documentation/Paragraph/Question"
-msgstr ""
-
-#: apps/resource_manage/views/problem.py:44
-#: apps/resource_manage/views/problem.py:45
-#: apps/resource_manage/views/problem.py:46
-msgid "Create system question"
-msgstr ""
-
-#: apps/resource_manage/views/problem.py:66
-#: apps/resource_manage/views/problem.py:67
-#: apps/resource_manage/views/problem.py:68
-msgid "Get a list of associated system paragraphs"
-msgstr ""
-
-#: apps/resource_manage/views/problem.py:88
-#: apps/resource_manage/views/problem.py:89
-#: apps/resource_manage/views/problem.py:90
-msgid "Batch associated system paragraphs"
-msgstr ""
-
-#: apps/resource_manage/views/problem.py:109
-#: apps/resource_manage/views/problem.py:110
-#: apps/resource_manage/views/problem.py:111
-msgid "Batch deletion system issues"
-msgstr ""
-
-#: apps/resource_manage/views/problem.py:130
-#: apps/resource_manage/views/problem.py:131
-#: apps/resource_manage/views/problem.py:132
-msgid "Delete system question"
-msgstr ""
-
-#: apps/resource_manage/views/problem.py:152
-#: apps/resource_manage/views/problem.py:153
-#: apps/resource_manage/views/problem.py:154
-msgid "Modify system question"
-msgstr ""
-
-#: apps/resource_manage/views/problem.py:177
-#: apps/resource_manage/views/problem.py:178
-#: apps/resource_manage/views/problem.py:179
-msgid "Get the list of system questions by page"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:24 apps/resource_manage/views/tool.py:25
-#: apps/resource_manage/views/tool.py:26
-msgid "Get system tool"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:29 apps/resource_manage/views/tool.py:50
-#: apps/resource_manage/views/tool.py:65 apps/resource_manage/views/tool.py:80
-#: apps/resource_manage/views/tool.py:98 apps/resource_manage/views/tool.py:119
-#: apps/resource_manage/views/tool.py:137
-#: apps/resource_manage/views/tool.py:156
-#: apps/resource_manage/views/tool.py:179
-msgid "System Tool"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:44 apps/resource_manage/views/tool.py:45
-#: apps/resource_manage/views/tool.py:46
-msgid "Update system tool"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:60 apps/resource_manage/views/tool.py:61
-#: apps/resource_manage/views/tool.py:62
-msgid "Get system tool by id"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:75 apps/resource_manage/views/tool.py:76
-#: apps/resource_manage/views/tool.py:77
-msgid "Delete system tool"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:93 apps/resource_manage/views/tool.py:94
-#: apps/resource_manage/views/tool.py:95
-msgid "Get system tool list by pagination"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:114
-#: apps/resource_manage/views/tool.py:115
-#: apps/resource_manage/views/tool.py:116
-msgid "Export system tool"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:132
-#: apps/resource_manage/views/tool.py:133
-#: apps/resource_manage/views/tool.py:134
-msgid "Debug system tool"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:150
-#: apps/resource_manage/views/tool.py:151
-#: apps/resource_manage/views/tool.py:152
-msgid "Check system code"
-msgstr ""
-
-#: apps/resource_manage/views/tool.py:173
-#: apps/resource_manage/views/tool.py:174
-#: apps/resource_manage/views/tool.py:175
-msgid "Edit system tool icon"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:16
-#: apps/role_setting/api/role_setting.py:22
-#: apps/role_setting/api/role_setting.py:33
-#: apps/role_setting/api/role_setting.py:143
-#: apps/role_setting/serializers/role_setting_serializers.py:193
-#: apps/workspace/api/workspace.py:81 apps/xpack/api/chat_user.py:104
-msgid "ID"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:17
-#: apps/role_setting/api/role_setting.py:23
-#: apps/role_setting/api/role_setting.py:34 apps/users/serializers/user.py:258
-#: apps/xpack/api/knowledge_lark.py:24 apps/xpack/serializers/chat_user.py:235
-msgid "Name"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:18
-#: apps/role_setting/api/role_setting.py:29
-#: apps/role_setting/serializers/role_setting_serializers.py:194
-msgid "Enable"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:26
-msgid "Permission"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:37
-msgid "Children"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:55
-#: apps/role_setting/serializers/role_setting_serializers.py:107
-msgid "Role type"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:76
-msgid "Internal role"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:80
-msgid "Custom role"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:108
-#: apps/role_setting/api/role_setting.py:128
-#: apps/role_setting/api/role_setting.py:164
-#: apps/role_setting/serializers/role_setting_serializers.py:110
-#: apps/role_setting/serializers/role_setting_serializers.py:329
-#: apps/users/api/user.py:26 apps/workspace/api/workspace.py:86
-msgid "Role ID"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:135
-msgid "User relation ID"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:145
-#: apps/role_setting/api/role_setting.py:185
-#: apps/role_setting/serializers/role_setting_serializers.py:330
-#: apps/users/api/user.py:77 apps/users/serializers/login.py:27
-#: apps/users/serializers/user.py:56 apps/users/serializers/user.py:114
-#: apps/workspace/api/workspace.py:83 apps/workspace/api/workspace.py:124
-#: apps/workspace/serializers/workspace_serializers.py:240
-#: apps/xpack/api/auth_config.py:24 apps/xpack/api/chat_user.py:105
-#: apps/xpack/api/user_group.py:75 apps/xpack/serializers/chat_user.py:62
-#: apps/xpack/serializers/chat_user.py:564
-msgid "Username"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:146 apps/workspace/api/workspace.py:84
-#: apps/xpack/api/chat_user.py:106
-msgid "Nickname"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:148
-msgid "Workspace Name"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:104
-msgid "Role name"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:122
-#: apps/role_setting/serializers/role_setting_serializers.py:200
-#: apps/role_setting/serializers/role_setting_serializers.py:325
-#: apps/role_setting/serializers/role_setting_serializers.py:337
-msgid "Role does not exist"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:124
-#: apps/role_setting/serializers/role_setting_serializers.py:202
-msgid "Cannot modify built-in role"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:132
-msgid "Role name already exists"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:152
-msgid "Invalid role type"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:204
-msgid "Cannot delete built-in role"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:262
-#: apps/users/api/user.py:135 apps/users/serializers/user.py:471
-#: apps/workspace/serializers/workspace_serializers.py:161
-#: apps/xpack/api/user_group.py:90 apps/xpack/serializers/chat_user.py:158
-#: apps/xpack/serializers/chat_user.py:172
-#: apps/xpack/serializers/chat_user.py:502
-msgid "User IDs"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:267
-#: apps/users/api/user.py:30
-msgid "Workspace IDs"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:272
-#: apps/workspace/serializers/workspace_serializers.py:172
-msgid "Members"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:312
-#: apps/workspace/serializers/workspace_serializers.py:223
-msgid "User relation does not exist"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:316
-#: apps/workspace/serializers/workspace_serializers.py:226
-msgid "Cannot remove member from built-in role"
-msgstr ""
-
-#: apps/role_setting/serializers/role_setting_serializers.py:370
-msgid "Only update members to normal users"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:39
-#: apps/role_setting/views/role_setting.py:40
-#: apps/role_setting/views/role_setting.py:41
-msgid "Get role permission template"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:62
-#: apps/role_setting/views/role_setting.py:63
-#: apps/role_setting/views/role_setting.py:64
-msgid "Create or update role"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:80
-#: apps/role_setting/views/role_setting.py:81
-#: apps/role_setting/views/role_setting.py:82
-msgid "Get role list"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:98
-#: apps/role_setting/views/role_setting.py:99
-#: apps/role_setting/views/role_setting.py:100
-msgid "Delete role"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:120
-#: apps/role_setting/views/role_setting.py:121
-#: apps/role_setting/views/role_setting.py:122
-msgid "Create or update role permission"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:140
-#: apps/role_setting/views/role_setting.py:141
-#: apps/role_setting/views/role_setting.py:142
-msgid "Get role permission"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:161
-#: apps/role_setting/views/role_setting.py:162
-#: apps/role_setting/views/role_setting.py:163
-msgid "Add member to system role"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:186
-#: apps/role_setting/views/role_setting.py:187
-#: apps/role_setting/views/role_setting.py:188
-msgid "Remove member from system role"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:205
-#: apps/role_setting/views/role_setting.py:206
-#: apps/role_setting/views/role_setting.py:207
-msgid "Get system role member list"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:223
-#: apps/role_setting/views/role_setting.py:224
-#: apps/role_setting/views/role_setting.py:225
-msgid "Get Workspace role list"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:227
-#: apps/role_setting/views/role_setting.py:248
-#: apps/role_setting/views/role_setting.py:273
-#: apps/role_setting/views/role_setting.py:292
-msgid "Workspace Role"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:242
-#: apps/role_setting/views/role_setting.py:243
-#: apps/role_setting/views/role_setting.py:244
-msgid "Add member to workspace role"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:268
-#: apps/role_setting/views/role_setting.py:269
-#: apps/role_setting/views/role_setting.py:270
-msgid "Remove member from workspace role"
-msgstr ""
-
-#: apps/role_setting/views/role_setting.py:287
-#: apps/role_setting/views/role_setting.py:288
-#: apps/role_setting/views/role_setting.py:289
-msgid "Get workspace role member list"
-msgstr ""
-
-#: apps/shared/api/shared_knowledge.py:242 apps/xpack/api/knowledge_lark.py:54
-msgid "Folder token"
-msgstr ""
-
-#: apps/shared/api/shared_tool.py:19 apps/shared/api/shared_tool.py:46
-#: apps/shared/api/shared_tool.py:93 apps/shared/api/shared_tool.py:133
-#: apps/shared/serializers/shared_tool.py:43
-#: apps/shared/serializers/shared_tool.py:83 apps/tools/serializers/tool.py:142
-#: apps/tools/serializers/tool.py:158 apps/tools/serializers/tool.py:454
-msgid "tool name"
-msgstr ""
-
-#: apps/shared/api/shared_tool.py:26 apps/shared/api/shared_tool.py:53
-#: apps/shared/api/shared_tool.py:100 apps/shared/api/shared_tool.py:140
-#: apps/shared/serializers/shared_tool.py:44
-#: apps/shared/serializers/shared_tool.py:85 apps/tools/serializers/tool.py:144
-#: apps/tools/serializers/tool.py:159
-msgid "tool description"
-msgstr ""
-
-#: apps/shared/api/shared_tool.py:166 apps/shared/api/shared_tool.py:184
-#: apps/shared/api/shared_tool.py:256 apps/shared/api/shared_tool.py:288
-#: apps/shared/api/shared_tool.py:310 apps/shared/serializers/shared_tool.py:66
-#: apps/shared/serializers/shared_tool.py:107
-#: apps/tools/serializers/tool.py:267
-msgid "tool id"
-msgstr ""
-
-#: apps/shared/serializers/shared_knowledge.py:35
-#: apps/shared/serializers/shared_model.py:20
-#: apps/shared/serializers/shared_tool.py:19
-msgid "workspace id list"
-msgstr ""
-
-#: apps/shared/serializers/shared_knowledge.py:36
-#: apps/shared/serializers/shared_model.py:21
-#: apps/shared/serializers/shared_tool.py:20
-msgid "authentication type"
-msgstr ""
-
-#: apps/shared/serializers/shared_knowledge.py:196
-#: apps/shared/serializers/shared_knowledge.py:216
-#: apps/shared/serializers/shared_knowledge.py:236
-msgid "Knowledge does not exist"
-msgstr ""
-
-#: apps/shared/serializers/shared_knowledge.py:218
-#: apps/shared/serializers/shared_knowledge.py:238
-msgid "Only shared knowledge can be authorized"
-msgstr ""
-
-#: apps/shared/serializers/shared_tool.py:74
-msgid "Only shared tools can be deleted"
-msgstr ""
-
-#: apps/shared/serializers/shared_tool.py:76
-msgid "System tools cannot be deleted"
-msgstr ""
-
-#: apps/shared/serializers/shared_tool.py:118
-#: apps/shared/serializers/shared_tool.py:138
-msgid "Tool does not exist"
-msgstr ""
-
-#: apps/shared/serializers/shared_tool.py:120
-#: apps/shared/serializers/shared_tool.py:140
-msgid "Only shared tools can be authorized"
-msgstr ""
-
-#: apps/shared/views/shared_dataset_lark_views.py:25
-#: apps/shared/views/shared_dataset_lark_views.py:26
-#: apps/shared/views/shared_dataset_lark_views.py:27
-#: apps/xpack/views/dataset_lark_views.py:23
-#: apps/xpack/views/dataset_lark_views.py:24
-#: apps/xpack/views/dataset_lark_views.py:25
-msgid "Create a lark knowledge base"
-msgstr ""
-
-#: apps/shared/views/shared_dataset_lark_views.py:44
-#: apps/shared/views/shared_dataset_lark_views.py:45
-#: apps/shared/views/shared_dataset_lark_views.py:46
-#: apps/xpack/views/dataset_lark_views.py:44
-#: apps/xpack/views/dataset_lark_views.py:45
-#: apps/xpack/views/dataset_lark_views.py:46
-msgid "Update a lark knowledge base"
-msgstr ""
-
-#: apps/shared/views/shared_dataset_lark_views.py:67
-#: apps/shared/views/shared_dataset_lark_views.py:68
-#: apps/shared/views/shared_dataset_lark_views.py:69
-#: apps/xpack/views/dataset_lark_views.py:67
-#: apps/xpack/views/dataset_lark_views.py:68
-#: apps/xpack/views/dataset_lark_views.py:69
-msgid "Get document list from lark"
-msgstr ""
-
-#: apps/shared/views/shared_dataset_lark_views.py:72
-#: apps/shared/views/shared_dataset_lark_views.py:90
-#: apps/shared/views/shared_dataset_lark_views.py:109
-#: apps/shared/views/shared_dataset_lark_views.py:129
-#: apps/shared/views/shared_document.py:36
-#: apps/shared/views/shared_document.py:56
-#: apps/shared/views/shared_document.py:83
-#: apps/shared/views/shared_document.py:114
-#: apps/shared/views/shared_document.py:131
-#: apps/shared/views/shared_document.py:156
-#: apps/shared/views/shared_document.py:184
-#: apps/shared/views/shared_document.py:211
-#: apps/shared/views/shared_document.py:238
-#: apps/shared/views/shared_document.py:268
-#: apps/shared/views/shared_document.py:297
-#: apps/shared/views/shared_document.py:318
-#: apps/shared/views/shared_document.py:346
-#: apps/shared/views/shared_document.py:363
-#: apps/shared/views/shared_document.py:384
-#: apps/shared/views/shared_document.py:412
-#: apps/shared/views/shared_document.py:436
-#: apps/shared/views/shared_document.py:461
-#: apps/shared/views/shared_document.py:486
-#: apps/shared/views/shared_document.py:508
-#: apps/shared/views/shared_document.py:531
-#: apps/shared/views/shared_document.py:554
-#: apps/shared/views/shared_document.py:575
-#: apps/shared/views/shared_document.py:602
-#: apps/shared/views/shared_document.py:629
-#: apps/shared/views/shared_document.py:651
-#: apps/shared/views/shared_document.py:665
-msgid "Shared Knowledge/Documentation"
-msgstr ""
-
-#: apps/shared/views/shared_dataset_lark_views.py:85
-#: apps/shared/views/shared_dataset_lark_views.py:86
-#: apps/shared/views/shared_dataset_lark_views.py:87
-#: apps/xpack/views/dataset_lark_views.py:86
-#: apps/xpack/views/dataset_lark_views.py:87
-#: apps/xpack/views/dataset_lark_views.py:88
-msgid "Import documents to the lark knowledge base"
-msgstr ""
-
-#: apps/shared/views/shared_dataset_lark_views.py:104
-#: apps/shared/views/shared_dataset_lark_views.py:105
-#: apps/shared/views/shared_dataset_lark_views.py:106
-#: apps/xpack/views/dataset_lark_views.py:106
-#: apps/xpack/views/dataset_lark_views.py:107
-#: apps/xpack/views/dataset_lark_views.py:108
-msgid "Synchronize lark document"
-msgstr ""
-
-#: apps/shared/views/shared_dataset_lark_views.py:123
-#: apps/shared/views/shared_dataset_lark_views.py:124
-#: apps/shared/views/shared_dataset_lark_views.py:125
-#: apps/xpack/views/dataset_lark_views.py:126
-#: apps/xpack/views/dataset_lark_views.py:127
-#: apps/xpack/views/dataset_lark_views.py:128
-msgid "Batch synchronize lark document"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:30
-#: apps/shared/views/shared_document.py:31
-#: apps/shared/views/shared_document.py:32
-msgid "Create shared document"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:51
-#: apps/shared/views/shared_document.py:52
-#: apps/shared/views/shared_document.py:53
-msgid "Get shared document"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:77
-#: apps/shared/views/shared_document.py:78
-#: apps/shared/views/shared_document.py:79
-msgid "Segmented shared document"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:109
-#: apps/shared/views/shared_document.py:110
-#: apps/shared/views/shared_document.py:111
-msgid "Get a list of shared segment IDs"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:125
-#: apps/shared/views/shared_document.py:126
-#: apps/shared/views/shared_document.py:127
-msgid "Cancel shared tasks in batches"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:150
-#: apps/shared/views/shared_document.py:151
-#: apps/shared/views/shared_document.py:152
-msgid "Create shared documents in batches"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:178
-#: apps/shared/views/shared_document.py:179
-#: apps/shared/views/shared_document.py:180
-msgid "Batch sync shared documents"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:205
-#: apps/shared/views/shared_document.py:206
-#: apps/shared/views/shared_document.py:207
-msgid "Delete shared documents in batches"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:233
-#: apps/shared/views/shared_document.py:234
-msgid "Batch refresh shared document vector library"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:262
-#: apps/shared/views/shared_document.py:263
-#: apps/shared/views/shared_document.py:264
-msgid "Batch generate related shared problems"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:291
-#: apps/shared/views/shared_document.py:292
-#: apps/shared/views/shared_document.py:293
-msgid "Modify shared document hit processing methods in batches"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:313
-#: apps/shared/views/shared_document.py:314
-msgid "Migrate shared documents in batches"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:341
-#: apps/shared/views/shared_document.py:342
-#: apps/shared/views/shared_document.py:343
-msgid "Get shared document details"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:357
-#: apps/shared/views/shared_document.py:358
-#: apps/shared/views/shared_document.py:359
-msgid "Modify shared document"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:379
-#: apps/shared/views/shared_document.py:380
-#: apps/shared/views/shared_document.py:381
-msgid "Delete shared document"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:406
-#: apps/shared/views/shared_document.py:407
-#: apps/shared/views/shared_document.py:408
-msgid "Synchronize shared web site types"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:430
-#: apps/shared/views/shared_document.py:431
-#: apps/shared/views/shared_document.py:432
-msgid "Refresh shared document vector library"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:455
-#: apps/shared/views/shared_document.py:456
-#: apps/shared/views/shared_document.py:457
-msgid "Cancel shared task"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:481
-#: apps/shared/views/shared_document.py:482
-#: apps/shared/views/shared_document.py:483
-msgid "Get shared document by pagination"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:504
-#: apps/shared/views/shared_document.py:505
-msgid "Export shared document"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:527
-#: apps/shared/views/shared_document.py:528
-msgid "Export Zip shared document"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:550
-#: apps/shared/views/shared_document.py:551
-msgid "Download shared source file"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:569
-#: apps/shared/views/shared_document.py:571
-msgid "Create Web site shared documents"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:596
-#: apps/shared/views/shared_document.py:597
-#: apps/shared/views/shared_document.py:598
-msgid "Import QA and create shared documentation"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:623
-#: apps/shared/views/shared_document.py:624
-#: apps/shared/views/shared_document.py:625
-msgid "Import tables and create shared documents"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:647
-#: apps/shared/views/shared_document.py:648
-msgid "Get shared QA template"
-msgstr ""
-
-#: apps/shared/views/shared_document.py:661
-#: apps/shared/views/shared_document.py:662
-msgid "Get shared form template"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:28
-#: apps/shared/views/shared_knowledge.py:29
-#: apps/shared/views/shared_knowledge.py:30
-msgid "Get share resource knowledge"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:48
-#: apps/shared/views/shared_knowledge.py:49
-#: apps/shared/views/shared_knowledge.py:50
-msgid "Get shared knowledge list by pagination"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:70
-#: apps/shared/views/shared_knowledge.py:71
-#: apps/shared/views/shared_knowledge.py:72
-msgid "Update shared knowledge"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:86
-#: apps/shared/views/shared_knowledge.py:87
-#: apps/shared/views/shared_knowledge.py:88
-msgid "Get shared knowledge"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:101
-#: apps/shared/views/shared_knowledge.py:102
-#: apps/shared/views/shared_knowledge.py:103
-msgid "Delete shared knowledge"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:119
-#: apps/shared/views/shared_knowledge.py:120
-#: apps/shared/views/shared_knowledge.py:121
-msgid "Synchronize the shared knowledge base of the website"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:145
-#: apps/shared/views/shared_knowledge.py:146
-#: apps/shared/views/shared_knowledge.py:147
-msgid "Shared Hit test list"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:172
-#: apps/shared/views/shared_knowledge.py:173
-#: apps/shared/views/shared_knowledge.py:174
-msgid "Shared Re-vectorize"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:192
-#: apps/shared/views/shared_knowledge.py:193
-msgid "Export shared knowledge base"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:210
-#: apps/shared/views/shared_knowledge.py:211
-msgid "Export shared knowledge base containing images"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:229
-#: apps/shared/views/shared_knowledge.py:230
-#: apps/shared/views/shared_knowledge.py:231
-msgid "Shared generate related"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:251
-#: apps/shared/views/shared_knowledge.py:252
-#: apps/shared/views/shared_knowledge.py:253
-msgid "Get model for shared knowledge base"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:271
-#: apps/shared/views/shared_knowledge.py:272
-#: apps/shared/views/shared_knowledge.py:273
-msgid "Get embedding model for shared knowledge base"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:291
-#: apps/shared/views/shared_knowledge.py:293
-msgid "Authorization knowledge workspace"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:292
-msgid "Authorization knowledge workspace "
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:307
-#: apps/shared/views/shared_knowledge.py:308
-#: apps/shared/views/shared_knowledge.py:309
-msgid "Get Authorization knowledge workspace"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:326
-#: apps/shared/views/shared_knowledge.py:327
-#: apps/shared/views/shared_knowledge.py:328
-msgid "Create shared base knowledge"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:349
-#: apps/shared/views/shared_knowledge.py:350
-#: apps/shared/views/shared_knowledge.py:351
-msgid "Create shared web knowledge"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:381
-#: apps/shared/views/shared_knowledge.py:382
-#: apps/shared/views/shared_knowledge.py:383
-msgid "Get shared workspace knowledge"
-msgstr ""
-
-#: apps/shared/views/shared_knowledge.py:402
-#: apps/shared/views/shared_knowledge.py:403
-#: apps/shared/views/shared_knowledge.py:404
-msgid "Get shared workspace knowledge list by pagination"
-msgstr ""
-
-#: apps/shared/views/shared_model.py:213 apps/shared/views/shared_model.py:215
-msgid "Authorization model workspace"
-msgstr ""
-
-#: apps/shared/views/shared_model.py:214
-msgid "Authorization model workspace "
-msgstr ""
-
-#: apps/shared/views/shared_model.py:229 apps/shared/views/shared_model.py:230
-#: apps/shared/views/shared_model.py:231
-msgid "Get Authorization model workspace"
-msgstr ""
-
-#: apps/shared/views/shared_model.py:248 apps/shared/views/shared_model.py:249
-#: apps/shared/views/shared_model.py:250
-msgid "Get Share model by workspace id"
-msgstr ""
-
-#: apps/shared/views/shared_model.py:265 apps/shared/views/shared_model.py:266
-#: apps/shared/views/shared_model.py:267
-msgid "Get Share model by workspace id with pagination"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:24
-#: apps/shared/views/shared_paragraph.py:25
-#: apps/shared/views/shared_paragraph.py:26
-msgid "Shared paragraph list"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:29
-#: apps/shared/views/shared_paragraph.py:50
-#: apps/shared/views/shared_paragraph.py:76
-#: apps/shared/views/shared_paragraph.py:93
-#: apps/shared/views/shared_paragraph.py:125
-#: apps/shared/views/shared_paragraph.py:151
-#: apps/shared/views/shared_paragraph.py:179
-#: apps/shared/views/shared_paragraph.py:201
-#: apps/shared/views/shared_paragraph.py:233
-#: apps/shared/views/shared_paragraph.py:259
-#: apps/shared/views/shared_paragraph.py:283
-#: apps/shared/views/shared_paragraph.py:314
-#: apps/shared/views/shared_paragraph.py:345
-#: apps/shared/views/shared_paragraph.py:371
-msgid "Shared Knowledge/Documentation/Paragraph"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:45
-#: apps/shared/views/shared_paragraph.py:46
-msgid "Create shared paragraph"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:70
-#: apps/shared/views/shared_paragraph.py:71
-#: apps/shared/views/shared_paragraph.py:72
-msgid "Batch shared paragraph"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:88
-#: apps/shared/views/shared_paragraph.py:89
-msgid "Migrate shared paragraphs in batches"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:119
-#: apps/shared/views/shared_paragraph.py:120
-#: apps/shared/views/shared_paragraph.py:121
-msgid "Batch generate shared related"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:145
-#: apps/shared/views/shared_paragraph.py:146
-#: apps/shared/views/shared_paragraph.py:147
-msgid "Modify shared paragraph data"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:174
-#: apps/shared/views/shared_paragraph.py:175
-#: apps/shared/views/shared_paragraph.py:176
-msgid "Get shared paragraph details"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:196
-#: apps/shared/views/shared_paragraph.py:197
-#: apps/shared/views/shared_paragraph.py:198
-msgid "Delete shared paragraph"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:227
-#: apps/shared/views/shared_paragraph.py:228
-#: apps/shared/views/shared_paragraph.py:229
-msgid "Add shared associated questions"
-msgstr ""
-
-#: apps/shared/views/shared_paragraph.py:254
-#: apps/shared/views/shared_paragraph.py:255
-#: apps/shared/views/shared_paragraph.py:256
+#: no source
 msgid "Get a list of shared paragraph questions"
 msgstr ""
 
-#: apps/shared/views/shared_paragraph.py:277
-#: apps/shared/views/shared_paragraph.py:278
-#: apps/shared/views/shared_paragraph.py:279
-msgid "Disassociation shared issue"
+#: no source
+msgid "Get a list of shared segment IDs"
 msgstr ""
 
-#: apps/shared/views/shared_paragraph.py:308
-#: apps/shared/views/shared_paragraph.py:309
-#: apps/shared/views/shared_paragraph.py:310
-msgid "Related shared questions"
+#: no source
+msgid "Get a list of system paragraph questions"
 msgstr ""
 
-#: apps/shared/views/shared_paragraph.py:340
-#: apps/shared/views/shared_paragraph.py:341
-#: apps/shared/views/shared_paragraph.py:342
-msgid "Get shared paragraph list by pagination"
+#: no source
+msgid "Get a list of system segment IDs"
 msgstr ""
 
-#: apps/shared/views/shared_problem.py:23
-#: apps/shared/views/shared_problem.py:24
-#: apps/shared/views/shared_problem.py:25
-msgid "Shared question list"
+#: apps/trigger/views/trigger_task.py:78
+#: apps/trigger/views/trigger_task.py:79
+#: apps/trigger/views/trigger_task.py:80
+msgid "Get a paginated list of execution records for trigger tasks."
 msgstr ""
 
-#: apps/shared/views/shared_problem.py:28
-#: apps/shared/views/shared_problem.py:50
-#: apps/shared/views/shared_problem.py:71
-#: apps/shared/views/shared_problem.py:94
-#: apps/shared/views/shared_problem.py:115
-#: apps/shared/views/shared_problem.py:135
-#: apps/shared/views/shared_problem.py:158
-#: apps/shared/views/shared_problem.py:182
-msgid "Shared Knowledge/Documentation/Paragraph/Question"
+#: apps/application/views/application_chat.py:121
+#: apps/application/views/application_chat.py:122
+#: apps/application/views/application_chat.py:123
+msgid "Get a temporary session id based on the application id"
+msgstr "Get a temporary session id based on the agent id"
+
+#: apps/knowledge/views/knowledge.py:570
+#: apps/knowledge/views/knowledge.py:571
+#: apps/knowledge/views/knowledge.py:572
+msgid "Get all tags of knowledge base"
 msgstr ""
 
-#: apps/shared/views/shared_problem.py:44
-#: apps/shared/views/shared_problem.py:45
-#: apps/shared/views/shared_problem.py:46
-msgid "Create shared question"
+#: apps/users/views/user.py:130
+#: apps/users/views/user.py:131
+#: apps/users/views/user.py:132
+msgid "Get all user"
 msgstr ""
 
-#: apps/shared/views/shared_problem.py:66
-#: apps/shared/views/shared_problem.py:67
-#: apps/shared/views/shared_problem.py:68
-msgid "Get a list of associated shared paragraphs"
+#: apps/application/views/application_access_token.py:61
+#: apps/application/views/application_access_token.py:62
+#: apps/application/views/application_access_token.py:63
+msgid "Get application access restriction information"
+msgstr "Get agent access restriction information"
+
+#: apps/application/views/application_api_key.py:59
+msgid "GET application ApiKey List"
+msgstr "GET agent ApiKey List"
+
+#: apps/chat/views/chat.py:140
+#: apps/chat/views/chat.py:141
+#: apps/chat/views/chat.py:142
+msgid "Get application authentication information"
+msgstr "Get agent authentication information"
+
+#: apps/application/views/application.py:221
+#: apps/application/views/application.py:222
+#: apps/application/views/application.py:223
+msgid "Get application details"
+msgstr "Get agent details"
+
+#: apps/chat/views/chat.py:123
+#: apps/chat/views/chat.py:124
+#: apps/chat/views/chat.py:125
+msgid "Get application related information"
+msgstr "Get agent related information"
+
+#: no source
+msgid "Get Application Settings"
+msgstr "Get Agent Settings"
+
+#: apps/application/views/application_version.py:79
+#: apps/application/views/application_version.py:80
+#: apps/application/views/application_version.py:81
+msgid "Get application version details"
+msgstr "Get agent version details"
+
+#: apps/application/views/application.py:299
+#: apps/application/views/application.py:300
+#: apps/application/views/application.py:301
+msgid "Get Appstore apps"
 msgstr ""
 
-#: apps/shared/views/shared_problem.py:88
-#: apps/shared/views/shared_problem.py:89
-#: apps/shared/views/shared_problem.py:90
-msgid "Batch associated shared paragraphs"
+#: apps/knowledge/views/knowledge.py:317
+#: apps/knowledge/views/knowledge.py:318
+#: apps/knowledge/views/knowledge.py:319
+#: apps/tools/views/tool.py:530
+#: apps/tools/views/tool.py:531
+#: apps/tools/views/tool.py:532
+#: apps/tools/views/tool_workflow.py:194
+#: apps/tools/views/tool_workflow.py:195
+#: apps/tools/views/tool_workflow.py:196
+msgid "Get Appstore tools"
 msgstr ""
 
-#: apps/shared/views/shared_problem.py:109
-#: apps/shared/views/shared_problem.py:110
-#: apps/shared/views/shared_problem.py:111
-msgid "Batch deletion shared issues"
+#: no source
+msgid "Get authentication configuration"
 msgstr ""
 
-#: apps/shared/views/shared_problem.py:130
-#: apps/shared/views/shared_problem.py:131
-#: apps/shared/views/shared_problem.py:132
-msgid "Delete shared question"
+#: no source
+msgid "Get Authentication Configuration"
 msgstr ""
 
-#: apps/shared/views/shared_problem.py:152
-#: apps/shared/views/shared_problem.py:153
-#: apps/shared/views/shared_problem.py:154
-msgid "Modify shared question"
+#: no source
+msgid "Get authentication types"
 msgstr ""
 
-#: apps/shared/views/shared_problem.py:177
-#: apps/shared/views/shared_problem.py:178
-#: apps/shared/views/shared_problem.py:179
-msgid "Get the list of shared questions by page"
+#: no source
+msgid "Get Authorization knowledge workspace"
 msgstr ""
 
-#: apps/shared/views/shared_tool.py:25 apps/shared/views/shared_tool.py:26
-#: apps/shared/views/shared_tool.py:27
-msgid "Get share resource tool"
+#: no source
+msgid "Get Authorization model workspace"
 msgstr ""
 
-#: apps/shared/views/shared_tool.py:43 apps/shared/views/shared_tool.py:44
-#: apps/shared/views/shared_tool.py:45
-msgid "Create shared tool"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:62 apps/shared/views/shared_tool.py:63
-#: apps/shared/views/shared_tool.py:64
-msgid "Update shared tool"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:78 apps/shared/views/shared_tool.py:79
-#: apps/shared/views/shared_tool.py:80
-msgid "Get shared tool"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:93 apps/shared/views/shared_tool.py:94
-#: apps/shared/views/shared_tool.py:95
-msgid "Delete shared tool"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:111 apps/shared/views/shared_tool.py:112
-#: apps/shared/views/shared_tool.py:113
-msgid "Get shared tool list by pagination"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:134 apps/shared/views/shared_tool.py:135
-#: apps/shared/views/shared_tool.py:136
-msgid "Import shared tool"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:152 apps/shared/views/shared_tool.py:153
-#: apps/shared/views/shared_tool.py:154
-msgid "Export shared tool"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:170 apps/shared/views/shared_tool.py:171
-#: apps/shared/views/shared_tool.py:172
-msgid "Debug shared Tool"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:188 apps/shared/views/shared_tool.py:189
-#: apps/shared/views/shared_tool.py:190
-msgid "Check shared code"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:212 apps/shared/views/shared_tool.py:213
-#: apps/shared/views/shared_tool.py:214
-msgid "Edit shared tool icon"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:233 apps/shared/views/shared_tool.py:235
-msgid "Authorization tool workspace"
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:234
-msgid "Authorization tool workspace "
-msgstr ""
-
-#: apps/shared/views/shared_tool.py:249 apps/shared/views/shared_tool.py:250
-#: apps/shared/views/shared_tool.py:251
+#: no source
 msgid "Get Authorization tool workspace"
 msgstr ""
 
-#: apps/shared/views/shared_tool.py:268 apps/shared/views/shared_tool.py:269
-#: apps/shared/views/shared_tool.py:270
-msgid "Get shared workspace tool"
+#: apps/users/views/login.py:70
+#: apps/users/views/login.py:71
+#: apps/users/views/login.py:72
+msgid "Get captcha"
 msgstr ""
 
-#: apps/shared/views/shared_tool.py:289 apps/shared/views/shared_tool.py:290
-#: apps/shared/views/shared_tool.py:291
-msgid "Get shared workspace tool list by pagination"
+#: apps/chat/views/chat.py:204
+#: apps/chat/views/chat.py:205
+#: apps/chat/views/chat.py:206
+msgid "Get Chat captcha"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:28
-msgid "SMTP host"
+#: apps/application/views/application_chat_link.py:45
+#: apps/application/views/application_chat_link.py:46
+#: apps/application/views/application_chat_link.py:47
+msgid "Get chat record by share link"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:29
-msgid "SMTP port"
+#: no source
+msgid "Get chat user information"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:30
-#: apps/system_manage/serializers/email_setting.py:34
-msgid "Sender's email"
+#: no source
+msgid "Get chat user list"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:31 apps/users/api/user.py:93
-#: apps/users/serializers/login.py:28 apps/users/serializers/user.py:57
-#: apps/users/serializers/user.py:126 apps/users/serializers/user.py:291
-#: apps/users/serializers/user.py:517 apps/xpack/api/auth_config.py:25
-#: apps/xpack/api/chat_user.py:71 apps/xpack/serializers/chat_auth.py:24
-#: apps/xpack/serializers/chat_user.py:74
-#: apps/xpack/serializers/chat_user.py:267
-#: apps/xpack/serializers/chat_user.py:601
-msgid "Password"
+#: apps/chat/views/chat_record.py:186
+#: apps/chat/views/chat_record.py:187
+#: apps/chat/views/chat_record.py:188
+msgid "Get conversation details"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:32
-msgid "Whether to enable TLS"
+#: apps/application/views/application_chat_record.py:86
+#: apps/application/views/application_chat_record.py:87
+#: apps/application/views/application_chat_record.py:88
+msgid "Get conversation record details"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:33
-msgid "Whether to enable SSL"
+#: apps/users/views/user.py:68
+#: apps/users/views/user.py:69
+#: apps/users/views/user.py:70
+#: apps/users/views/user.py:82
+#: apps/users/views/user.py:83
+msgid "Get current user information"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:49
-msgid "Email verification failed"
+#: no source
+msgid "Get current user role list"
 msgstr ""
 
-#: apps/system_manage/serializers/user_resource_permission.py:53
-msgid "target id"
+#: apps/users/views/user.py:191
+#: apps/users/views/user.py:192
+#: apps/users/views/user.py:193
+msgid "Get default password"
 msgstr ""
 
-#: apps/system_manage/serializers/user_resource_permission.py:70
-msgid "Non-existent application|knowledge base id["
+#: apps/knowledge/views/document.py:87
+#: apps/knowledge/views/document.py:88
+#: apps/knowledge/views/document.py:89
+msgid "Get document"
 msgstr ""
 
-#: apps/system_manage/views/email_setting.py:50
-#: apps/system_manage/views/email_setting.py:51
-#: apps/system_manage/views/email_setting.py:52
-msgid "Create or update email settings"
+#: apps/knowledge/views/document.py:840
+#: apps/knowledge/views/document.py:841
+#: apps/knowledge/views/document.py:842
+msgid "Get document by pagination"
 msgstr ""
 
-#: apps/system_manage/views/email_setting.py:55
-#: apps/system_manage/views/email_setting.py:70
-#: apps/system_manage/views/email_setting.py:86
-msgid "Email Settings"
+#: apps/knowledge/views/document.py:127
+#: apps/knowledge/views/document.py:128
+#: apps/knowledge/views/document.py:129
+msgid "Get document details"
 msgstr ""
 
-#: apps/system_manage/views/email_setting.py:66
-#: apps/system_manage/views/email_setting.py:67
-msgid "Test email settings"
+#: no source
+msgid "Get document list from lark"
+msgstr ""
+
+#: apps/knowledge/views/document.py:1009
+#: apps/knowledge/views/document.py:1010
+#: apps/knowledge/views/document.py:1011
+msgid "Get document tags"
 msgstr ""
 
 #: apps/system_manage/views/email_setting.py:82
@@ -6485,2900 +3682,7456 @@ msgstr ""
 msgid "Get email settings"
 msgstr ""
 
+#: apps/chat/views/chat_embed.py:22
+#: apps/chat/views/chat_embed.py:23
+#: apps/chat/views/chat_embed.py:24
+msgid "Get embedded js"
+msgstr ""
+
+#: no source
+msgid "Get embedding model for knowledge base"
+msgstr ""
+
+#: no source
+msgid "Get embedding model for shared knowledge base"
+msgstr ""
+
+#: no source
+msgid "Get embedding model for system knowledge base"
+msgstr ""
+
+#: apps/oss/views/file.py:18
+#: apps/oss/views/file.py:19
+#: apps/oss/views/file.py:20
+msgid "Get file"
+msgstr ""
+
+#: apps/folders/views/folder.py:126
+#: apps/folders/views/folder.py:127
+#: apps/folders/views/folder.py:128
+msgid "Get folder"
+msgstr ""
+
+#: apps/folders/views/folder.py:67
+#: apps/folders/views/folder.py:68
+#: apps/folders/views/folder.py:69
+msgid "Get folder tree"
+msgstr ""
+
+#: apps/knowledge/views/document.py:1336
+#: apps/knowledge/views/document.py:1337
+msgid "Get form template"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:49
+#: apps/chat/views/chat_record.py:50
+#: apps/chat/views/chat_record.py:51
+msgid "Get historical conversation"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:125
+#: apps/chat/views/chat_record.py:126
+#: apps/chat/views/chat_record.py:127
+msgid "Get historical conversation by page"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:145
+#: apps/chat/views/chat_record.py:146
+#: apps/chat/views/chat_record.py:147
+msgid "Get historical conversation records"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:166
+#: apps/chat/views/chat_record.py:167
+msgid "Get historical conversation records by page"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:165
+msgid "Get historical conversation records by page "
+msgstr ""
+
+#: apps/tools/views/tool.py:482
+#: apps/tools/views/tool.py:483
+#: apps/tools/views/tool.py:484
+msgid "Get internal tool"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:119
+#: apps/knowledge/views/knowledge.py:120
+#: apps/knowledge/views/knowledge.py:121
+msgid "Get knowledge"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:37
+#: apps/knowledge/views/knowledge.py:38
+#: apps/knowledge/views/knowledge.py:39
+msgid "Get knowledge by folder"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:44
+msgid "Get Knowledge Tag"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:45
+msgid "Get knowledge tag"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow_version.py:89
+#: apps/knowledge/views/knowledge_workflow_version.py:90
+#: apps/knowledge/views/knowledge_workflow_version.py:91
+msgid "Get knowledge version details"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:398
+#: apps/knowledge/views/knowledge_workflow.py:399
+#: apps/knowledge/views/knowledge_workflow.py:400
+msgid "Get knowledge workflow"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:170
+#: apps/knowledge/views/knowledge_workflow.py:171
+#: apps/knowledge/views/knowledge_workflow.py:172
+msgid "Get knowledge workflow action"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:428
+#: apps/knowledge/views/knowledge_workflow.py:429
+#: apps/knowledge/views/knowledge_workflow.py:430
+msgid "Get knowledge workflow version list"
+msgstr ""
+
+#: no source
+msgid "Get license information"
+msgstr ""
+
 #: apps/system_manage/views/system_profile.py:22
 #: apps/system_manage/views/system_profile.py:23
 msgid "Get MaxKB related information"
 msgstr ""
 
-#: apps/system_manage/views/system_profile.py:25
-msgid "System parameters"
+#: no source
+msgid "Get menu operate log"
 msgstr ""
 
-#: apps/system_manage/views/user_resource_permission.py:40
-#: apps/system_manage/views/user_resource_permission.py:41
-msgid "Obtain resource authorization list"
+#: apps/models_provider/views/provide.py:75
+#: apps/models_provider/views/provide.py:76
+#: apps/models_provider/views/provide.py:77
+msgid "Get model default parameters"
 msgstr ""
 
-#: apps/system_manage/views/user_resource_permission.py:44
-#: apps/system_manage/views/user_resource_permission.py:60
-msgid "Resources authorization"
+#: apps/knowledge/views/knowledge.py:512
+#: apps/knowledge/views/knowledge.py:513
+#: apps/knowledge/views/knowledge.py:514
+msgid "Get model for knowledge base"
 msgstr ""
 
-#: apps/system_manage/views/user_resource_permission.py:55
-#: apps/system_manage/views/user_resource_permission.py:56
-msgid "Modify the resource authorization list"
+#: no source
+msgid "Get model for shared knowledge base"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:118 apps/tools/serializers/tool.py:169
-msgid "variable name"
+#: no source
+msgid "Get model for system knowledge base"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:122
-msgid "fields only support string|int|dict|array|float"
+#: apps/models_provider/views/model.py:181
+#: apps/models_provider/views/model.py:182
+#: apps/models_provider/views/model.py:183
+msgid "Get model parameter form"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:131
-msgid "field name"
+#: no source
+msgid "Get paginated operate log"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:132
-msgid "field label"
+#: apps/knowledge/views/paragraph.py:211
+#: apps/knowledge/views/paragraph.py:212
+#: apps/knowledge/views/paragraph.py:213
+msgid "Get paragraph details"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:146 apps/tools/serializers/tool.py:160
-#: apps/tools/serializers/tool.py:174
-msgid "tool content"
+#: apps/knowledge/views/paragraph.py:415
+#: apps/knowledge/views/paragraph.py:416
+#: apps/knowledge/views/paragraph.py:417
+msgid "Get paragraph list by pagination"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:148 apps/tools/serializers/tool.py:161
-#: apps/tools/serializers/tool.py:175
-msgid "input field list"
+#: no source
+msgid "Get platform configuration"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:150 apps/tools/serializers/tool.py:162
-#: apps/tools/serializers/tool.py:176
-msgid "init field list"
+#: no source
+msgid "Get platform information"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:163 apps/tools/serializers/tool.py:177
-msgid "init params"
+#: no source
+msgid "Get platform status"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:170
-msgid "variable value"
+#: apps/knowledge/views/document.py:1322
+#: apps/knowledge/views/document.py:1323
+msgid "Get QA template"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:182
-msgid "function content"
+#: no source
+msgid "Get Resource chat user group List"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:238
-msgid "field has no value set"
+#: no source
+msgid "Get Resource chat user group page List"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:262
-#, python-brace-format
-msgid "Field: {name} Type: {_type} Value: {value} Type conversion error"
+#: no source
+msgid "Get Resource chat user List"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:275
-msgid "Tool not found"
+#: no source
+msgid "Get Resource chat user page group List"
 msgstr ""
 
-#: apps/tools/serializers/tool.py:388
-msgid "function ID"
+#: no source
+msgid "Get Resource chat user page List"
 msgstr ""
 
-#: apps/tools/views/tool.py:33 apps/tools/views/tool.py:34
-#: apps/tools/views/tool.py:35
-msgid "Create tool"
+#: no source
+msgid "Get resource model list"
 msgstr ""
 
-#: apps/tools/views/tool.py:56 apps/tools/views/tool.py:57
-#: apps/tools/views/tool.py:58
-msgid "Get tool by folder"
+#: no source
+msgid "Get role list"
 msgstr ""
 
-#: apps/tools/views/tool.py:77 apps/tools/views/tool.py:78
-#: apps/tools/views/tool.py:79
-msgid "Debug Tool"
+#: no source
+msgid "Get role permission"
 msgstr ""
 
-#: apps/tools/views/tool.py:98 apps/tools/views/tool.py:99
-#: apps/tools/views/tool.py:100
-msgid "Update tool"
+#: no source
+msgid "Get role permission template"
 msgstr ""
 
-#: apps/tools/views/tool.py:122 apps/tools/views/tool.py:123
-#: apps/tools/views/tool.py:124
+#: no source
+msgid "Get Share model"
+msgstr ""
+
+#: apps/models_provider/views/model.py:273
+#: apps/models_provider/views/model.py:274
+#: apps/models_provider/views/model.py:275
+msgid "Get Share model by workspace id"
+msgstr ""
+
+#: no source
+msgid "Get Share model by workspace id with pagination"
+msgstr ""
+
+#: no source
+msgid "Get share resource knowledge"
+msgstr ""
+
+#: no source
+msgid "Get share resource tool"
+msgstr ""
+
+#: no source
+msgid "Get shared document"
+msgstr ""
+
+#: no source
+msgid "Get shared document by pagination"
+msgstr ""
+
+#: no source
+msgid "Get shared document details"
+msgstr ""
+
+#: no source
+msgid "Get shared form template"
+msgstr ""
+
+#: no source
+msgid "Get shared knowledge"
+msgstr ""
+
+#: no source
+msgid "Get shared knowledge list by pagination"
+msgstr ""
+
+#: no source
+msgid "Get shared paragraph details"
+msgstr ""
+
+#: no source
+msgid "Get shared paragraph list by pagination"
+msgstr ""
+
+#: no source
+msgid "Get shared QA template"
+msgstr ""
+
+#: no source
+msgid "Get shared tool"
+msgstr ""
+
+#: no source
+msgid "Get shared tool list by pagination"
+msgstr ""
+
+#: no source
+msgid "Get shared workspace knowledge"
+msgstr ""
+
+#: no source
+msgid "Get shared workspace knowledge list by pagination"
+msgstr ""
+
+#: no source
+msgid "Get shared workspace tool"
+msgstr ""
+
+#: no source
+msgid "Get shared workspace tool list by pagination"
+msgstr ""
+
+#: no source
+msgid "Get system document"
+msgstr ""
+
+#: no source
+msgid "Get system document by pagination"
+msgstr ""
+
+#: no source
+msgid "Get system document details"
+msgstr ""
+
+#: no source
+msgid "Get system form template"
+msgstr ""
+
+#: no source
+msgid "Get system knowledge"
+msgstr ""
+
+#: no source
+msgid "Get system knowledge list"
+msgstr ""
+
+#: no source
+msgid "Get system knowledge list by pagination"
+msgstr ""
+
+#: no source
+msgid "Get system paragraph details"
+msgstr ""
+
+#: no source
+msgid "Get system paragraph list by pagination"
+msgstr ""
+
+#: no source
+msgid "Get system QA template"
+msgstr ""
+
+#: no source
+msgid "Get system role member list"
+msgstr ""
+
+#: no source
+msgid "Get System Task source trigger details"
+msgstr ""
+
+#: no source
+msgid "Get system tool"
+msgstr ""
+
+#: no source
+msgid "Get system tool by id"
+msgstr ""
+
+#: no source
+msgid "Get system tool list by pagination"
+msgstr ""
+
+#: no source
+msgid "Get system workspace list"
+msgstr ""
+
+#: no source
+msgid "Get system workspace member list"
+msgstr ""
+
+#: no source
+msgid "Get SystemAPIKey List"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:318
+#: apps/trigger/views/trigger.py:319
+#: apps/trigger/views/trigger.py:320
+msgid "Get Task source trigger details"
+msgstr ""
+
+#: apps/application/views/application.py:75
+#: apps/application/views/application.py:76
+#: apps/application/views/application.py:77
+msgid "Get the application list"
+msgstr "Get the agent list"
+
+#: apps/application/views/application.py:94
+#: apps/application/views/application.py:95
+#: apps/application/views/application.py:96
+msgid "Get the application list by page"
+msgstr "Get the agent list by page"
+
+#: apps/application/views/application_version.py:30
+#: apps/application/views/application_version.py:31
+#: apps/application/views/application_version.py:32
+msgid "Get the application version list"
+msgstr "Get the agent version list"
+
+#: apps/application/views/application_chat.py:44
+#: apps/application/views/application_chat.py:45
+#: apps/application/views/application_chat.py:46
+msgid "Get the conversation list"
+msgstr ""
+
+#: apps/application/views/application_chat.py:69
+#: apps/application/views/application_chat.py:70
+#: apps/application/views/application_chat.py:71
+msgid "Get the conversation list by page"
+msgstr ""
+
+#: apps/application/views/application_chat_record.py:31
+#: apps/application/views/application_chat_record.py:32
+#: apps/application/views/application_chat_record.py:33
+msgid "Get the conversation record list"
+msgstr ""
+
+#: apps/application/views/application_chat_record.py:57
+#: apps/application/views/application_chat_record.py:58
+#: apps/application/views/application_chat_record.py:59
+msgid "Get the conversation record list by page"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:220
+#: apps/knowledge/views/knowledge.py:221
+#: apps/knowledge/views/knowledge.py:222
+msgid "Get the knowledge base paginated list"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow_version.py:40
+#: apps/knowledge/views/knowledge_workflow_version.py:41
+#: apps/knowledge/views/knowledge_workflow_version.py:42
+msgid "Get the knowledge version list"
+msgstr ""
+
+#: apps/application/views/application_version.py:54
+#: apps/application/views/application_version.py:55
+#: apps/application/views/application_version.py:56
+msgid "Get the list of application versions by page"
+msgstr "Get the list of agent versions by page"
+
+#: apps/knowledge/views/knowledge_workflow_version.py:64
+#: apps/knowledge/views/knowledge_workflow_version.py:65
+#: apps/knowledge/views/knowledge_workflow_version.py:66
+msgid "Get the list of knowledge versions by page"
+msgstr ""
+
+#: apps/application/views/application_chat_record.py:140
+#: apps/application/views/application_chat_record.py:141
+#: apps/application/views/application_chat_record.py:142
+msgid "Get the list of marked paragraphs"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:158
+#: apps/tools/views/tool_workflow.py:159
+#: apps/tools/views/tool_workflow.py:160
+msgid "Get the list of MCP tools"
+msgstr ""
+
+#: apps/knowledge/views/problem.py:232
+#: apps/knowledge/views/problem.py:233
+#: apps/knowledge/views/problem.py:234
+msgid "Get the list of questions by page"
+msgstr ""
+
+#: no source
+msgid "Get the list of shared questions by page"
+msgstr ""
+
+#: no source
+msgid "Get the list of system questions by page"
+msgstr ""
+
+#: apps/knowledge/views/termbase.py:238
+#: apps/knowledge/views/termbase.py:239
+#: apps/knowledge/views/termbase.py:240
+msgid "Get the list of termbase by page"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:65
+#: apps/tools/views/tool_workflow_version.py:66
+#: apps/tools/views/tool_workflow_version.py:67
+msgid "Get the list of tool versions by page"
+msgstr ""
+
+#: apps/models_provider/views/provide.py:92
+#: apps/models_provider/views/provide.py:93
+#: apps/models_provider/views/provide.py:94
+msgid "Get the model creation form"
+msgstr ""
+
+#: apps/chat/views/chat.py:184
+#: apps/chat/views/chat.py:185
+#: apps/chat/views/chat.py:186
+msgid "Get the session id according to the application id"
+msgstr "Get the session id according to the agent id"
+
+#: no source
+msgid "Get the System trigger list of source"
+msgstr ""
+
+#: apps/trigger/views/trigger_task.py:28
+#: apps/trigger/views/trigger_task.py:29
+#: apps/trigger/views/trigger_task.py:30
+msgid "Get the task list of triggers"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:41
+#: apps/tools/views/tool_workflow_version.py:42
+#: apps/tools/views/tool_workflow_version.py:43
+msgid "Get the tool version list"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:79
+#: apps/trigger/views/trigger.py:80
+#: apps/trigger/views/trigger.py:81
+msgid "Get the trigger list"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:227
+#: apps/trigger/views/trigger.py:228
+#: apps/trigger/views/trigger.py:229
+msgid "Get the trigger list by page"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:290
+#: apps/trigger/views/trigger.py:291
+#: apps/trigger/views/trigger.py:292
+msgid "Get the trigger list of source"
+msgstr ""
+
+#: apps/tools/views/tool.py:149
+#: apps/tools/views/tool.py:150
+#: apps/tools/views/tool.py:151
 msgid "Get tool"
 msgstr ""
 
-#: apps/tools/views/tool.py:141 apps/tools/views/tool.py:142
-#: apps/tools/views/tool.py:143
-msgid "Delete tool"
+#: apps/tools/views/tool.py:68
+#: apps/tools/views/tool.py:69
+#: apps/tools/views/tool.py:70
+msgid "Get tool by folder"
 msgstr ""
 
-#: apps/tools/views/tool.py:167 apps/tools/views/tool.py:168
-#: apps/tools/views/tool.py:169
+#: apps/tools/views/tool.py:314
+#: apps/tools/views/tool.py:315
+msgid "Get tool list"
+msgstr ""
+
+#: apps/tools/views/tool.py:313
+msgid "Get tool list "
+msgstr ""
+
+#: apps/tools/views/tool.py:282
+#: apps/tools/views/tool.py:283
+#: apps/tools/views/tool.py:284
 msgid "Get tool list by pagination"
 msgstr ""
 
-#: apps/tools/views/tool.py:195 apps/tools/views/tool.py:196
-#: apps/tools/views/tool.py:197
+#: apps/tools/views/tool.py:640
+#: apps/tools/views/tool.py:641
+#: apps/tools/views/tool.py:642
+msgid "Get tool record"
+msgstr ""
+
+#: apps/tools/views/tool.py:611
+#: apps/tools/views/tool.py:612
+#: apps/tools/views/tool.py:613
+msgid "Get tool records"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:90
+#: apps/tools/views/tool_workflow_version.py:91
+#: apps/tools/views/tool_workflow_version.py:92
+msgid "Get tool version details"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:100
+#: apps/tools/views/tool_workflow.py:101
+#: apps/tools/views/tool_workflow.py:102
+msgid "Get tool workflow"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:105
+#: apps/trigger/views/trigger.py:106
+#: apps/trigger/views/trigger.py:107
+msgid "Get trigger details"
+msgstr ""
+
+#: apps/oss/views/file.py:76
+#: apps/oss/views/file.py:78
+#: apps/oss/views/file.py:79
+msgid "Get url"
+msgstr ""
+
+#: apps/system_manage/views/user_resource_permission.py:110
+#: apps/system_manage/views/user_resource_permission.py:111
+#: apps/system_manage/views/user_resource_permission.py:112
+msgid "Get user authorization status of resource"
+msgstr ""
+
+#: apps/system_manage/views/user_resource_permission.py:176
+#: apps/system_manage/views/user_resource_permission.py:177
+#: apps/system_manage/views/user_resource_permission.py:178
+msgid "Get user authorization status of resource by page"
+msgstr ""
+
+#: no source
+msgid "Get user group list"
+msgstr ""
+
+#: apps/users/views/user.py:219
+#: apps/users/views/user.py:220
+#: apps/users/views/user.py:221
+msgid "Get user information"
+msgstr ""
+
+#: no source
+msgid "Get user list by group"
+msgstr ""
+
+#: apps/users/views/user.py:146
+#: apps/users/views/user.py:147
+#: apps/users/views/user.py:148
+msgid "Get user list under workspace"
+msgstr ""
+
+#: apps/users/views/user.py:161
+#: apps/users/views/user.py:162
+#: apps/users/views/user.py:163
+msgid "Get user member under workspace"
+msgstr ""
+
+#: apps/users/views/user.py:284
+#: apps/users/views/user.py:285
+#: apps/users/views/user.py:286
+msgid "Get user paginated list"
+msgstr ""
+
+#: apps/system_manage/views/valid.py:25
+#: apps/system_manage/views/valid.py:26
+#: apps/system_manage/views/valid.py:27
+msgid "Get verification results"
+msgstr ""
+
+#: no source
+msgid "Get workspace list"
+msgstr ""
+
+#: no source
+msgid "Get workspace list by current user"
+msgstr ""
+
+#: no source
+msgid "Get workspace list by user"
+msgstr ""
+
+#: no source
+msgid "Get workspace member list"
+msgstr ""
+
+#: no source
+msgid "Get Workspace role list"
+msgstr ""
+
+#: no source
+msgid "Get workspace role member list"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:91
+msgid "Global variables"
+msgstr ""
+
+#: no source
+msgid "Good at common conversational tasks, supports 32K contexts"
+msgstr ""
+
+#: no source
+msgid "Good at handling programming tasks, supports 16K contexts"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:53
+msgid "gpt-3.5-turbo snapshot on January 25, 2024, supporting context length 16,385 tokens"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:57
+msgid "gpt-3.5-turbo snapshot on November 6, 2023, supporting context length 16,385 tokens"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:69
+msgid "gpt-4-turbo snapshot on April 9, 2024, supporting context length 128,000 tokens"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:72
+msgid "gpt-4-turbo snapshot on January 25, 2024, supporting context length 128,000 tokens"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:75
+msgid "gpt-4-turbo snapshot on November 6, 2023, supporting context length 128,000 tokens"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:65
+msgid "gpt-4o snapshot on May 13, 2024, supporting context length 128,000 tokens"
+msgstr ""
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:19
+msgid "Group id"
+msgstr ""
+
+#: no source
+msgid "Group ID"
+msgstr ""
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:20
+msgid "group_name"
+msgstr ""
+
+#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:34
+msgid "Have strong multi-modal understanding capabilities. Able to understand up to five images simultaneously and supports video content understanding"
+msgstr ""
+
+#: no source
+msgid "header font color"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:71
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:73
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:76
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:73
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:73
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tti.py:61
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py:44
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:52
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:56
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:33
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:53
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:46
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:50
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:36
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:55
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:68
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:54
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:54
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:52
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/gemini_model_provider/model/stt.py:48
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:56
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:35
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:47
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:47
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/minimax_model_provider/model/tts.py:44
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:37
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:54
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:54
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:36
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:55
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:54
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:22
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:56
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/tencent_model_provider/model/tti.py:56
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:49
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:44
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:52
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:56
+#: apps/models_provider/impl/volcanic_engine_model_provider/model/tts.py:79
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:46
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:66
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:43
+#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:75
+#: apps/models_provider/impl/xf_model_provider/model/tts/super_humanoid_tts.py:101
+#: apps/models_provider/impl/xf_model_provider/model/tts/tts.py:103
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:31
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:52
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:44
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:44
+#: apps/models_provider/impl/xinference_model_provider/model/tts.py:48
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:52
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:55
+#: apps/models_provider/impl/zhipu_model_provider/model/tti.py:54
+msgid "Hello"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:48
+msgid "High-speed version of M2.7 for low-latency scenarios. 204K context window"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:22
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:17
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:16
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:15
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:14
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:18
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:18
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:16
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:16
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:13
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:18
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:19
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:18
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:23
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:14
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:16
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:16
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:41
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:16
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:16
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:16
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:22
+msgid "Higher values make the output more random, while lower values make it more focused and deterministic"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:34
+msgid "Hindi"
+msgstr ""
+
+#: apps/application/serializers/application.py:350
+#: apps/application/serializers/application.py:597
+msgid "Historical chat records"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:32
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:27
+msgid "History Questions"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:170
+#: apps/knowledge/serializers/document.py:248
+#: apps/knowledge/serializers/document.py:478
+msgid "hit handling method"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:770
+msgid "Hit handling method"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1505
+msgid "Hit handling method is required"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:284
+#: apps/knowledge/views/knowledge.py:285
+#: apps/knowledge/views/knowledge.py:286
+msgid "Hit test list"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:360
+#: apps/common/constants/permission_constants.py:418
+#: apps/common/constants/permission_constants.py:428
+msgid "Hit-Test"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:409
+#: apps/homepage/views/homepage.py:38
+#: apps/homepage/views/homepage.py:63
+#: apps/homepage/views/homepage.py:88
+#: apps/homepage/views/homepage.py:113
+#: apps/homepage/views/homepage.py:138
+#: apps/homepage/views/homepage.py:163
+#: apps/homepage/views/homepage.py:188
+#: apps/homepage/views/homepage.py:212
+#: apps/homepage/views/homepage.py:237
+#: apps/homepage/views/homepage.py:264
+#: apps/homepage/views/homepage.py:285
+#: apps/homepage/views/homepage.py:306
+#: apps/homepage/views/homepage.py:327
+msgid "Home page"
+msgstr ""
+
+#: apps/chat/api/chat_embed_api.py:24
+msgid "host"
+msgstr ""
+
+#: apps/chat/serializers/chat_embed_serializers.py:25
+msgid "Host"
+msgstr ""
+
+#: apps/oss/serializers/file.py:99
+msgid "HTTP Range"
+msgstr ""
+
+#: apps/oss/serializers/file.py:100
+msgid "HTTP Range header for partial content requests, e.g., \"bytes=0-1023\""
+msgstr ""
+
+#: no source
+msgid "HttpClient query failed: "
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:102
+msgid "Hunyuan graph model"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:71
+msgid "Hunyuan's latest code generation model, after training the base model with 200B high-quality code data, and iterating on high-quality SFT data for half a year, the context long window length has been increased to 8K, and it ranks among the top in the automatic evaluation indicators of code generation in the five major languages; the five major languages In the manual high-quality evaluation of 10 comprehensive code tasks that consider all aspects, the performance is in the first echelon."
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:65
+msgid "Hunyuan's latest MOE architecture FunctionCall model has been trained with high-quality FunctionCall data and has a context window of 32K, leading in multiple dimensions of evaluation indicators."
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:59
+msgid "Hunyuan's latest version of the role-playing model, a role-playing model launched by Hunyuan's official fine-tuning training, is based on the Hunyuan model combined with the role-playing scene data set for additional training, and has better basic effects in role-playing scenes."
+msgstr ""
+
+#: apps/application/serializers/application.py:611
+msgid "Icon"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:19
+#: apps/tools/serializers/tool.py:1379
+msgid "icon"
+msgstr ""
+
+#: no source
+msgid "icon url"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1360
+#: apps/knowledge/serializers/knowledge.py:1505
+#: apps/users/api/user.py:76
+msgid "id"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1280
+#: apps/knowledge/serializers/knowledge.py:1386
+msgid "id does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:52
+#: apps/knowledge/serializers/document.py:124
+#: apps/knowledge/serializers/document.py:231
+#: apps/knowledge/serializers/document.py:247
+#: apps/trigger/serializers/trigger.py:32
+msgid "id list"
+msgstr ""
+
+#: apps/application/serializers/application.py:1754
+msgid "id list cannot be empty"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:114
+msgid "Ideal for content creation, conversational AI, language understanding, R&D, and enterprise applications"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:120
+msgid "Ideal for limited computing power and resources, edge devices, and faster training times."
+msgstr ""
+
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:17
+msgid "If not passed, the default value is 'zh'"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:15
+msgid "If not passed, the default value is 16000"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:12
+msgid "If not passed, the default value is 16k_zh (Chinese universal)"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:13
+msgid "If not passed, the default value is 201 (Japanese anime style)"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:19
+msgid "If not passed, the default value is iat"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:24
+msgid "If not passed, the default value is mandarin"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:14
+msgid "If not passed, the default value is streaming_asr_demo"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:13
+msgid "If not passed, the default value is What is this audio saying? Only answer the audio content"
+msgstr ""
+
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:14
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:14
+msgid "If not passed, the default value is zh"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:14
+msgid "If not passed, the default value is zh_cn"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:49
+msgid "If not transmitted, the default value is 768:768."
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:16
+msgid "If the gap between width, height and 512 is too large, the picture rendering effect will be poor and the probability of excessive delay will increase significantly. Recommended ratio and corresponding width and height before super score: width*height"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:85
+msgid "iFlytek Spark"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:23
+msgid "iFlytek Xiaojing"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:22
+msgid "iFlytek Xiaoping"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:20
+msgid "iFlytek Xiaoyan"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:21
+msgid "iFlytek Xujiu"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:24
+msgid "iFlytek Xuxiaobao"
+msgstr ""
+
+#: apps/application/serializers/application.py:684
+#: apps/application/serializers/application.py:1454
+#: apps/knowledge/serializers/knowledge_workflow.py:381
+#: apps/knowledge/serializers/knowledge_workflow.py:628
+#: apps/tools/serializers/tool.py:496
+#: apps/tools/serializers/tool_workflow.py:362
+msgid "Illegal download callback url"
+msgstr ""
+
+#: apps/application/serializers/application.py:660
+#: apps/application/serializers/application.py:1395
+#: apps/knowledge/serializers/knowledge_workflow.py:367
+#: apps/knowledge/serializers/knowledge_workflow.py:614
+#: apps/tools/serializers/tool.py:481
+#: apps/tools/serializers/tool.py:1319
+#: apps/tools/serializers/tool_workflow.py:346
+msgid "Illegal download url"
+msgstr ""
+
+#: apps/chat/serializers/chat_authentication.py:120
+msgid "Illegal User"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:25
+msgid "illustration"
+msgstr ""
+
+#: no source
+msgid "Image download failed, check network"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:152
+msgid "Image Generation"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:15
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:14
+msgid "Image size"
+msgstr ""
+
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:15
+msgid "Image size, only cogview-3-plus supports this parameter. Optional range: [1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440], the default is 1024x1024."
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:156
+msgid "Image to Video"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:24
+msgid "impasto style"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:361
+msgid "Import"
+msgstr ""
+
+#: apps/application/views/application.py:115
+#: apps/application/views/application.py:116
+#: apps/application/views/application.py:117
+msgid "Import Application"
+msgstr ""
+
+#: no source
+msgid "Import documents to the lark knowledge base"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:448
+#: apps/knowledge/views/knowledge.py:449
+#: apps/knowledge/views/knowledge.py:450
+msgid "Import knowledge bundle"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:325
+#: apps/knowledge/views/knowledge_workflow.py:326
+#: apps/knowledge/views/knowledge_workflow.py:327
+msgid "Import knowledge workflow"
+msgstr ""
+
+#: apps/knowledge/views/document.py:1239
+#: apps/knowledge/views/document.py:1240
+#: apps/knowledge/views/document.py:1241
+msgid "Import QA and create documentation"
+msgstr ""
+
+#: no source
+msgid "Import QA and create shared documentation"
+msgstr ""
+
+#: no source
+msgid "Import shared tool"
+msgstr ""
+
+#: apps/knowledge/views/document.py:1281
+#: apps/knowledge/views/document.py:1282
+#: apps/knowledge/views/document.py:1283
+msgid "Import tables and create documents"
+msgstr ""
+
+#: no source
+msgid "Import tables and create shared documents"
+msgstr ""
+
+#: apps/tools/views/tool.py:345
+#: apps/tools/views/tool.py:346
+#: apps/tools/views/tool.py:347
 msgid "Import tool"
 msgstr ""
 
-#: apps/tools/views/tool.py:218 apps/tools/views/tool.py:219
-#: apps/tools/views/tool.py:220
-msgid "Export tool"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:27
+msgid "Impressionism 1 (Monet)"
 msgstr ""
 
-#: apps/tools/views/tool.py:244 apps/tools/views/tool.py:245
-#: apps/tools/views/tool.py:246
-msgid "Check code"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:28
+msgid "Impressionism 2"
 msgstr ""
 
-#: apps/tools/views/tool.py:268 apps/tools/views/tool.py:269
-#: apps/tools/views/tool.py:270
-msgid "Edit tool icon"
+#: apps/application/serializers/application_chat.py:173
+msgid "inaccurate"
 msgstr ""
 
-#: apps/users/api/user.py:154
-msgid "Email or Username"
+#: apps/homepage/api/home_page_api.py:386
+msgid "Inactive model count"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:349
+msgid "Inactive tool count"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:173
+msgid "incomplete"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:51
+msgid "Incorrect trigger task"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:27
+msgid "Indonesian language"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:291
+#: apps/tools/serializers/tool.py:307
+#: apps/tools/serializers/tool.py:330
+msgid "init field list"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1574
+msgid "Init Field List"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:308
+#: apps/tools/serializers/tool.py:331
+msgid "init params"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:18
+msgid "ink painting"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:289
+#: apps/tools/serializers/tool.py:306
+#: apps/tools/serializers/tool.py:329
+msgid "input field list"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1575
+msgid "Input Field List"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:34
+#: apps/tools/serializers/tool.py:275
+msgid "input type"
+msgstr ""
+
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:14
+#: apps/application/flow/step_node/variable_splitting_node/i_variable_splitting_node.py:14
+msgid "input variable"
+msgstr ""
+
+#: no source
+msgid "input_field_list must be a dict"
+msgstr ""
+
+#: apps/maxkb/settings/base/model.py:99
+#: apps/maxkb/settings/base/web.py:116
+msgid "Intelligent customer service platform"
+msgstr ""
+
+#: no source
+msgid "Internal role"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:220
+msgid "interval_unit must be one of %s"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:215
+msgid "interval_value must be an integer greater than or equal to 1"
+msgstr ""
+
+#: apps/users/serializers/login.py:291
+msgid "Invalid access token"
+msgstr ""
+
+#: apps/chat/serializers/chat_authentication.py:49
+#: apps/chat/serializers/chat_authentication.py:60
+#: apps/chat/serializers/chat_authentication.py:62
+msgid "Invalid access_token"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:79
+msgid "Invalid chat record ids"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:236
+msgid "Invalid cron expression: %s"
+msgstr ""
+
+#: apps/users/serializers/login.py:112
+#: apps/users/serializers/user.py:551
+#: apps/users/views/user.py:396
+msgid "Invalid encrypted data"
+msgstr ""
+
+#: no source
+msgid "Invalid json format."
+msgstr ""
+
+#: no source
+msgid "Invalid license file format"
+msgstr ""
+
+#: no source
+msgid "Invalid role type"
+msgstr ""
+
+#: no source
+msgid "Invalid Slack request"
+msgstr ""
+
+#: no source
+msgid "Invalid source type"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:162
+msgid "Invalid time format: %s, must be HH:MM (e.g., 09:00)"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:221
+msgid "Ip Address"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:221
+#: apps/chat/serializers/chat.py:292
+#: apps/chat/serializers/chat.py:537
+msgid "IP Address"
+msgstr ""
+
+#: no source
+msgid "ip_address"
+msgstr ""
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:43
+#: apps/knowledge/serializers/knowledge.py:772
+#: apps/knowledge/serializers/paragraph.py:76
+#: apps/tools/serializers/tool.py:293
+#: apps/tools/serializers/tool.py:311
+#: apps/trigger/serializers/trigger.py:255
+#: apps/trigger/serializers/trigger.py:277
+#: apps/trigger/serializers/trigger.py:312
+#: apps/trigger/serializers/trigger.py:641
+#: apps/users/serializers/user.py:253
+msgid "Is active"
+msgstr ""
+
+#: apps/users/serializers/user.py:408
+msgid "Is Active"
+msgstr ""
+
+#: no source
+msgid "Is Append"
+msgstr ""
+
+#: no source
+msgid "is auth"
+msgstr ""
+
+#: no source
+msgid "Is auth"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:26
+msgid "Is cross-domain allowed"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:39
+msgid "Is delete"
+msgstr ""
+
+#: apps/users/serializers/user.py:56
+msgid "Is Edit Password"
+msgstr ""
+
+#: no source
+msgid "Is Exist"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:26
+msgid "Is it enabled"
+msgstr ""
+
+#: apps/application/api/application_chat_record.py:53
+#: apps/application/serializers/application_chat_record.py:94
+msgid "Is it in order"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:32
+msgid "Is permanent"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:77
+msgid "Is the answer in streaming mode"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:25
+msgid "Is this field required"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:33
+msgid "is_active"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:23
+msgid "Japanese"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:37
+msgid "Japanese animation"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:22
+msgid "Japanese male"
+msgstr ""
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:14
+msgid "Key"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:341
+#: apps/common/constants/permission_constants.py:354
+#: apps/common/constants/permission_constants.py:412
+#: apps/common/constants/permission_constants.py:422
+#: apps/common/constants/permission_constants.py:435
+#: apps/knowledge/views/knowledge_workflow.py:259
+msgid "Knowledge"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge_workflow.py:267
+msgid "knowledge action id"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:42
+#: apps/knowledge/views/knowledge.py:71
+#: apps/knowledge/views/knowledge.py:98
+#: apps/knowledge/views/knowledge.py:124
+#: apps/knowledge/views/knowledge.py:149
+#: apps/knowledge/views/knowledge.py:187
+#: apps/knowledge/views/knowledge.py:225
+#: apps/knowledge/views/knowledge.py:255
+#: apps/knowledge/views/knowledge.py:290
+#: apps/knowledge/views/knowledge.py:340
+#: apps/knowledge/views/knowledge.py:367
+#: apps/knowledge/views/knowledge.py:394
+#: apps/knowledge/views/knowledge.py:421
+#: apps/knowledge/views/knowledge.py:454
+#: apps/knowledge/views/knowledge.py:488
+#: apps/knowledge/views/knowledge.py:517
+#: apps/knowledge/views/knowledge.py:575
+#: apps/knowledge/views/knowledge.py:600
+#: apps/knowledge/views/knowledge.py:628
+#: apps/knowledge/views/knowledge_workflow.py:82
+#: apps/knowledge/views/knowledge_workflow.py:116
+#: apps/knowledge/views/knowledge_workflow.py:146
+#: apps/knowledge/views/knowledge_workflow.py:175
+#: apps/knowledge/views/knowledge_workflow.py:204
+#: apps/knowledge/views/knowledge_workflow.py:234
+#: apps/knowledge/views/knowledge_workflow.py:298
+#: apps/knowledge/views/knowledge_workflow.py:331
+#: apps/knowledge/views/knowledge_workflow.py:372
+#: apps/knowledge/views/knowledge_workflow.py:403
+#: apps/knowledge/views/knowledge_workflow.py:433
+#: apps/knowledge/views/knowledge_workflow.py:464
+msgid "Knowledge Base"
+msgstr ""
+
+#: no source
+msgid "knowledge Base"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge_workflow.py:89
+msgid "knowledge base data"
+msgstr ""
+
+#: apps/application/serializers/application.py:231
+#: apps/application/serializers/application_chat_record.py:250
+#: apps/application/serializers/application_chat_record.py:376
+#: apps/application/serializers/application_chat_record.py:476
+msgid "Knowledge base id"
+msgstr ""
+
+#: apps/application/serializers/application.py:232
+msgid "Knowledge Base List"
+msgstr ""
+
+#: no source
+msgid "Knowledge base name duplicate!"
+msgstr ""
+
+#: no source
+msgid "Knowledge base not found!"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:125
+#: apps/knowledge/serializers/common.py:161
+msgid "Knowledge base setting error, please reset the knowledge base"
+msgstr ""
+
+#: apps/knowledge/views/document.py:59
+#: apps/knowledge/views/document.py:92
+#: apps/knowledge/views/document.py:132
+#: apps/knowledge/views/document.py:158
+#: apps/knowledge/views/document.py:191
+#: apps/knowledge/views/document.py:230
+#: apps/knowledge/views/document.py:273
+#: apps/knowledge/views/document.py:293
+#: apps/knowledge/views/document.py:331
+#: apps/knowledge/views/document.py:369
+#: apps/knowledge/views/document.py:407
+#: apps/knowledge/views/document.py:444
+#: apps/knowledge/views/document.py:481
+#: apps/knowledge/views/document.py:519
+#: apps/knowledge/views/document.py:559
+#: apps/knowledge/views/document.py:599
+#: apps/knowledge/views/document.py:638
+#: apps/knowledge/views/document.py:677
+#: apps/knowledge/views/document.py:716
+#: apps/knowledge/views/document.py:754
+#: apps/knowledge/views/document.py:845
+#: apps/knowledge/views/document.py:890
+#: apps/knowledge/views/document.py:923
+#: apps/knowledge/views/document.py:956
+#: apps/knowledge/views/document.py:981
+#: apps/knowledge/views/document.py:1014
+#: apps/knowledge/views/document.py:1044
+#: apps/knowledge/views/document.py:1078
+#: apps/knowledge/views/document.py:1159
+#: apps/knowledge/views/document.py:1203
+#: apps/knowledge/views/document.py:1245
+#: apps/knowledge/views/document.py:1287
+#: apps/knowledge/views/document.py:1326
+#: apps/knowledge/views/document.py:1340
+msgid "Knowledge Base/Documentation"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:29
+#: apps/knowledge/views/paragraph.py:55
+#: apps/knowledge/views/paragraph.py:87
+#: apps/knowledge/views/paragraph.py:110
+#: apps/knowledge/views/paragraph.py:149
+#: apps/knowledge/views/paragraph.py:181
+#: apps/knowledge/views/paragraph.py:216
+#: apps/knowledge/views/paragraph.py:244
+#: apps/knowledge/views/paragraph.py:282
+#: apps/knowledge/views/paragraph.py:315
+#: apps/knowledge/views/paragraph.py:345
+#: apps/knowledge/views/paragraph.py:383
+#: apps/knowledge/views/paragraph.py:420
+#: apps/knowledge/views/paragraph.py:452
+msgid "Knowledge Base/Documentation/Paragraph"
+msgstr ""
+
+#: apps/knowledge/views/problem.py:28
+#: apps/knowledge/views/problem.py:56
+#: apps/knowledge/views/problem.py:84
+#: apps/knowledge/views/problem.py:113
+#: apps/knowledge/views/problem.py:143
+#: apps/knowledge/views/problem.py:172
+#: apps/knowledge/views/problem.py:204
+#: apps/knowledge/views/problem.py:237
+msgid "Knowledge Base/Documentation/Paragraph/Question"
+msgstr ""
+
+#: apps/knowledge/views/termbase.py:33
+#: apps/knowledge/views/termbase.py:64
+#: apps/knowledge/views/termbase.py:99
+#: apps/knowledge/views/termbase.py:134
+#: apps/knowledge/views/termbase.py:168
+#: apps/knowledge/views/termbase.py:205
+#: apps/knowledge/views/termbase.py:243
+msgid "Knowledge Base/Documentation/Termbase"
+msgstr ""
+
+#: apps/knowledge/views/document.py:1119
+#: apps/knowledge/views/tag.py:25
+#: apps/knowledge/views/tag.py:49
+#: apps/knowledge/views/tag.py:78
+#: apps/knowledge/views/tag.py:105
+#: apps/knowledge/views/tag.py:132
+msgid "Knowledge Base/Tag"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:280
+#: apps/homepage/views/homepage.py:281
+msgid "Knowledge data aggregation"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:111
+#: apps/knowledge/serializers/knowledge.py:122
+#: apps/knowledge/serializers/knowledge.py:130
+#: apps/knowledge/serializers/knowledge.py:182
+msgid "knowledge description"
+msgstr ""
+
+#: apps/knowledge/task/embedding.py:121
+msgid "Knowledge documentation: {document_names}"
+msgstr ""
+
+#: no source
+msgid "Knowledge does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:112
+#: apps/knowledge/serializers/knowledge.py:123
+msgid "knowledge embedding"
+msgstr ""
+
+#: apps/application/api/application_chat_record.py:129
+#: apps/knowledge/serializers/knowledge.py:1472
+#: apps/knowledge/serializers/knowledge_version.py:45
+#: apps/knowledge/serializers/knowledge_version.py:82
+#: apps/knowledge/serializers/tag.py:47
+#: apps/knowledge/serializers/tag.py:94
+#: apps/knowledge/serializers/tag.py:168
+#: apps/knowledge/serializers/tag.py:202
+msgid "Knowledge ID"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:355
+#: apps/knowledge/serializers/document.py:473
+#: apps/knowledge/serializers/document.py:587
+#: apps/knowledge/serializers/document.py:686
+#: apps/knowledge/serializers/document.py:1207
+#: apps/knowledge/serializers/document.py:1293
+#: apps/knowledge/serializers/document.py:1315
+#: apps/knowledge/serializers/document.py:1652
+#: apps/knowledge/serializers/document.py:1698
+#: apps/knowledge/serializers/document.py:1773
+#: apps/knowledge/serializers/document.py:1814
+#: apps/knowledge/serializers/document.py:1843
+#: apps/knowledge/serializers/document.py:1879
+#: apps/knowledge/serializers/knowledge.py:316
+#: apps/knowledge/serializers/knowledge.py:1256
+#: apps/knowledge/serializers/knowledge_workflow.py:114
+#: apps/knowledge/serializers/knowledge_workflow.py:266
+#: apps/knowledge/serializers/knowledge_workflow.py:391
+#: apps/knowledge/serializers/knowledge_workflow.py:518
+#: apps/knowledge/serializers/knowledge_workflow.py:568
+#: apps/knowledge/serializers/knowledge_workflow.py:646
+#: apps/knowledge/serializers/paragraph.py:108
+#: apps/knowledge/serializers/paragraph.py:204
+#: apps/knowledge/serializers/paragraph.py:339
+#: apps/knowledge/serializers/paragraph.py:437
+#: apps/knowledge/serializers/paragraph.py:473
+#: apps/knowledge/serializers/paragraph.py:553
+#: apps/knowledge/serializers/paragraph.py:602
+#: apps/knowledge/serializers/paragraph.py:779
+#: apps/knowledge/serializers/problem.py:64
+#: apps/knowledge/serializers/problem.py:138
+#: apps/knowledge/serializers/problem.py:198
+#: apps/knowledge/serializers/problem.py:235
+#: apps/knowledge/serializers/termbase.py:36
+#: apps/knowledge/serializers/termbase.py:66
+#: apps/knowledge/serializers/termbase.py:104
+#: apps/knowledge/serializers/termbase.py:140
+msgid "knowledge id"
+msgstr ""
+
+#: no source
+msgid "Knowledge id"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:396
+#: apps/knowledge/serializers/document.py:368
+#: apps/knowledge/serializers/document.py:373
+#: apps/knowledge/serializers/document.py:597
+#: apps/knowledge/serializers/document.py:695
+#: apps/knowledge/serializers/document.py:1216
+#: apps/knowledge/serializers/document.py:1325
+#: apps/knowledge/serializers/document.py:1661
+#: apps/knowledge/serializers/document.py:1709
+#: apps/knowledge/serializers/document.py:1786
+#: apps/knowledge/serializers/document.py:1827
+#: apps/knowledge/serializers/document.py:1853
+#: apps/knowledge/serializers/document.py:1890
+#: apps/knowledge/serializers/knowledge.py:333
+#: apps/knowledge/serializers/knowledge.py:1277
+#: apps/knowledge/serializers/knowledge.py:1384
+#: apps/knowledge/serializers/knowledge_version.py:92
+#: apps/knowledge/serializers/knowledge_workflow.py:657
+#: apps/knowledge/serializers/paragraph.py:119
+#: apps/knowledge/serializers/paragraph.py:215
+#: apps/knowledge/serializers/paragraph.py:449
+#: apps/knowledge/serializers/paragraph.py:488
+#: apps/knowledge/serializers/paragraph.py:563
+#: apps/knowledge/serializers/paragraph.py:619
+#: apps/knowledge/serializers/paragraph.py:790
+#: apps/knowledge/serializers/problem.py:73
+#: apps/knowledge/serializers/problem.py:148
+#: apps/knowledge/serializers/problem.py:207
+#: apps/knowledge/serializers/problem.py:245
+#: apps/knowledge/serializers/tag.py:57
+#: apps/knowledge/serializers/tag.py:104
+#: apps/knowledge/serializers/tag.py:178
+#: apps/knowledge/serializers/tag.py:212
+#: apps/knowledge/serializers/termbase.py:45
+#: apps/knowledge/serializers/termbase.py:76
+#: apps/knowledge/serializers/termbase.py:113
+#: apps/knowledge/serializers/termbase.py:150
+msgid "Knowledge id does not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:14
+msgid "knowledge id list"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1008
+msgid "knowledge id not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:249
+#: apps/knowledge/serializers/common.py:274
+msgid "Knowledge ID or Document ID must be provided"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1505
+msgid "knowledge ids"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1486
+msgid "Knowledge is already a workflow"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:109
+#: apps/knowledge/serializers/knowledge.py:120
+#: apps/knowledge/serializers/knowledge.py:129
+#: apps/knowledge/serializers/knowledge.py:178
+msgid "knowledge name"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1484
+msgid "Knowledge not found"
+msgstr ""
+
+#: no source
+msgid "Knowledge Resource"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:189
+msgid "knowledge scope"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:125
+msgid "knowledge selector"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge_version.py:83
+msgid "Knowledge version ID"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:110
+#: apps/knowledge/views/knowledge_workflow.py:111
+#: apps/knowledge/views/knowledge_workflow.py:112
+msgid "Knowledge workflow debug"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:76
+#: apps/knowledge/views/knowledge_workflow.py:77
+#: apps/knowledge/views/knowledge_workflow.py:78
+msgid "Knowledge workflow upload document"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow_version.py:45
+#: apps/knowledge/views/knowledge_workflow_version.py:69
+#: apps/knowledge/views/knowledge_workflow_version.py:94
+#: apps/knowledge/views/knowledge_workflow_version.py:116
+msgid "Knowledge/Version"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:24
+msgid "Korean"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:26
+msgid "Korean female"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:35
+msgid "label"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:40
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:14
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:14
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:16
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:14
+#: apps/users/serializers/user.py:1188
+msgid "language"
 msgstr ""
 
 #: apps/users/api/user.py:224
 msgid "Language"
 msgstr ""
 
-#: apps/users/serializers/login.py:29 apps/users/serializers/login.py:69
-msgid "captcha"
-msgstr ""
-
-#: apps/users/serializers/login.py:50
-#: apps/xpack/serializers/chat_user_serializer.py:120
-msgid "Captcha code error or expiration"
-msgstr ""
-
-#: apps/users/serializers/login.py:55
-#: apps/xpack/serializers/auth_config_serializer.py:192
-#: apps/xpack/serializers/chat_user_serializer.py:125
-#: apps/xpack/serializers/qr_login/qr_login.py:37
-msgid "The user has been disabled, please contact the administrator!"
-msgstr ""
-
-#: apps/users/serializers/user.py:47
-msgid "Is Edit Password"
-msgstr ""
-
-#: apps/users/serializers/user.py:48
-msgid "permissions"
-msgstr ""
-
-#: apps/users/serializers/user.py:58 apps/users/serializers/user.py:106
-#: apps/users/serializers/user.py:250 apps/users/serializers/user.py:557
-#: apps/users/serializers/user.py:641 apps/xpack/api/chat_user.py:107
-#: apps/xpack/serializers/chat_user.py:54
-#: apps/xpack/serializers/chat_user.py:227
-msgid "Email"
-msgstr ""
-
-#: apps/users/serializers/user.py:59 apps/users/serializers/user.py:140
-#: apps/xpack/serializers/chat_user.py:88
-msgid "Nick name"
-msgstr ""
-
-#: apps/users/serializers/user.py:60 apps/users/serializers/user.py:145
-#: apps/users/serializers/user.py:263 apps/xpack/api/chat_user.py:108
-#: apps/xpack/serializers/chat_user.py:93
-#: apps/xpack/serializers/chat_user.py:240
-msgid "Phone"
-msgstr ""
-
-#: apps/users/serializers/user.py:120 apps/xpack/serializers/chat_user.py:68
-msgid "Username must be 4-64 characters long"
-msgstr ""
-
-#: apps/users/serializers/user.py:133 apps/users/serializers/user.py:298
-#: apps/xpack/serializers/chat_user.py:81
-#: apps/xpack/serializers/chat_user.py:274
-msgid ""
-"The password must be 6-20 characters long and must be a combination of "
-"letters, numbers, and special characters."
-msgstr ""
-
-#: apps/users/serializers/user.py:170
-msgid "Email or username"
-msgstr ""
-
-#: apps/users/serializers/user.py:226
-msgid ""
-"The community version supports up to 2 users. If you need more users, please "
-"contact us (https://fit2cloud.com/)."
-msgstr ""
-
-#: apps/users/serializers/user.py:270 apps/xpack/api/auth_config.py:31
-#: apps/xpack/api/chat_user.py:109 apps/xpack/serializers/chat_user.py:247
-msgid "Is Active"
-msgstr ""
-
-#: apps/users/serializers/user.py:281 apps/xpack/serializers/chat_user.py:262
-msgid "Nickname is already in use"
-msgstr ""
-
-#: apps/users/serializers/user.py:286
-msgid "Email is already in use"
-msgstr ""
-
-#: apps/users/serializers/user.py:305 apps/xpack/serializers/chat_user.py:281
-msgid "Re Password"
-msgstr ""
-
-#: apps/users/serializers/user.py:310 apps/users/serializers/user.py:522
-#: apps/users/serializers/user.py:529 apps/xpack/serializers/chat_user.py:286
-#: apps/xpack/serializers/chat_user.py:606
-#: apps/xpack/serializers/chat_user.py:613
-msgid ""
-"The confirmation password must be 6-20 characters long and must be a "
-"combination of letters, numbers, and special characters."
-msgstr ""
-
-#: apps/users/serializers/user.py:333 apps/xpack/serializers/chat_user.py:309
-msgid "User does not exist"
-msgstr ""
-
-#: apps/users/serializers/user.py:348
-msgid "Unable to delete administrator"
-msgstr ""
-
-#: apps/users/serializers/user.py:366
-msgid "Cannot modify administrator status"
-msgstr ""
-
-#: apps/users/serializers/user.py:478 apps/xpack/serializers/chat_user.py:164
-#: apps/xpack/serializers/chat_user.py:192
-#: apps/xpack/serializers/chat_user.py:512
-msgid "User IDs cannot be empty"
-msgstr ""
-
-#: apps/users/serializers/user.py:524 apps/xpack/serializers/chat_user.py:608
-msgid "Confirm Password"
-msgstr ""
-
-#: apps/users/serializers/user.py:561 apps/users/serializers/user.py:647
-#: apps/xpack/api/knowledge_lark.py:26
-msgid "Type"
-msgstr ""
-
-#: apps/users/serializers/user.py:563 apps/users/serializers/user.py:651
-msgid "The type only supports register|reset_password"
-msgstr ""
-
-#: apps/users/serializers/user.py:581
-#, python-brace-format
-msgid "Do not send emails again within {seconds} seconds"
-msgstr ""
-
-#: apps/users/serializers/user.py:611
-msgid ""
-"The email service has not been set up. Please contact the administrator to "
-"set up the email service in [Email Settings]."
-msgstr ""
-
-#: apps/users/serializers/user.py:622
-#, python-brace-format
-msgid "【Intelligent knowledge base question and answer system-{action}】"
-msgstr ""
-
-#: apps/users/serializers/user.py:623
-msgid "User registration"
-msgstr ""
-
-#: apps/users/serializers/user.py:623 apps/users/views/user.py:248
-#: apps/users/views/user.py:249 apps/users/views/user.py:250
-#: apps/users/views/user.py:283 apps/users/views/user.py:284
-#: apps/users/views/user.py:285
-msgid "Change password"
-msgstr ""
-
-#: apps/users/serializers/user.py:644
-msgid "Verification code"
-msgstr ""
-
-#: apps/users/serializers/user.py:672
+#: apps/users/serializers/user.py:1198
 msgid "language only support:"
 msgstr ""
 
-#: apps/users/views/login.py:38 apps/users/views/login.py:39
-#: apps/users/views/login.py:40 apps/xpack/views/chat_user_auth.py:184
-#: apps/xpack/views/chat_user_auth.py:185
-#: apps/xpack/views/chat_user_auth.py:186
-msgid "Log in"
-msgstr ""
-
-#: apps/users/views/login.py:55 apps/users/views/login.py:56
-#: apps/users/views/login.py:57 apps/xpack/views/chat_user_auth.py:203
-#: apps/xpack/views/chat_user_auth.py:204
-#: apps/xpack/views/chat_user_auth.py:205
-msgid "Sign out"
-msgstr ""
-
-#: apps/users/views/user.py:60 apps/users/views/user.py:61
-#: apps/users/views/user.py:62 apps/users/views/user.py:74
-#: apps/users/views/user.py:75 apps/xpack/views/system_chat_user.py:359
-#: apps/xpack/views/system_chat_user.py:360
-#: apps/xpack/views/system_chat_user.py:361
-msgid "Get current user information"
-msgstr ""
-
-#: apps/users/views/user.py:120 apps/users/views/user.py:121
-#: apps/users/views/user.py:122
-msgid "Get all user"
-msgstr ""
-
-#: apps/users/views/user.py:133 apps/users/views/user.py:134
-#: apps/users/views/user.py:135
-msgid "Get user list under workspace"
-msgstr ""
-
-#: apps/users/views/user.py:147 apps/users/views/user.py:148
-#: apps/users/views/user.py:149
-msgid "Get user member under workspace"
-msgstr ""
-
-#: apps/users/views/user.py:161 apps/users/views/user.py:162
-#: apps/users/views/user.py:163
-msgid "Create user"
-msgstr ""
-
-#: apps/users/views/user.py:177 apps/users/views/user.py:178
-#: apps/users/views/user.py:179
-msgid "Get default password"
-msgstr ""
-
-#: apps/users/views/user.py:190 apps/users/views/user.py:191
-#: apps/users/views/user.py:192
-msgid "Delete user"
-msgstr ""
-
-#: apps/users/views/user.py:203 apps/users/views/user.py:204
-#: apps/users/views/user.py:205
-msgid "Get user information"
-msgstr ""
-
-#: apps/users/views/user.py:214 apps/users/views/user.py:215
-#: apps/users/views/user.py:216
-msgid "Update user information"
-msgstr ""
-
-#: apps/users/views/user.py:232 apps/users/views/user.py:233
-#: apps/users/views/user.py:234
-msgid "Batch delete user"
-msgstr ""
-
-#: apps/users/views/user.py:266 apps/users/views/user.py:267
-#: apps/users/views/user.py:268 apps/workspace/views/workspace_chat_user.py:168
-#: apps/workspace/views/workspace_chat_user.py:169
-#: apps/workspace/views/workspace_chat_user.py:170
-#: apps/xpack/views/system_chat_user.py:197
-#: apps/xpack/views/system_chat_user.py:198
-#: apps/xpack/views/system_chat_user.py:199
-msgid "Get user paginated list"
-msgstr ""
-
-#: apps/users/views/user.py:300 apps/users/views/user.py:301
-#: apps/users/views/user.py:302
-msgid "Send email"
-msgstr ""
-
-#: apps/users/views/user.py:318 apps/users/views/user.py:319
-#: apps/users/views/user.py:320
-msgid "Check whether the verification code is correct"
-msgstr ""
-
-#: apps/users/views/user.py:335 apps/users/views/user.py:336
-#: apps/users/views/user.py:337
-msgid "Send email to current user"
-msgstr ""
-
-#: apps/users/views/user.py:353 apps/users/views/user.py:354
-#: apps/users/views/user.py:355 apps/xpack/views/system_chat_user.py:336
-#: apps/xpack/views/system_chat_user.py:337
-#: apps/xpack/views/system_chat_user.py:338
-msgid "Modify current user password"
-msgstr ""
-
-#: apps/users/views/user.py:368 apps/xpack/views/system_chat_user.py:352
-msgid "Failed to change password"
-msgstr ""
-
-#: apps/workspace/api/workspace.py:73
-#: apps/workspace/serializers/workspace_serializers.py:213
-msgid "User Relation ID"
-msgstr ""
-
-#: apps/workspace/api/workspace.py:87
-msgid "Role Name"
-msgstr ""
-
-#: apps/workspace/serializers/workspace_serializers.py:42
-#: apps/workspace/serializers/workspace_serializers.py:95
-#: apps/workspace/serializers/workspace_serializers.py:110
-#: apps/workspace/serializers/workspace_serializers.py:177
-#: apps/workspace/serializers/workspace_serializers.py:219
-#: apps/workspace/serializers/workspace_serializers.py:246
-msgid "Workspace does not exist"
-msgstr ""
-
-#: apps/workspace/serializers/workspace_serializers.py:49
-msgid "Workspace name already exists"
-msgstr ""
-
-#: apps/workspace/serializers/workspace_serializers.py:97
-#: apps/workspace/serializers/workspace_serializers.py:112
-msgid "Default workspace cannot be deleted"
-msgstr ""
-
-#: apps/workspace/serializers/workspace_serializers.py:122
-msgid "Applications Resource"
-msgstr ""
-
-#: apps/workspace/serializers/workspace_serializers.py:124
-msgid "Knowledge Resource"
-msgstr ""
-
-#: apps/workspace/serializers/workspace_serializers.py:130
-#, python-format
-msgid "This workspace contains %s, cannot be deleted."
-msgstr ""
-
-#: apps/workspace/serializers/workspace_serializers.py:166
-msgid "Role IDs"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:32 apps/workspace/views/workspace.py:33
-#: apps/workspace/views/workspace.py:34
-msgid "Create or update workspace"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:45 apps/workspace/views/workspace.py:46
-#: apps/workspace/views/workspace.py:47
-msgid "Get system workspace list"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:58 apps/workspace/views/workspace.py:59
-#: apps/workspace/views/workspace.py:60
-msgid "Delete workspace"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:75 apps/workspace/views/workspace.py:76
-#: apps/workspace/views/workspace.py:77
-msgid "Check workspace can it be deleted"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:95 apps/workspace/views/workspace.py:96
-#: apps/workspace/views/workspace.py:97
-msgid "Add member to system workspace"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:114 apps/workspace/views/workspace.py:115
-#: apps/workspace/views/workspace.py:116
-msgid "Remove member from system workspace"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:133 apps/workspace/views/workspace.py:134
-#: apps/workspace/views/workspace.py:135
-msgid "Get system workspace member list"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:151 apps/workspace/views/workspace.py:152
-#: apps/workspace/views/workspace.py:153
-msgid "Get workspace list"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:164 apps/workspace/views/workspace.py:165
-#: apps/workspace/views/workspace.py:166
-msgid "Add member to workspace"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:183 apps/workspace/views/workspace.py:184
-#: apps/workspace/views/workspace.py:185
-msgid "Remove member from workspace"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:202 apps/workspace/views/workspace.py:203
-#: apps/workspace/views/workspace.py:204
-msgid "Get workspace member list"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:219 apps/workspace/views/workspace.py:220
-#: apps/workspace/views/workspace.py:221
-msgid "Get workspace list by current user"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:232 apps/workspace/views/workspace.py:233
-#: apps/workspace/views/workspace.py:234
-msgid "Get workspace list by user"
-msgstr ""
-
-#: apps/workspace/views/workspace.py:246 apps/workspace/views/workspace.py:247
-#: apps/workspace/views/workspace.py:248
-msgid "Get current user role list"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:44
-#: apps/workspace/views/workspace_chat_user.py:45
-#: apps/workspace/views/workspace_chat_user.py:46
-#: apps/workspace/views/workspace_chat_user.py:51
-#: apps/xpack/views/system_chat_user.py:57
-#: apps/xpack/views/system_chat_user.py:58
-#: apps/xpack/views/system_chat_user.py:59
-msgid "Create chat user"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:47
-#: apps/workspace/views/workspace_chat_user.py:51
-#: apps/workspace/views/workspace_chat_user.py:63
-#: apps/workspace/views/workspace_chat_user.py:67
-#: apps/workspace/views/workspace_chat_user.py:76
-#: apps/workspace/views/workspace_chat_user.py:87
-#: apps/workspace/views/workspace_chat_user.py:92
-#: apps/workspace/views/workspace_chat_user.py:105
-#: apps/workspace/views/workspace_chat_user.py:120
-#: apps/workspace/views/workspace_chat_user.py:124
-#: apps/workspace/views/workspace_chat_user.py:136
-#: apps/workspace/views/workspace_chat_user.py:140
-#: apps/workspace/views/workspace_chat_user.py:152
-#: apps/workspace/views/workspace_chat_user.py:171
-msgid "Workspace/Chat user"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:60
-#: apps/workspace/views/workspace_chat_user.py:61
-#: apps/workspace/views/workspace_chat_user.py:62
-#: apps/workspace/views/workspace_chat_user.py:67
-#: apps/xpack/views/system_chat_user.py:86
-#: apps/xpack/views/system_chat_user.py:87
-#: apps/xpack/views/system_chat_user.py:88
-msgid "Delete chat user"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:73
-#: apps/workspace/views/workspace_chat_user.py:74
-#: apps/workspace/views/workspace_chat_user.py:75
-#: apps/xpack/views/system_chat_user.py:99
-#: apps/xpack/views/system_chat_user.py:100
-#: apps/xpack/views/system_chat_user.py:101
-msgid "Get chat user information"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:84
-#: apps/workspace/views/workspace_chat_user.py:85
-#: apps/workspace/views/workspace_chat_user.py:86
-#: apps/workspace/views/workspace_chat_user.py:92
-#: apps/xpack/views/system_chat_user.py:110
-#: apps/xpack/views/system_chat_user.py:111
-#: apps/xpack/views/system_chat_user.py:112
-msgid "Update chat user information"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:102
-#: apps/workspace/views/workspace_chat_user.py:103
-#: apps/workspace/views/workspace_chat_user.py:104
-#: apps/workspace/views/workspace_chat_user.py:261
-#: apps/workspace/views/workspace_chat_user.py:262
-#: apps/workspace/views/workspace_chat_user.py:263
-#: apps/xpack/views/system_chat_user.py:128
-#: apps/xpack/views/system_chat_user.py:129
-#: apps/xpack/views/system_chat_user.py:130
-#: apps/xpack/views/system_chat_user.py:318
-#: apps/xpack/views/system_chat_user.py:319
-#: apps/xpack/views/system_chat_user.py:320
-msgid "Get user list by group"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:117
-#: apps/workspace/views/workspace_chat_user.py:118
-#: apps/workspace/views/workspace_chat_user.py:119
-#: apps/workspace/views/workspace_chat_user.py:124
-#: apps/xpack/views/system_chat_user.py:143
-#: apps/xpack/views/system_chat_user.py:144
-#: apps/xpack/views/system_chat_user.py:145
-msgid "Batch delete chat user"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:133
-#: apps/workspace/views/workspace_chat_user.py:134
-#: apps/workspace/views/workspace_chat_user.py:135
-#: apps/workspace/views/workspace_chat_user.py:140
-#: apps/xpack/views/system_chat_user.py:160
-#: apps/xpack/views/system_chat_user.py:161
-#: apps/xpack/views/system_chat_user.py:162
-msgid "Batch add chat user to group"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:149
-#: apps/workspace/views/workspace_chat_user.py:150
-#: apps/workspace/views/workspace_chat_user.py:151
-#: apps/xpack/views/system_chat_user.py:177
-#: apps/xpack/views/system_chat_user.py:178
-#: apps/xpack/views/system_chat_user.py:179
-msgid "Change chat user password"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:186
-#: apps/workspace/views/workspace_chat_user.py:187
-#: apps/workspace/views/workspace_chat_user.py:188
-#: apps/xpack/views/system_chat_user.py:230
-#: apps/xpack/views/system_chat_user.py:231
-#: apps/xpack/views/system_chat_user.py:232
-msgid "Create or update Chat User Group"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:191
-#: apps/workspace/views/workspace_chat_user.py:202
-#: apps/workspace/views/workspace_chat_user.py:216
-#: apps/workspace/views/workspace_chat_user.py:232
-#: apps/workspace/views/workspace_chat_user.py:249
-#: apps/workspace/views/workspace_chat_user.py:264
-msgid "Workspace/User Group"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:198
-#: apps/workspace/views/workspace_chat_user.py:199
-#: apps/workspace/views/workspace_chat_user.py:200
-#: apps/xpack/views/system_chat_user.py:243
-#: apps/xpack/views/system_chat_user.py:244
-#: apps/xpack/views/system_chat_user.py:245
-msgid "Get user group list"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:211
-#: apps/workspace/views/workspace_chat_user.py:212
-#: apps/workspace/views/workspace_chat_user.py:213
-#: apps/xpack/views/system_chat_user.py:256
-#: apps/xpack/views/system_chat_user.py:257
-#: apps/xpack/views/system_chat_user.py:258
-msgid "Delete chat user group"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:226
-#: apps/workspace/views/workspace_chat_user.py:227
-#: apps/workspace/views/workspace_chat_user.py:228
-#: apps/xpack/views/system_chat_user.py:273
-#: apps/xpack/views/system_chat_user.py:274
-#: apps/xpack/views/system_chat_user.py:275
-msgid "Add member to chat user group"
-msgstr ""
-
-#: apps/workspace/views/workspace_chat_user.py:243
-#: apps/workspace/views/workspace_chat_user.py:244
-#: apps/workspace/views/workspace_chat_user.py:245
-#: apps/xpack/views/system_chat_user.py:295
-#: apps/xpack/views/system_chat_user.py:296
-#: apps/xpack/views/system_chat_user.py:297
-msgid "Remove member from chat user group"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:29
-msgid "Auth Type"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:30
-msgid "Config"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:77
-msgid "Corp ID"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:78
-msgid "Agent ID"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:79
-msgid "App Secret"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:80
-msgid "Callback URL"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:84
-msgid "Key"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:106
-msgid "Access Token"
-msgstr ""
-
-#: apps/xpack/api/chat_user.py:31 apps/xpack/api/chat_user.py:83
-#: apps/xpack/api/chat_user.py:113 apps/xpack/serializers/chat_user.py:101
-#: apps/xpack/serializers/chat_user.py:177
-#: apps/xpack/serializers/chat_user.py:252
-msgid "User Group IDs"
-msgstr ""
-
-#: apps/xpack/api/chat_user.py:118
-msgid "User Group Names"
-msgstr ""
-
-#: apps/xpack/api/chat_user.py:132 apps/xpack/serializers/chat_user.py:120
-#: apps/xpack/serializers/resource_chat_user.py:37
-msgid "Username or Nickname"
-msgstr ""
-
-#: apps/xpack/api/chat_user.py:148 apps/xpack/serializers/chat_user.py:360
-msgid "Sync Type"
-msgstr ""
-
-#: apps/xpack/api/knowledge_lark.py:25
-msgid "Token"
-msgstr ""
-
-#: apps/xpack/api/knowledge_lark.py:27
-msgid "Is Exist"
-msgstr ""
-
-#: apps/xpack/api/license.py:13
-msgid "corporation"
-msgstr ""
-
-#: apps/xpack/api/license.py:14
-msgid "isv"
-msgstr ""
-
-#: apps/xpack/api/license.py:15
-msgid "expired"
-msgstr ""
-
-#: apps/xpack/api/license.py:16
-msgid "product"
-msgstr ""
-
-#: apps/xpack/api/license.py:17
-msgid "edition"
-msgstr ""
-
-#: apps/xpack/api/license.py:18
-msgid "license version"
-msgstr ""
-
-#: apps/xpack/api/license.py:19
-msgid "count"
-msgstr ""
-
-#: apps/xpack/api/license.py:20
-msgid "serial number"
-msgstr ""
-
-#: apps/xpack/api/license.py:21
-msgid "remark"
-msgstr ""
-
-#: apps/xpack/api/license.py:26
-msgid "message"
-msgstr ""
-
-#: apps/xpack/api/license.py:27
-msgid "license details"
-msgstr ""
-
-#: apps/xpack/api/license.py:36
-#: apps/xpack/serializers/license/license_serializers.py:56
-msgid "license file"
-msgstr ""
-
-#: apps/xpack/api/license.py:37
-msgid "License file is required"
-msgstr ""
-
-#: apps/xpack/api/license.py:38
-msgid "Invalid license file format"
-msgstr ""
-
-#: apps/xpack/api/operate_log.py:12
-#: apps/xpack/serializers/operate_log_serializer.py:57
-msgid "menu"
-msgstr ""
-
-#: apps/xpack/api/operate_log.py:13
-#: apps/xpack/serializers/operate_log_serializer.py:58
-msgid "operate"
-msgstr ""
-
-#: apps/xpack/api/operate_log.py:14
-msgid "menu_label"
-msgstr ""
-
-#: apps/xpack/api/operate_log.py:15
-msgid "operate_label"
-msgstr ""
-
-#: apps/xpack/api/platform.py:35
-msgid "Platform type"
-msgstr ""
-
-#: apps/xpack/api/platform.py:50
-msgid "Platform configuration"
-msgstr ""
-
-#: apps/xpack/api/resource_chat_user_group.py:40
-#: apps/xpack/serializers/resource_chat_user.py:25
-#: apps/xpack/serializers/resource_chat_user_group.py:69
-msgid "is auth"
-msgstr ""
-
-#: apps/xpack/api/user_group.py:31 apps/xpack/api/user_group.py:99
-msgid "User Group ID"
-msgstr ""
-
-#: apps/xpack/api/user_group.py:54 apps/xpack/serializers/chat_user.py:406
-#: apps/xpack/serializers/chat_user.py:563
-msgid "Group ID"
-msgstr ""
-
-#: apps/xpack/api/user_group.py:114 apps/xpack/serializers/chat_user.py:541
-msgid "User group relation IDs"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:19
-msgid "theme color"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:21
-msgid "header font color"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:25
-msgid "float location type"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:26
-msgid "float location value"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:30
-msgid "float location x"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:31
-msgid "float location y"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:35
-msgid "show source"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:36
-msgid "show exec"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:38
-msgid "show history"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:39
-msgid "draggable"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:40
-msgid "show guide"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:42
-msgid "icon url"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:43
-msgid "chat background"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:44
-msgid "chat background url"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:45
-msgid "avatar"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:46
-msgid "avatar url"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:47
-msgid "user avatar"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:48
-msgid "user avatar url"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:49
-msgid "float icon"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:50
-msgid "float icon url"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:51
-msgid "disclaimer"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:52
-msgid "disclaimer value"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:55
-msgid "show avatar"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:56
-msgid "show user avatar"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:124
-msgid "Float location field type error"
-msgstr ""
-
-#: apps/xpack/serializers/application_setting_serializer.py:130
-msgid "Custom theme field type error"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:27
-#: apps/xpack/serializers/platform_serializer.py:31
-msgid "App Secret is required"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:28
-#: apps/xpack/serializers/platform_serializer.py:26
-#: apps/xpack/serializers/platform_serializer.py:34
-#: apps/xpack/serializers/platform_serializer.py:40
-#: apps/xpack/serializers/platform_serializer.py:46
-msgid "Callback URL is required"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:32
-#: apps/xpack/serializers/auth_config_serializer.py:41
-msgid "Corp ID is required"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:33
-#: apps/xpack/serializers/platform_serializer.py:22
-msgid "Agent ID is required"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:37
-#: apps/xpack/serializers/auth_config_serializer.py:42
-msgid "App Key is required"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:53
-msgid "LDAP server cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:54
-msgid "Base DN cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:55
-msgid "Password cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:56
-msgid "OU cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:57
-msgid "LDAP filter cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:58
-msgid "LDAP mapping cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:62
-msgid "Authorization address cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:63
-msgid "Token address cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:64
-msgid "User information address cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:65
-msgid "Scope cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:66
-msgid "Client ID cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:67
-msgid "Client secret cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:68
-msgid "Redirect address cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:69
-msgid "Field mapping cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:262
-msgid "Configuration information is wrong and failed to save"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:288
-msgid "Connection failed"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:306
-msgid "Platform does not exist"
-msgstr ""
-
-#: apps/xpack/serializers/auth_config_serializer.py:316
-msgid "Unsupported platform type"
-msgstr ""
-
-#: apps/xpack/serializers/channel/chat_manage.py:100
-msgid "Think: "
-msgstr ""
-
-#: apps/xpack/serializers/channel/chat_manage.py:103
-#: apps/xpack/serializers/channel/chat_manage.py:105
-msgid "AI reply: "
-msgstr ""
-
-#: apps/xpack/serializers/channel/chat_manage.py:318
-msgid "Thinking, please wait a moment!"
-msgstr ""
-
-#: apps/xpack/serializers/channel/ding_talk.py:19
-#: apps/xpack/serializers/channel/wechat.py:91
-#: apps/xpack/serializers/channel/wechat.py:132
-#: apps/xpack/serializers/channel/wecom.py:78
-#: apps/xpack/serializers/channel/wecom.py:259
-msgid "The corresponding platform configuration was not found"
-msgstr ""
-
-#: apps/xpack/serializers/channel/ding_talk.py:27
-#: apps/xpack/serializers/channel/lark.py:117
-msgid "Currently only text messages are supported"
-msgstr ""
-
-#: apps/xpack/serializers/channel/ding_talk.py:91
-#: apps/xpack/serializers/channel/wechat.py:163
-#: apps/xpack/serializers/channel/wecom.py:189
-msgid "Image download failed, check network"
-msgstr ""
-
-#: apps/xpack/serializers/channel/ding_talk.py:92
-#: apps/xpack/serializers/channel/wechat.py:161
-#: apps/xpack/serializers/channel/wecom.py:185
-msgid "Please analyze the content of the image."
-msgstr ""
-
-#: apps/xpack/serializers/channel/ding_talk.py:95
-#, python-brace-format
-msgid "DingTalk application: {user}"
-msgstr ""
-
-#: apps/xpack/serializers/channel/ding_talk.py:106
-#: apps/xpack/serializers/channel/ding_talk.py:151
-msgid "Content generated by AI"
-msgstr ""
-
-#: apps/xpack/serializers/channel/lark.py:92
-msgid "Lark application: "
-msgstr ""
-
-#: apps/xpack/serializers/channel/slack.py:116
-msgid "The corresponding platform configuration for Slack was not found"
-msgstr ""
-
-#: apps/xpack/serializers/channel/slack.py:206
-msgid "Thinking..."
-msgstr ""
-
-#: apps/xpack/serializers/channel/slack.py:333
-msgid "Invalid json format."
-msgstr ""
-
-#: apps/xpack/serializers/channel/slack.py:339
-msgid "Invalid Slack request"
-msgstr ""
-
-#: apps/xpack/serializers/channel/slack.py:347
-#, python-brace-format
-msgid "Slack application: {user}"
-msgstr ""
-
-#: apps/xpack/serializers/channel/slack.py:480
-msgid "Stop"
-msgstr ""
-
-#: apps/xpack/serializers/channel/tools.py:58
-#, python-brace-format
-msgid ""
-"Thinking about 【{question}】...If you want me to continue answering, please "
-"reply {trigger_message}"
-msgstr ""
-
-#: apps/xpack/serializers/channel/tools.py:158
-msgid ""
-"\n"
-" ------------\n"
-"[To be continued, reply \"Continue to answer the question]"
-msgstr ""
-
-#: apps/xpack/serializers/channel/tools.py:238
-#, python-brace-format
-msgid ""
-"To be continued, reply \"{trigger_message}\" to continue answering the "
-"question"
-msgstr ""
-
-#: apps/xpack/serializers/channel/wechat.py:143
-#, python-brace-format
-msgid "WeChat Official Account: {account}"
-msgstr ""
-
-#: apps/xpack/serializers/channel/wechat.py:150
-#: apps/xpack/serializers/channel/wecom.py:171
-#: apps/xpack/serializers/channel/wecom.py:175
-msgid ""
-"The app does not enable the speech-to-text function or the speech-to-text "
-"function fails."
-msgstr ""
-
-#: apps/xpack/serializers/channel/wechat.py:189
-msgid "Message types not supported yet"
-msgstr ""
-
-#: apps/xpack/serializers/channel/wechat.py:196
-msgid "Welcome to subscribe"
-msgstr ""
-
-#: apps/xpack/serializers/channel/wecom.py:86
-msgid "Enterprise WeChat user: "
-msgstr ""
-
-#: apps/xpack/serializers/channel/wecom.py:97
-msgid "Enterprise WeChat customer service: "
-msgstr ""
-
-#: apps/xpack/serializers/channel/wecom.py:134
-#: apps/xpack/serializers/channel/wecom.py:150
-msgid "This type of message is not supported yet"
-msgstr ""
-
-#: apps/xpack/serializers/channel/wecom.py:254
-msgid "Signature missing"
-msgstr ""
-
-#: apps/xpack/serializers/channel/wecom.py:266
-#: apps/xpack/serializers/channel/wecom.py:273
-#, python-brace-format
-msgid "An error occurred while processing the GET request {e}"
-msgstr ""
-
-#: apps/xpack/serializers/chat_auth.py:51
-msgid "The password is incorrect"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:42
-msgid "Some user groups do not exist"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:181
-msgid "Is Append"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:194
-msgid "User Group IDs cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:198
-msgid "Some users do not exist"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:361
-msgid "Sync Type: LOCAL or LDAP"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:403
-msgid "Unsupported sync type"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:412
-#: apps/xpack/serializers/chat_user.py:444
-#: apps/xpack/serializers/chat_user.py:483
-#: apps/xpack/serializers/chat_user.py:510
-#: apps/xpack/serializers/chat_user.py:548
-#: apps/xpack/serializers/chat_user.py:570
-msgid "User group does not exist"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:451
-msgid "User group name already exists"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:485
-msgid "Default user group cannot be deleted"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user.py:550
-msgid "User group relation IDs cannot be empty"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user_serializer.py:75
-msgid "Invalid access token"
-msgstr ""
-
-#: apps/xpack/serializers/chat_user_serializer.py:102
-msgid "The user does not have permission to access the application"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:56
-#: apps/xpack/serializers/dataset_lark_serializer.py:299
-msgid "app id"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:57
-#: apps/xpack/serializers/dataset_lark_serializer.py:300
-msgid "app secret"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:58
-#: apps/xpack/serializers/dataset_lark_serializer.py:105
-#: apps/xpack/serializers/dataset_lark_serializer.py:301
-msgid "folder token"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:60
-msgid "embedding model"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:71
-#: apps/xpack/serializers/dataset_lark_serializer.py:311
-msgid "Network error or folder token error!"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:113
-#: apps/xpack/serializers/dataset_lark_serializer.py:155
-#: apps/xpack/task/sync.py:308
-msgid "Knowledge base not found!"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:125
-#: apps/xpack/task/sync.py:240
-msgid "Failed to get lark document list!"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:147
-msgid "Knowledge id"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:169
-msgid "Synchronization is only supported for lark documents"
-msgstr ""
-
-#: apps/xpack/serializers/license/license_serializers.py:102
-#: apps/xpack/serializers/license/license_serializers.py:123
-#: apps/xpack/serializers/license/license_tools.py:111
-msgid "The license is invalid"
-msgstr ""
-
-#: apps/xpack/serializers/license/license_tools.py:136
-msgid "License usage limit exceeded."
-msgstr ""
-
-#: apps/xpack/serializers/license/license_tools.py:160
-msgid "The network is busy, try again later."
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:59
-msgid "user"
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:61
-msgid "ip_address"
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:62
-msgid "workspace_id"
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:134
-msgid "Fail"
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:171
-msgid "Menu"
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:172
-msgid "Operate"
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:173
-msgid "Operate user"
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:175
-msgid "Ip Address"
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:176
-msgid "API Details"
-msgstr ""
-
-#: apps/xpack/serializers/operate_log_serializer.py:177
-msgid "Operate Time"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:12
-msgid "app_id is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:13
-msgid "app_secret is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:14
-msgid "token is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:15
-msgid "callback_url is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:21
-#: apps/xpack/serializers/platform_serializer.py:30
-msgid "App ID is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:23
-msgid "Secret is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:24
-msgid "Token is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:33
-msgid "Verification Token is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:38
-msgid "Client ID is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:39
-msgid "Client Secret is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:44
-msgid "Signing Secret is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:45
-msgid "Bot User Token is required"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:66
-msgid "Check if the fields are correct"
-msgstr ""
-
-#: apps/xpack/serializers/platform_serializer.py:155
-#, python-brace-format
-msgid "The platform configuration corresponding to {type} was not found"
-msgstr ""
-
-#: apps/xpack/serializers/resource_chat_user.py:35
-#: apps/xpack/serializers/resource_chat_user.py:111
-#: apps/xpack/serializers/resource_chat_user_group.py:18
-#: apps/xpack/serializers/resource_chat_user_group.py:86
-msgid "Resource id"
-msgstr ""
-
-#: apps/xpack/serializers/resource_chat_user.py:38
-#: apps/xpack/serializers/resource_chat_user.py:112
-msgid "User group id"
-msgstr ""
-
-#: apps/xpack/serializers/resource_chat_user.py:94
-msgid "Is auth"
-msgstr ""
-
-#: apps/xpack/serializers/resource_chat_user_group.py:20
-msgid "User group name"
-msgstr ""
-
-#: apps/xpack/serializers/resource_chat_user_group.py:68
-msgid "user_group_id"
-msgstr ""
-
-#: apps/xpack/serializers/sso_auth/cas.py:32
-msgid "HttpClient query failed: "
-msgstr ""
-
-#: apps/xpack/serializers/sso_auth/cas.py:58
-msgid "CAS authentication failed"
-msgstr ""
-
-#: apps/xpack/serializers/sso_auth/oauth2.py:165
-#: apps/xpack/serializers/sso_auth/oauth2.py:184
-#: apps/xpack/serializers/sso_auth/oauth2.py:187
-msgid "Failed to obtain user information"
-msgstr ""
-
-#: apps/xpack/serializers/system_api_key.py:12
-msgid "Allow cross domain"
-msgstr ""
-
-#: apps/xpack/serializers/system_api_key.py:13
-msgid "Cross domain list"
-msgstr ""
-
-#: apps/xpack/serializers/system_api_key.py:44
-msgid "system API key id"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:20
-msgid "theme"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:22
-msgid "login logo"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:23
-msgid "login image"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:24
-msgid "title"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:25
-msgid "slogan"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:26
-#: apps/xpack/serializers/system_params.py:27
-msgid "show user manual"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:28
-msgid "user manual url"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:29
-msgid "show forum"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:30
-msgid "forum url"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:31
-msgid "show project"
-msgstr ""
-
-#: apps/xpack/serializers/system_params.py:32
-msgid "project url"
-msgstr ""
-
-#: apps/xpack/views/application_setting.py:24
-#: apps/xpack/views/application_setting.py:25
-#: apps/xpack/views/application_setting.py:26
-msgid "Modify Application Settings"
-msgstr "Modify Agent Settings"
-
-#: apps/xpack/views/application_setting.py:42
-#: apps/xpack/views/application_setting.py:43
-#: apps/xpack/views/application_setting.py:44
-msgid "Get Application Settings"
-msgstr "Get Agent Settings"
-
-#: apps/xpack/views/auth.py:52 apps/xpack/views/auth.py:53
-#: apps/xpack/views/auth.py:54 apps/xpack/views/chat_user_auth.py:46
-#: apps/xpack/views/chat_user_auth.py:47 apps/xpack/views/chat_user_auth.py:48
-msgid "Get authentication types"
-msgstr ""
-
-#: apps/xpack/views/auth.py:55 apps/xpack/views/auth.py:70
-#: apps/xpack/views/auth.py:90 apps/xpack/views/auth.py:108
-#: apps/xpack/views/auth.py:223 apps/xpack/views/auth.py:235
-#: apps/xpack/views/auth.py:249
-msgid "Authentication Configuration"
-msgstr ""
-
-#: apps/xpack/views/auth.py:67 apps/xpack/views/auth.py:68
-#: apps/xpack/views/auth.py:69 apps/xpack/views/chat_user_auth.py:62
-#: apps/xpack/views/chat_user_auth.py:63 apps/xpack/views/chat_user_auth.py:64
-msgid "Test LDAP connection"
-msgstr ""
-
-#: apps/xpack/views/auth.py:87 apps/xpack/views/auth.py:88
-#: apps/xpack/views/auth.py:89
-msgid "Add or modify authentication configuration"
-msgstr ""
-
-#: apps/xpack/views/auth.py:105 apps/xpack/views/auth.py:106
-#: apps/xpack/views/auth.py:107
-msgid "Get authentication configuration"
-msgstr ""
-
-#: apps/xpack/views/auth.py:118 apps/xpack/views/auth.py:119
-#: apps/xpack/views/auth.py:120 apps/xpack/views/chat_user_auth.py:112
-#: apps/xpack/views/chat_user_auth.py:113
-#: apps/xpack/views/chat_user_auth.py:114
-msgid "Ldap Log in"
-msgstr ""
-
-#: apps/xpack/views/auth.py:121 apps/xpack/views/auth.py:138
-#: apps/xpack/views/auth.py:157 apps/xpack/views/auth.py:176
-#: apps/xpack/views/auth.py:194 apps/xpack/views/auth.py:208
-#: apps/xpack/views/auth.py:266 apps/xpack/views/auth.py:286
-#: apps/xpack/views/auth.py:307 apps/xpack/views/auth.py:327
-#: apps/xpack/views/auth.py:348 apps/xpack/views/auth.py:368
-msgid "Three-party login"
-msgstr ""
-
-#: apps/xpack/views/auth.py:135 apps/xpack/views/auth.py:136
-#: apps/xpack/views/auth.py:137 apps/xpack/views/chat_user_auth.py:129
-#: apps/xpack/views/chat_user_auth.py:130
-#: apps/xpack/views/chat_user_auth.py:131
-msgid "CAS Log in"
-msgstr ""
-
-#: apps/xpack/views/auth.py:154 apps/xpack/views/auth.py:155
-#: apps/xpack/views/auth.py:156 apps/xpack/views/chat_user_auth.py:148
-#: apps/xpack/views/chat_user_auth.py:149
-#: apps/xpack/views/chat_user_auth.py:150
-msgid "OIDC Log in"
-msgstr ""
-
-#: apps/xpack/views/auth.py:173 apps/xpack/views/auth.py:174
-#: apps/xpack/views/auth.py:175 apps/xpack/views/chat_user_auth.py:167
-#: apps/xpack/views/chat_user_auth.py:168
-#: apps/xpack/views/chat_user_auth.py:169
-msgid "OAuth2 Log in"
-msgstr ""
-
-#: apps/xpack/views/auth.py:191 apps/xpack/views/auth.py:192
-#: apps/xpack/views/auth.py:193 apps/xpack/views/chat_user_auth.py:220
-#: apps/xpack/views/chat_user_auth.py:221
-#: apps/xpack/views/chat_user_auth.py:222
-msgid "Scan code login type"
-msgstr ""
-
-#: apps/xpack/views/auth.py:205 apps/xpack/views/auth.py:206
-#: apps/xpack/views/auth.py:207 apps/xpack/views/auth.py:220
-#: apps/xpack/views/auth.py:221 apps/xpack/views/auth.py:222
-#: apps/xpack/views/chat_user_auth.py:234
-#: apps/xpack/views/chat_user_auth.py:235
-#: apps/xpack/views/chat_user_auth.py:236
-#: apps/xpack/views/chat_user_auth.py:249
-#: apps/xpack/views/chat_user_auth.py:250
-#: apps/xpack/views/chat_user_auth.py:251
-msgid "Get platform information"
-msgstr ""
-
-#: apps/xpack/views/auth.py:232 apps/xpack/views/auth.py:233
-#: apps/xpack/views/auth.py:234 apps/xpack/views/chat_user_auth.py:261
-#: apps/xpack/views/chat_user_auth.py:262
-#: apps/xpack/views/chat_user_auth.py:263
-msgid "Modify platform information"
-msgstr ""
-
-#: apps/xpack/views/auth.py:246 apps/xpack/views/auth.py:247
-#: apps/xpack/views/auth.py:248 apps/xpack/views/chat_user_auth.py:275
-#: apps/xpack/views/chat_user_auth.py:276
-#: apps/xpack/views/chat_user_auth.py:277
-msgid "Test platform connection"
-msgstr ""
-
-#: apps/xpack/views/auth.py:263 apps/xpack/views/auth.py:264
-#: apps/xpack/views/auth.py:265 apps/xpack/views/chat_user_auth.py:292
-#: apps/xpack/views/chat_user_auth.py:293
-#: apps/xpack/views/chat_user_auth.py:294
-msgid "DingTalk callback"
-msgstr ""
-
-#: apps/xpack/views/auth.py:283 apps/xpack/views/auth.py:284
-#: apps/xpack/views/auth.py:285 apps/xpack/views/chat_user_auth.py:312
-#: apps/xpack/views/chat_user_auth.py:313
-#: apps/xpack/views/chat_user_auth.py:314
-msgid "DingTalk OAuth2 callback"
-msgstr ""
-
-#: apps/xpack/views/auth.py:304 apps/xpack/views/auth.py:305
-#: apps/xpack/views/auth.py:306 apps/xpack/views/chat_user_auth.py:333
-#: apps/xpack/views/chat_user_auth.py:334
-#: apps/xpack/views/chat_user_auth.py:335
-msgid "WeCom callback"
-msgstr ""
-
-#: apps/xpack/views/auth.py:324 apps/xpack/views/auth.py:325
-#: apps/xpack/views/auth.py:326 apps/xpack/views/chat_user_auth.py:353
-#: apps/xpack/views/chat_user_auth.py:354
-#: apps/xpack/views/chat_user_auth.py:355
-msgid "WeCom OAuth2 callback"
-msgstr ""
-
-#: apps/xpack/views/auth.py:345 apps/xpack/views/auth.py:346
-#: apps/xpack/views/auth.py:347 apps/xpack/views/chat_user_auth.py:374
-#: apps/xpack/views/chat_user_auth.py:375
-#: apps/xpack/views/chat_user_auth.py:376
-msgid "Lark callback"
-msgstr ""
-
-#: apps/xpack/views/auth.py:365 apps/xpack/views/auth.py:366
-#: apps/xpack/views/auth.py:367 apps/xpack/views/chat_user_auth.py:394
-#: apps/xpack/views/chat_user_auth.py:395
-#: apps/xpack/views/chat_user_auth.py:396
-msgid "Lark OAuth2 callback"
-msgstr ""
-
-#: apps/xpack/views/chat_user_auth.py:49 apps/xpack/views/chat_user_auth.py:65
-#: apps/xpack/views/chat_user_auth.py:85 apps/xpack/views/chat_user_auth.py:252
-#: apps/xpack/views/chat_user_auth.py:264
-#: apps/xpack/views/chat_user_auth.py:278
-msgid "Chat User/Authentication Configuration"
-msgstr ""
-
-#: apps/xpack/views/chat_user_auth.py:82 apps/xpack/views/chat_user_auth.py:83
-#: apps/xpack/views/chat_user_auth.py:84
-msgid "Add or modify Chat/Authentication Configuration"
-msgstr ""
-
-#: apps/xpack/views/chat_user_auth.py:99 apps/xpack/views/chat_user_auth.py:100
-#: apps/xpack/views/chat_user_auth.py:101
-msgid "Get Authentication Configuration"
-msgstr ""
-
-#: apps/xpack/views/chat_user_auth.py:102
-msgid "Chat User/login authentication"
-msgstr ""
-
-#: apps/xpack/views/chat_user_auth.py:115
-#: apps/xpack/views/chat_user_auth.py:132
-#: apps/xpack/views/chat_user_auth.py:151
-#: apps/xpack/views/chat_user_auth.py:170
-#: apps/xpack/views/chat_user_auth.py:223
-#: apps/xpack/views/chat_user_auth.py:237
-#: apps/xpack/views/chat_user_auth.py:295
-#: apps/xpack/views/chat_user_auth.py:315
-#: apps/xpack/views/chat_user_auth.py:336
-#: apps/xpack/views/chat_user_auth.py:356
-#: apps/xpack/views/chat_user_auth.py:377
-#: apps/xpack/views/chat_user_auth.py:397
-msgid "Chat User/Three-party login"
-msgstr ""
-
-#: apps/xpack/views/chat_user_auth.py:187
-msgid "Chat User/login"
-msgstr ""
-
-#: apps/xpack/views/chat_user_auth.py:414
-#: apps/xpack/views/chat_user_auth.py:415
-#: apps/xpack/views/chat_user_auth.py:416
-msgid "Application Password Certification"
-msgstr "Agent Password Certification"
-
-#: apps/xpack/views/license.py:31 apps/xpack/views/license.py:32
-#: apps/xpack/views/license.py:33
-msgid "Get license information"
-msgstr ""
-
-#: apps/xpack/views/license.py:42 apps/xpack/views/license.py:44
-msgid "Update license information"
-msgstr ""
-
-#: apps/xpack/views/license.py:43
-msgid "Update license information by uploading a new license file"
-msgstr ""
-
-#: apps/xpack/views/operate_log.py:21 apps/xpack/views/operate_log.py:22
-#: apps/xpack/views/operate_log.py:23
-msgid "Get menu operate log"
-msgstr ""
-
-#: apps/xpack/views/operate_log.py:25 apps/xpack/views/operate_log.py:41
-#: apps/xpack/views/operate_log.py:57
-msgid "System operate log"
-msgstr ""
-
-#: apps/xpack/views/operate_log.py:36 apps/xpack/views/operate_log.py:37
-#: apps/xpack/views/operate_log.py:38
-msgid "Get paginated operate log"
-msgstr ""
-
-#: apps/xpack/views/operate_log.py:54 apps/xpack/views/operate_log.py:55
-#: apps/xpack/views/operate_log.py:56
-msgid "Export operate log"
-msgstr ""
-
-#: apps/xpack/views/platform.py:60 apps/xpack/views/platform.py:61
-#: apps/xpack/views/platform.py:62
-msgid "Get platform configuration"
-msgstr ""
-
-#: apps/xpack/views/platform.py:65 apps/xpack/views/platform.py:79
-msgid "Application/application access"
-msgstr "Agent/agent access"
-
-#: apps/xpack/views/platform.py:73 apps/xpack/views/platform.py:74
-#: apps/xpack/views/platform.py:75
-msgid "Update platform configuration"
-msgstr ""
-
-#: apps/xpack/views/platform.py:94 apps/xpack/views/platform.py:95
-#: apps/xpack/views/platform.py:96
-msgid "Get platform status"
-msgstr ""
-
-#: apps/xpack/views/platform.py:98 apps/xpack/views/platform.py:118
-msgid "Application/Get platform status"
-msgstr "Agent/Get platform status"
-
-#: apps/xpack/views/platform.py:113 apps/xpack/views/platform.py:114
-#: apps/xpack/views/platform.py:115
-msgid "Update platform status"
-msgstr ""
-
-#: apps/xpack/views/resource_chat_user.py:27
-#: apps/xpack/views/resource_chat_user.py:28
-#: apps/xpack/views/resource_chat_user.py:29
-msgid "Get Resource chat user List"
-msgstr ""
-
-#: apps/xpack/views/resource_chat_user.py:32
-#: apps/xpack/views/resource_chat_user.py:54
-#: apps/xpack/views/resource_chat_user.py:77
-#: apps/xpack/views/system_chat_user_group.py:24
-#: apps/xpack/views/system_chat_user_group.py:45
-#: apps/xpack/views/system_chat_user_group.py:67
-msgid "Chat user"
-msgstr ""
-
-#: apps/xpack/views/resource_chat_user.py:48
-#: apps/xpack/views/resource_chat_user.py:49
-#: apps/xpack/views/resource_chat_user.py:50
-msgid "Edit Resource chat user List"
-msgstr ""
-
-#: apps/xpack/views/resource_chat_user.py:72
-#: apps/xpack/views/resource_chat_user.py:73
-#: apps/xpack/views/resource_chat_user.py:74
-msgid "Get Resource chat user page List"
-msgstr ""
-
-#: apps/xpack/views/system_api_key.py:19 apps/xpack/views/system_api_key.py:20
-#: apps/xpack/views/system_api_key.py:21
-msgid "Create SystemAPIKey"
-msgstr ""
-
-#: apps/xpack/views/system_api_key.py:34 apps/xpack/views/system_api_key.py:35
-#: apps/xpack/views/system_api_key.py:36
-msgid "Get SystemAPIKey List"
-msgstr ""
-
-#: apps/xpack/views/system_api_key.py:50 apps/xpack/views/system_api_key.py:51
-#: apps/xpack/views/system_api_key.py:52
-msgid "Update SystemAPIKey"
-msgstr ""
-
-#: apps/xpack/views/system_api_key.py:66 apps/xpack/views/system_api_key.py:67
-#: apps/xpack/views/system_api_key.py:68
-msgid "Delete SystemAPIKey"
-msgstr ""
-
-#: apps/xpack/views/system_chat_user.py:60
-#: apps/xpack/views/system_chat_user.py:76
-#: apps/xpack/views/system_chat_user.py:89
-#: apps/xpack/views/system_chat_user.py:102
-#: apps/xpack/views/system_chat_user.py:113
-#: apps/xpack/views/system_chat_user.py:131
-#: apps/xpack/views/system_chat_user.py:146
-#: apps/xpack/views/system_chat_user.py:163
-#: apps/xpack/views/system_chat_user.py:180
-#: apps/xpack/views/system_chat_user.py:200
-#: apps/xpack/views/system_chat_user.py:217
-msgid "System/Chat user"
-msgstr ""
-
-#: apps/xpack/views/system_chat_user.py:73
-#: apps/xpack/views/system_chat_user.py:74
-#: apps/xpack/views/system_chat_user.py:75
-msgid "Get chat user list"
-msgstr ""
-
-#: apps/xpack/views/system_chat_user.py:214
-#: apps/xpack/views/system_chat_user.py:216
-msgid "Sync chat users"
-msgstr ""
-
-#: apps/xpack/views/system_chat_user.py:215
-msgid "Sync chat users from external source"
-msgstr ""
-
-#: apps/xpack/views/system_chat_user.py:235
-#: apps/xpack/views/system_chat_user.py:247
-#: apps/xpack/views/system_chat_user.py:261
-#: apps/xpack/views/system_chat_user.py:279
-#: apps/xpack/views/system_chat_user.py:301
-#: apps/xpack/views/system_chat_user.py:321
-msgid "System/User Group"
-msgstr ""
-
-#: apps/xpack/views/system_chat_user_group.py:19
-#: apps/xpack/views/system_chat_user_group.py:20
-#: apps/xpack/views/system_chat_user_group.py:21
-msgid "Get Resource chat user group List"
-msgstr ""
-
-#: apps/xpack/views/system_chat_user_group.py:39
-#: apps/xpack/views/system_chat_user_group.py:40
-#: apps/xpack/views/system_chat_user_group.py:41
-msgid "Edit Resource chat user group List"
-msgstr ""
-
-#: apps/xpack/views/system_chat_user_group.py:62
-#: apps/xpack/views/system_chat_user_group.py:64
-msgid "Get Resource chat user group page List"
-msgstr ""
-
-#: apps/xpack/views/system_chat_user_group.py:63
-msgid "Get Resource chat user page group List"
-msgstr ""
-
-#: apps/xpack/views/system_params.py:22 apps/xpack/views/system_params.py:23
-#: apps/xpack/views/system_params.py:24
-msgid "View appearance settings"
-msgstr ""
-
-#: apps/xpack/views/system_params.py:39 apps/xpack/views/system_params.py:40
-#: apps/xpack/views/system_params.py:41
-msgid "Update appearance settings"
-msgstr ""
-
-msgid "Application Access"
-msgstr "Agent Access"
-
-msgid "Display execution details"
-msgstr ""
-
-msgid "LOCAL"
-msgstr "Account login"
-
-msgid "CAS"
-msgstr "CAS"
-
-msgid "LDAP"
-msgstr "LDAP"
-
-msgid "OIDC"
-msgstr "OIDC"
-
-msgid "OAuth2"
-msgstr "OAuth2"
-
-msgid "dingtalk"
-msgstr "DingTalk"
-
-msgid "wecom"
-msgstr "WeCom"
-
-msgid "lark"
-msgstr "Lark"
-
-msgid "Get tool list"
-msgstr ""
-
-msgid "Setting"
-msgstr ""
-
-msgid "Get verification results"
-msgstr ""
-
-msgid "Validation"
-msgstr ""
-
-msgid "Models Resource"
-msgstr ""
-
-msgid "Tools Resource"
-msgstr ""
-
-msgid "Get resource model list"
-msgstr ""
-
-msgid "System Model"
-msgstr ""
-
-msgid "Dialogue users"
-msgstr ""
-
-msgid "Conversation log"
-msgstr ""
-
-msgid "Public access link"
-msgstr ""
-
-msgid "User management"
-msgstr "User Management"
-
-msgid "Chat User/logout"
-msgstr ""
-
-msgid "Paragraph"
-msgstr ""
-
-msgid "User group"
-msgstr ""
-
-msgid "Remove member from user group"
-msgstr ""
-
-msgid "Create a web site knowledge base"
-msgstr ""
-
-msgid "Modify knowledge base information"
-msgstr ""
-
-msgid "Delete knowledge base"
-msgstr ""
-
-msgid "model"
-msgstr "Model"
-
-msgid "Batch add user to group"
-msgstr ""
-
-msgid "Add internal tool"
-msgstr ""
-
-msgid "Batch generate related"
-msgstr ""
-
-msgid "Update personal system API_KEY"
-msgstr ""
-
-msgid "Delete user group"
-msgstr ""
-
-msgid "Add user"
-msgstr ""
-
-msgid "folder"
-msgstr "Folder"
-
-msgid "Create or update user group"
-msgstr ""
-
-msgid "Edit folder"
-msgstr ""
-
-msgid "Email settings"
-msgstr ""
-
-msgid "trial listening"
-msgstr ""
-
-msgid "Add member to user group"
-msgstr ""
-
-msgid "System"
-msgstr ""
-
-msgid "Shared Knowledge/Document"
-msgstr ""
-
-msgid "System Application"
-msgstr ""
-
-msgid "Hit-Test"
-msgstr ""
-
-msgid "Export Application"
-msgstr ""
-
-msgid "Add ApiKey"
-msgstr ""
-
-msgid "Delete application API_KEY"
-msgstr "Delete agent API_KEY"
-
-msgid "knowledge Base"
-msgstr ""
-
-msgid "API KEY"
-msgstr ""
-
-msgid "Download"
-msgstr ""
-
-msgid "Delete personal system API_KEY"
-msgstr ""
-
-msgid "Add personal system API_KEY"
-msgstr ""
-
-msgid "Generate related documents"
-msgstr ""
-
-msgid "Modify application access token"
-msgstr "Modify agent access token"
-
-msgid "File not exist. Only manually uploaded documents are supported"
-msgstr ""
-
-msgid "Resource"
-msgstr "Resource Management"
-
-msgid "LDAP configuration not found or not active"
-msgstr ""
-
-msgid "Lark configuration not found or not active"
-msgstr ""
-
-msgid "Failed to get Lark collaborators"
-msgstr ""
-
-msgid "Failed to get Lark user details"
-msgstr ""
-
-msgid "WeCom configuration not found or not active"
-msgstr ""
-
-msgid "Failed to get WeCom access token"
-msgstr ""
-
-msgid "Failed to get WeCom agent info"
-msgstr ""
-
-msgid "Failed to get WeCom department users"
-msgstr ""
-
-msgid "Failed to get WeCom user info"
-msgstr ""
-
-msgid "Publish status"
-msgstr ""
-
-msgid "Unpublished"
-msgstr ""
-
-msgid "Published"
-msgstr ""
-
-msgid "users_permission"
-msgstr ""
-
-msgid "Get user authorization status of resource"
-msgstr ""
-
-msgid "Edit user authorization status of resource"
-msgstr ""
-
-msgid "Get user authorization status of resource by page"
-msgstr ""
-
-msgid "Obtain resource authorization list by page"
-msgstr ""
-
-msgid "Engine model type"
-msgstr ""
-
-msgid "If not passed, the default value is 16k_zh (Chinese universal)"
-msgstr ""
-
-msgid "Chinese telephone universal"
-msgstr ""
-
-msgid "English telephone universal"
-msgstr ""
-
-msgid "Commonly used in Chinese"
-msgstr ""
-
-msgid "Chinese, English, and Guangdong"
-msgstr ""
-
-msgid "Chinese medical"
-msgstr ""
-
-msgid "English"
-msgstr ""
-
-msgid "Cantonese"
-msgstr ""
-
-msgid "Japanese"
-msgstr ""
-
-msgid "Korean"
-msgstr ""
-
-msgid "Vietnamese"
-msgstr ""
-
-msgid "Malay language"
-msgstr ""
-
-msgid "Indonesian language"
-msgstr ""
-
-msgid "Filipino language"
-msgstr ""
-
-msgid "Thai"
-msgstr ""
-
-msgid "Portuguese"
-msgstr ""
-
-msgid "Turkish"
-msgstr ""
-
-msgid "Arabic"
-msgstr ""
-
-msgid "Spanish"
-msgstr ""
-
-msgid "Hindi"
-msgstr ""
-
-msgid "French"
-msgstr ""
-
-msgid "German"
-msgstr ""
-
-msgid "Multiple dialects, supporting 23 dialects"
-msgstr ""
-
-msgid "This interface is used to recognize short audio files within 60 seconds. Supports Mandarin Chinese, English, Cantonese, Japanese, Vietnamese, Malay, Indonesian, Filipino, Thai, Portuguese, Turkish, Arabic, Hindi, French, German, and 23 Chinese dialects."
-msgstr ""
-
-msgid "CueWord"
-msgstr ""
-
-msgid "If not passed, the default value is What is this audio saying? Only answer the audio content"
-msgstr ""
-
-msgid "The Qwen Omni series model supports inputting multiple modalities of data, including video, audio, images, and text, and outputting audio and text."
-msgstr ""
-
-msgid "resource authorization"
-msgstr ""
-
-msgid "The Qwen Audio based end-to-end speech recognition model supports audio recognition within 3 minutes. At present, it mainly supports Chinese and English recognition."
-msgstr ""
-
-msgid "If not passed, the default value is 'zh'"
-msgstr ""
-
-msgid "System resources authorization"
-msgstr ""
-
-msgid "This folder contains resources that you dont have permission"
-msgstr ""
-
-msgid "Text to Video"
-msgstr ""
-
-msgid "Image to Video"
-msgstr ""
-
-msgid "Authentication failed. Please verify that the parameters are correct"
-msgstr ""
-
-msgid "Chat context"
-msgstr ""
-
-msgid "Prompt template"
-msgstr ""
-
-msgid "generate prompt"
-msgstr ""
-
-
-msgid "Watermark"
-msgstr ""
-
-msgid "Whether to add watermark"
-msgstr ""
-
-msgid "Resolution"
-msgstr ""
-
-msgid "Ratio"
-msgstr ""
-
-msgid "Duration"
-msgstr ""
-
-msgid "Failed to generate video"
-msgstr ""
-
-msgid "password"
-msgstr "Password login"
-
-msgid "Failed to obtain the image"
-msgstr ""
-
-msgid "Update auth setting"
-msgstr ""
-
-msgid "If not passed, the default value is streaming_asr_demo"
-msgstr ""
-
-msgid "If not passed, the default value is 16000"
-msgstr ""
-
-msgid "Sample Rate"
-msgstr ""
-
-msgid "Captcha is required"
-msgstr ""
-
-msgid "Tag"
-msgstr ""
-
-msgid "Tag Setting"
-msgstr ""
-
-msgid "Download Original Document"
-msgstr ""
-
-msgid "Replace Original Document"
-msgstr ""
-
-msgid "Update License"
-msgstr ""
-
-msgid "Tag Key"
-msgstr ""
-
-msgid "Tag Value"
-msgstr ""
-
-msgid "Tag id does not exist"
-msgstr ""
-
-msgid "Tag key already exists"
-msgstr ""
-
-msgid "Tag value already exists"
-msgstr ""
-
-msgid "Non-existent id"
-msgstr ""
-
-msgid "No permission for the target folder"
-msgstr ""
-
-msgid "Application token usage statistics"
-msgstr "Agent token usage statistics"
-
-msgid "Application top question statistics"
-msgstr "Agent top question statistics"
-
-msgid "SAML2 Metadata"
-msgstr ""
-
-msgid "SAML2 Log in"
-msgstr ""
-
-msgid "SAML2 SSO"
-msgstr ""
-
-msgid "Workflow"
-msgstr ""
-
-msgid "Web source url"
-msgstr ""
-
-msgid "Web knowledge selector"
-msgstr ""
-
-msgid "The default is body, you can enter .classname/#idname/tagname"
-msgstr ""
-
-msgid "Please enter the Web root address"
-msgstr ""
-
-msgid "File size exceeds limit"
-msgstr ""
-
-msgid "File upload is not enabled"
-msgstr ""
-
-msgid "Blocked unsafe redirect to internal host"
-msgstr ""
-
-msgid "Audio file recognition - Tongyi Qwen"
-msgstr ""
-
-msgid "Real-time speech recognition - Fun-ASR/Paraformer"
-msgstr ""
-
-msgid "Qwen-Omni"
-msgstr ""
-
-msgid "Super-humanoid: Lingxiaoxuan Flow"
-msgstr ""
-
-msgid "Super-humanoid: Lingyuyan Flow"
-msgstr ""
-
-msgid "Super-humanoid: Lingfeiyi Flow"
-msgstr ""
-
-msgid "Super-humanoid: Lingxiaoyue Flow"
-msgstr ""
-
-msgid "Super-humanoid: Sun Dasheng Flow"
-msgstr ""
-
-msgid "Super-humanoid: Lingyuzhao Flow"
-msgstr ""
-
-msgid "Super-humanoid: Lingxiaotang Flow"
-msgstr ""
-
-msgid "Super-humanoid: Lingxiaorong Flow"
-msgstr ""
-
-msgid "Super-humanoid: Xinyun Flow"
-msgstr ""
-
-msgid "Super-humanoid: Grant (EN)"
-msgstr ""
-
-msgid "Super-humanoid: Lila (EN)"
-msgstr ""
-
-msgid "Super-humanoid: Lingwanwan Pro"
-msgstr ""
-
-msgid "Super-humanoid: Yiyi Pro"
-msgstr ""
-
-msgid "Super-humanoid: Huifangnv Pro"
-msgstr ""
-
-msgid "Super-humanoid: Lingxiaoying Pro"
-msgstr ""
-
-msgid "Super-humanoid: Lingfeibo Pro"
-msgstr ""
-
-msgid "Super-humanoid: Lingyuyan Pro"
-msgstr ""
-
-msgid "Login failed %s times, account will be locked, you have %s more chances !"
-msgstr ""
-
-msgid "This account has been locked for %s minutes, please try again later"
-msgstr ""
-
-msgid "User does not have permission to use API Key"
-msgstr ""
-
-msgid "Import knowledge workflow"
-msgstr ""
-
-msgid "Export knowledge workflow"
-msgstr ""
-
-msgid "Role IDs cannot be empty"
-msgstr ""
-
-msgid "Some roles do not exist"
-msgstr ""
-
-msgid "Authorized pagination list for obtaining resources"
-msgstr ""
-
-msgid "Resources mapping"
-msgstr ""
-
-msgid "Batch set user roles"
-msgstr ""
-
-msgid "Role Setting cannot be empty"
-msgstr ""
-
-msgid "View related resources"
-msgstr ""
-
-msgid "Feedback reason"
-msgstr ""
-
-msgid "Other reason content"
-msgstr ""
-
-msgid "accurate"
-msgstr "accurate"
-
-msgid "complete"
-msgstr "complete"
-
-msgid "inaccurate"
-msgstr "inaccurate"
-
-msgid "incomplete"
-msgstr "incomplete"
-
-msgid "Secret key is invalid"
-msgstr ""
-
-msgid "Secret key is expired"
-msgstr ""
-
-msgid "Online Usage"
-msgstr ""
-
-msgid "API Call"
-msgstr ""
-
-msgid "Enterprise WeChat"
-msgstr ""
-
-msgid "WeChat Public Account"
-msgstr ""
-
+#: apps/application/serializers/application_chat.py:292
 msgid "Lark"
 msgstr "Lark App"
 
-msgid "DingTalk"
-msgstr "DingTalk App"
+#: no source
+msgid "lark"
+msgstr "Lark"
 
-msgid "Enterprise WeChat Robot"
+#: no source
+msgid "Lark application: "
 msgstr ""
 
-msgid "Trigger"
+#: no source
+msgid "Lark callback"
 msgstr ""
 
-msgid "Slack"
-msgstr "Slack App"
-
-msgid "Root Directory"
+#: no source
+msgid "Lark configuration not found or not active"
 msgstr ""
 
-msgid "Create trigger"
+#: no source
+msgid "Lark OAuth2 callback"
 msgstr ""
 
-msgid "Get the trigger list"
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:36
+msgid "Last frame url"
 msgstr ""
 
-msgid "Get trigger details"
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:33
+msgid "Latest flagship model with enhanced reasoning and coding. 204K context window"
 msgstr ""
 
-msgid "Modify the trigger"
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:48
+msgid "Latest Gemini 1.0 Pro model, updated with Google update"
 msgstr ""
 
-msgid "Delete the trigger"
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:55
+msgid "Latest Gemini 1.0 Pro Vision model, updated with Google update"
 msgstr ""
 
-msgid "Delete trigger in batches"
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:65
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:72
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:82
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:89
+msgid "Latest Gemini 1.5 Flash model, updated with Google updates"
 msgstr ""
 
-msgid "Activate trigger in batches"
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:38
+msgid "Latest gpt-4, updated with OpenAI adjustments"
 msgstr ""
 
-msgid "Get the trigger list by page"
+#: no source
+msgid "LDAP configuration not found or not active"
 msgstr ""
 
-msgid "Create trigger in source"
+#: no source
+msgid "LDAP filter cannot be empty"
 msgstr ""
 
-msgid "Get the trigger list of source"
+#: no source
+msgid "Ldap Log in"
 msgstr ""
 
-msgid "Modify the task source trigger"
+#: no source
+msgid "LDAP mapping cannot be empty"
 msgstr ""
 
-msgid "Get Task source trigger details"
+#: no source
+msgid "LDAP server cannot be empty"
 msgstr ""
 
-msgid "Delete the task source trigger"
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:28
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:31
+msgid "Library ID"
 msgstr ""
 
-msgid "Get the task list of triggers"
+#: no source
+msgid "license details"
 msgstr ""
 
-msgid "Retrieve detailed records of tasks executed by the trigger."
+#: no source
+msgid "license file"
 msgstr ""
 
-msgid "Get a paginated list of execution records for trigger tasks."
+#: no source
+msgid "License file is required"
 msgstr ""
 
-msgid "%s must be an array"
+#: no source
+msgid "License usage limit exceeded."
 msgstr ""
 
-msgid "%s must not be empty"
+#: no source
+msgid "license version"
 msgstr ""
 
-msgid "%s values must be between %s and %s"
+#: apps/chat/views/chat_record.py:29
+#: apps/chat/views/chat_record.py:30
+#: apps/chat/views/chat_record.py:31
+msgid "Like, Dislike"
 msgstr ""
 
-msgid "Invalid time format: %s, must be HH:MM (e.g., 09:00)"
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:37
+#: apps/knowledge/serializers/document.py:198
+msgid "limit"
 msgstr ""
 
-msgid "schedule_type must be one of %s"
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:43
+msgid "limit reference"
 msgstr ""
 
-msgid "interval_value must be an integer greater than or equal to 1"
+#: apps/common/utils/common.py:322
+msgid "Limit {count} exceeded, please contact us (https://fit2cloud.com/)."
 msgstr ""
 
-msgid "interval_unit must be one of %s"
+#: apps/application/serializers/application_chat_link.py:119
+msgid "Link"
 msgstr ""
 
-msgid "body must be an array"
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:33
+msgid "List of document ids to exclude"
 msgstr ""
 
-msgid "Error trigger type"
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:36
+msgid "List of exclusion vector ids"
 msgstr ""
 
-msgid "The following id does not exist: %s"
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:60
+msgid "Llama 2 is a set of pretrained and fine-tuned generative text models ranging in size from 7 billion to 70 billion. This is a repository of 13B pretrained models. Links to other models can be found in the index at the bottom."
 msgstr ""
 
-msgid "%s must be a dict"
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:64
+msgid "Llama 2 is a set of pretrained and fine-tuned generative text models ranging in size from 7 billion to 70 billion. This is a repository of 70B pretrained models. Links to other models can be found in the index at the bottom."
 msgstr ""
 
-msgid "input_field_list must be a dict"
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:56
+msgid "Llama 2 is a set of pretrained and fine-tuned generative text models ranging in size from 7 billion to 70 billion. This is a repository of 7B pretrained models. Links to other models can be found in the index at the bottom."
 msgstr ""
 
-msgid "%s type requires %s field"
+#: no source
+msgid "Llama-2-13b-chat was developed by Meta AI and is open source. It performs well in scenarios such as coding, reasoning and knowledge application. Llama-2-13b-chat is a native open source version with balanced performance and effect, suitable for conversation scenarios."
 msgstr ""
 
-msgid "trigger name"
+#: no source
+msgid "Llama-2-70b-chat was developed by Meta AI and is open source. It performs well in scenarios such as coding, reasoning, and knowledge application. Llama-2-70b-chat is a native open source version with high-precision effects."
 msgstr ""
 
-msgid "trigger description"
+#: apps/models_provider/base_model_provider.py:147
+msgid "LLM"
 msgstr ""
 
-msgid "trigger setting"
-msgstr ""
+#: no source
+msgid "LOCAL"
+msgstr "Account login"
 
-msgid "Trigger ID"
+#: apps/models_provider/impl/local_model_provider/local_model_provider.py:40
+msgid "local model"
 msgstr ""
 
-msgid "Trigger task can not be empty"
+#: apps/users/views/login.py:38
+#: apps/users/views/login.py:39
+#: apps/users/views/login.py:40
+msgid "Log in"
 msgstr ""
 
-msgid "%s id does not exist"
+#: apps/common/constants/permission_constants.py:401
+msgid "Login Auth"
 msgstr ""
 
-msgid "Trigger id does not exist"
+#: apps/common/auth/handle/impl/user_token.py:311
+msgid "Login expired"
 msgstr ""
 
-msgid "Trigger not found"
+#: apps/users/serializers/login.py:241
+msgid "Login failed %s times, account will be locked, you have %s more chances !"
 msgstr ""
 
-msgid "Trigger must have at least one task"
+#: no source
+msgid "login image"
 msgstr ""
 
-msgid "Trigger task number must be one"
+#: no source
+msgid "login logo"
 msgstr ""
 
-msgid "Incorrect trigger task"
+#: no source
+msgid "Long Fei"
 msgstr ""
 
-msgid "Trigger task ID"
+#: no source
+msgid "Long Jielidou"
 msgstr ""
 
-msgid "Trigger task record ID"
+#: no source
+msgid "Long Jing"
 msgstr ""
 
-msgid "Trigger task record id does not exist"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:31
+msgid "Long Laotie"
 msgstr ""
 
-msgid "Order field"
+#: no source
+msgid "Long Miao"
 msgstr ""
 
-msgid "System Trigger"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:32
+msgid "Long Shu"
 msgstr ""
 
-msgid "Get the System trigger list of source"
+#: no source
+msgid "Long Shuo"
 msgstr ""
 
-msgid "Get System Task source trigger details"
+#: no source
+msgid "Long Tong"
 msgstr ""
 
-msgid "Modify the System task source trigger"
+#: no source
+msgid "Long Xiang"
 msgstr ""
 
-msgid "Delete the System task source trigger"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:30
+msgid "Long Xiaobai"
 msgstr ""
 
-msgid "Invalid source type"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:29
+msgid "Long Xiaochen"
 msgstr ""
 
-msgid "Shared tool is not supported"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:27
+msgid "Long Xiaochun"
 msgstr ""
 
-msgid "Read Trigger"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:28
+msgid "Long Xiaoxia"
 msgstr ""
 
-msgid "Create Trigger"
+#: no source
+msgid "Long Yuan"
 msgstr ""
 
-msgid "Edit Trigger"
+#: no source
+msgid "Long Yue"
 msgstr ""
 
-msgid "Delete Trigger"
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:20
+msgid "loop_type"
 msgstr ""
 
-msgid "Read execute record"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:26
+msgid "Malay language"
 msgstr ""
-
-msgid "ADMIN"
-msgstr "System Administrator"
-
-msgid "WORKSPACE_MANAGE"
-msgstr "Workspace Manager"
-
-msgid "USER"
-msgstr "Regular User"
-
-msgid "Generate share link"
-msgstr "Generate share link"
-
-msgid "Chat record link"
-msgstr "Chat record link"
-
-msgid "Get chat record by share link"
-msgstr "Get chat record by share link"
-
-msgid "Invalid chat record ids"
-msgstr "Invalid chat record ids"
 
-msgid "Share link does not exist"
-msgstr "Share link does not exist"
-
-msgid "Chat has been deleted"
-msgstr "Chat has been deleted"
-
-msgid "cron type requires cron_expression field"
-msgstr "cron type requires cron_expression field"
-
-msgid "Invalid cron expression: %s"
-msgstr "Invalid cron expression: %s"
-
-msgid "Batch Remove Documents from Tag"
-msgstr "Batch Remove Documents from Tag"
+#: apps/system_manage/views/resource_mapping.py:67
+msgid "Mapping Resource"
+msgstr ""
 
-msgid "Document does not belong to current knowledge"
-msgstr "Document does not belong to current knowledge"
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:37
+msgid "Maximum length of the knowledge base paragraph"
+msgstr ""
 
-msgid "Move an application"
-msgstr "Move an application"
+#: apps/application/serializers/application.py:209
+msgid "Maximum number of quoted characters"
+msgstr ""
 
-msgid "Batch delete applications"
-msgstr "Batch delete applications"
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:27
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:33
+msgid "Maximum number of words in a quoted segment"
+msgstr ""
 
-msgid "Batch move applications"
-msgstr "Batch move applications"
+#: apps/tools/serializers/tool.py:168
+msgid "MCP configuration is invalid"
+msgstr ""
 
-msgid "Batch delete knowledge"
-msgstr "Batch delete knowledge"
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:38
+msgid "MCP Server"
+msgstr ""
 
-msgid "Batch move knowledge"
-msgstr "Batch move knowledge"
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:14
+msgid "Mcp server"
+msgstr ""
 
-msgid "Batch delete tools"
-msgstr "Batch delete tools"
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:13
+msgid "Mcp servers"
+msgstr ""
 
-msgid "Batch move tools"
-msgstr "Batch move tools"
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:42
+msgid "MCP Source"
+msgstr ""
 
-msgid "Model is not allowed to be empty"
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:17
+msgid "Mcp source"
 msgstr ""
 
-msgid "Not a valid zip file"
-msgstr "Not a valid zip file"
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:15
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:16
+msgid "Mcp tool"
+msgstr ""
 
-msgid "Not a valid KB export file, missing knowledge.json"
-msgstr "Not a valid KB export file, missing knowledge.json"
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:39
+msgid "MCP Tool ID"
+msgstr ""
 
-msgid "Not a valid KB export file, missing knowledge.xlsx"
-msgstr "Not a valid KB export file, missing knowledge.xlsx"
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:41
+msgid "MCP Tool IDs"
+msgstr ""
 
-msgid "Tags"
-msgstr "Tags"
+#: no source
+msgid "Members"
+msgstr ""
 
-msgid "Hit handling method"
-msgstr "Hit handling method"
+#: no source
+msgid "menu"
+msgstr ""
 
-msgid "Directly return similarity"
-msgstr "Directly return similarity"
+#: no source
+msgid "Menu"
+msgstr ""
 
-msgid "Paragraph is active"
-msgstr "Paragraph is active"
+#: no source
+msgid "menu_label"
+msgstr ""
 
-msgid "Document type"
-msgstr "Document type"
+#: no source
+msgid "message"
+msgstr ""
 
-msgid "Document meta"
-msgstr "Document meta"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:99
+msgid "message type error"
+msgstr ""
 
-msgid "Export knowledge bundle"
-msgstr "Export knowledge bundle"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:36
+#: apps/common/field/common.py:24
+#: apps/common/field/common.py:37
+msgid "Message type error"
+msgstr ""
 
-msgid "Import knowledge bundle"
-msgstr "Import knowledge bundle"
+#: no source
+msgid "Message types not supported yet"
+msgstr ""
 
-msgid "Export system knowledge bundle"
-msgstr "Export system knowledge bundle"
+#: apps/tools/serializers/tool.py:1572
+msgid "Messages"
+msgstr ""
 
-msgid "Export shared knowledge bundle"
-msgstr "Export shared knowledge bundle"
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:76
+msgid "Meta Llama 3: The most capable public product LLM to date. 70 billion parameters."
+msgstr ""
 
-msgid "Batch delete"
-msgstr "Batch delete"
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:72
+msgid "Meta Llama 3: The most capable public product LLM to date. 8 billion parameters."
+msgstr ""
 
-msgid "Batch move"
-msgstr "Batch move"
+#: apps/local_model/serializers/model_apply_serializers.py:105
+#: apps/models_provider/serializers/model_apply_serializers.py:42
+msgid "metadata"
+msgstr ""
 
-msgid "There is a circular dependency in the tool workflow"
-msgstr "There is a circular dependency in the tool workflow"
+#: apps/models_provider/api/provide.py:39
+msgid "method"
+msgstr ""
 
-msgid "model_params_form must be a list"
+#: apps/common/constants/permission_constants.py:368
+msgid "Migrate"
 msgstr ""
 
-msgid "The {index}th item in model_params_form must be a dictionary"
+#: apps/knowledge/views/document.py:1154
+#: apps/knowledge/views/document.py:1155
+msgid "Migrate documents in batches"
 msgstr ""
 
-msgid "The label field is required for the {index}th item in model_params_form"
+#: apps/knowledge/views/paragraph.py:105
+#: apps/knowledge/views/paragraph.py:106
+msgid "Migrate paragraphs in batches"
 msgstr ""
 
-msgid "Publish"
+#: no source
+msgid "Migrate shared documents in batches"
 msgstr ""
 
-msgid "token is required for EVENT triggers"
+#: no source
+msgid "Migrate shared paragraphs in batches"
 msgstr ""
 
-msgid "Home page"
+#: no source
+msgid "Migrate system knowledges in batches"
 msgstr ""
 
-msgid "Response code"
+#: no source
+msgid "Migrate system paragraphs in batches"
 msgstr ""
 
-msgid "Response message"
+#: apps/application/api/application_chat.py:82
+#: apps/application/serializers/application_chat.py:62
+msgid "Minimum number of clicks"
 msgstr ""
 
-msgid "Total count"
+#: apps/application/api/application_chat.py:76
+#: apps/application/serializers/application_chat.py:60
+msgid "Minimum number of likes"
 msgstr ""
 
-msgid "Application data aggregation"
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:95
+msgid "Mixed element visual model"
 msgstr ""
 
-msgid "Knowledge data aggregation"
+#: apps/application/serializers/application.py:348
+#: apps/application/serializers/application.py:595
+#: apps/chat/serializers/chat.py:156
+#: apps/common/constants/permission_constants.py:342
+#: apps/common/constants/permission_constants.py:411
+#: apps/common/constants/permission_constants.py:421
+#: apps/common/constants/permission_constants.py:436
+#: apps/models_provider/views/model.py:64
+#: apps/models_provider/views/model.py:86
+#: apps/models_provider/views/model.py:99
+#: apps/models_provider/views/model.py:120
+#: apps/models_provider/views/model.py:143
+#: apps/models_provider/views/model.py:164
+#: apps/models_provider/views/model.py:186
+#: apps/models_provider/views/model.py:207
+#: apps/models_provider/views/model.py:234
+#: apps/models_provider/views/model.py:256
+#: apps/models_provider/views/model.py:301
+#: apps/models_provider/views/model_apply.py:29
+#: apps/models_provider/views/model_apply.py:41
+#: apps/models_provider/views/model_apply.py:53
+#: apps/models_provider/views/provide.py:25
+#: apps/models_provider/views/provide.py:48
+#: apps/models_provider/views/provide.py:62
+#: apps/models_provider/views/provide.py:80
+#: apps/models_provider/views/provide.py:97
+msgid "Model"
 msgstr ""
+
+#: no source
+msgid "model"
+msgstr "Model"
 
-msgid "Tool data aggregation"
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:52
+#: apps/models_provider/impl/local_model_provider/credential/embedding/web.py:37
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:64
+#: apps/models_provider/impl/local_model_provider/credential/reranker/web.py:37
+msgid "Model catalog"
 msgstr ""
 
+#: apps/homepage/views/homepage.py:322
+#: apps/homepage/views/homepage.py:323
 msgid "Model data aggregation"
 msgstr ""
 
-msgid "Total application count"
+#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:65
+#: apps/application/serializers/application.py:241
+#: apps/application/serializers/application.py:1285
+#: apps/application/serializers/application.py:1291
+#: apps/application/serializers/application.py:1297
+#: apps/application/serializers/application.py:1303
+#: apps/knowledge/serializers/document.py:861
+#: apps/knowledge/serializers/knowledge.py:344
+#: apps/models_provider/serializers/model_serializer.py:140
+#: apps/models_provider/serializers/model_serializer.py:160
+#: apps/models_provider/serializers/model_serializer.py:498
+#: apps/models_provider/tools.py:116
+msgid "Model does not exist"
 msgstr ""
 
+#: apps/chat/serializers/chat.py:188
+#: apps/tools/serializers/tool.py:1602
+msgid "Model does not exists or is not an LLM model"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:56
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:29
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:19
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:13
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:13
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:14
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:19
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:22
+#: apps/application/flow/step_node/question_node/i_question_node.py:19
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:13
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:14
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:13
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:13
+#: apps/application/serializers/application.py:228
+#: apps/application/serializers/application.py:465
+#: apps/application/serializers/application.py:465
+#: apps/knowledge/serializers/common.py:77
+msgid "Model id"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:237
+#: apps/knowledge/serializers/paragraph.py:93
+#: apps/local_model/serializers/model_apply_serializers.py:129
+#: apps/models_provider/api/model.py:105
+#: apps/models_provider/serializers/model_apply_serializers.py:51
+#: apps/models_provider/serializers/model_serializer.py:128
+#: apps/models_provider/serializers/model_serializer.py:481
+msgid "model id"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1570
+msgid "Model ID"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:20
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:14
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:14
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:15
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:20
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:23
+#: apps/application/flow/step_node/question_node/i_question_node.py:20
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:14
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:15
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:14
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:14
+msgid "Model id type"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py:205
+#: apps/application/flow/step_node/image_generate_step_node/impl/base_image_generate_node.py:41
+#: apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py:44
+#: apps/application/flow/step_node/image_understand_step_node/impl/base_image_understand_node.py:157
+#: apps/application/flow/step_node/intent_node/impl/base_intent_node.py:67
+#: apps/application/flow/step_node/parameter_extraction_node/impl/base_parameter_extraction_node.py:99
+#: apps/application/flow/step_node/question_node/impl/base_question_node.py:98
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:77
+#: apps/application/flow/step_node/speech_to_text_step_node/impl/base_speech_to_text_node.py:39
+#: apps/application/flow/step_node/text_to_speech_step_node/impl/base_text_to_speech_node.py:63
+#: apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py:44
+#: apps/application/flow/step_node/video_understand_step_node/impl/base_video_understand_node.py:154
+msgid "Model is not allowed to be empty"
+msgstr ""
+
+#: apps/models_provider/api/model.py:37
+#: apps/models_provider/api/provide.py:17
+#: apps/models_provider/api/provide.py:23
+#: apps/models_provider/api/provide.py:28
+#: apps/models_provider/api/provide.py:30
+#: apps/models_provider/api/provide.py:82
+#: apps/models_provider/serializers/model_serializer.py:63
+#: apps/models_provider/serializers/model_serializer.py:248
+#: apps/models_provider/serializers/model_serializer.py:285
+#: apps/models_provider/serializers/model_serializer.py:359
+#: apps/models_provider/serializers/model_serializer.py:542
+msgid "model name"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:85
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:33
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:32
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:33
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:32
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:27
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:20
+#: apps/application/flow/step_node/question_node/i_question_node.py:33
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:23
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:23
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:32
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:31
+msgid "Model parameter settings"
+msgstr ""
+
+#: apps/application/serializers/application.py:382
+#: apps/application/serializers/application.py:613
+msgid "Model parameters"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1573
+msgid "Model Params Setting"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:349
+msgid "Model saving failed"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:82
+msgid "Model settings"
+msgstr ""
+
+#: apps/application/serializers/application.py:608
+msgid "Model setup"
+msgstr ""
+
+#: apps/models_provider/api/model.py:44
+#: apps/models_provider/api/provide.py:29
+#: apps/models_provider/api/provide.py:70
+#: apps/models_provider/api/provide.py:98
+#: apps/models_provider/serializers/model_serializer.py:65
+#: apps/models_provider/serializers/model_serializer.py:250
+#: apps/models_provider/serializers/model_serializer.py:287
+#: apps/models_provider/serializers/model_serializer.py:360
+#: apps/models_provider/serializers/model_serializer.py:543
+msgid "model type"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:60
+msgid "Model type cannot be empty"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:26
+msgid "Model type error"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:34
+msgid "Model type is not supported"
+msgstr ""
+
+#: no source
+msgid "Models Resource"
+msgstr ""
+
+#: apps/local_model/serializers/model_apply_serializers.py:114
+msgid "model_name"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:517
+msgid "model_params_form must be a list"
+msgstr ""
+
+#: apps/local_model/serializers/model_apply_serializers.py:116
+msgid "model_type"
+msgstr ""
+
+#: apps/application/serializers/application.py:470
+#: apps/application/serializers/application.py:470
+msgid "Modification time"
+msgstr ""
+
+#: apps/application/views/application_access_token.py:38
+#: apps/application/views/application_access_token.py:39
+#: apps/application/views/application_access_token.py:40
+msgid "Modify application access restriction information"
+msgstr "Modify agent access restriction information"
+
+#: no source
+msgid "Modify application access token"
+msgstr "Modify agent access token"
+
+#: apps/application/views/application_api_key.py:83
+#: apps/application/views/application_api_key.py:84
+#: apps/application/views/application_api_key.py:85
+msgid "Modify application API_KEY"
+msgstr "Modify agent API_KEY"
+
+#: no source
+msgid "Modify Application Settings"
+msgstr "Modify Agent Settings"
+
+#: apps/application/views/application_version.py:100
+#: apps/application/views/application_version.py:101
+#: apps/application/views/application_version.py:102
+msgid "Modify application version information"
+msgstr "Modify agent version information"
+
+#: apps/chat/views/chat_record.py:68
+#: apps/chat/views/chat_record.py:69
+#: apps/chat/views/chat_record.py:70
+msgid "Modify conversation about"
+msgstr ""
+
+#: apps/users/views/user.py:374
+#: apps/users/views/user.py:375
+#: apps/users/views/user.py:376
+msgid "Modify current user password"
+msgstr ""
+
+#: apps/knowledge/views/document.py:152
+#: apps/knowledge/views/document.py:153
+#: apps/knowledge/views/document.py:154
+msgid "Modify document"
+msgstr ""
+
+#: apps/knowledge/views/document.py:287
+#: apps/knowledge/views/document.py:288
+#: apps/knowledge/views/document.py:289
+msgid "Modify document hit processing methods in batches"
+msgstr ""
+
+#: no source
+msgid "Modify knowledge base information"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow_version.py:110
+#: apps/knowledge/views/knowledge_workflow_version.py:111
+#: apps/knowledge/views/knowledge_workflow_version.py:112
+msgid "Modify knowledge version information"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:175
+#: apps/knowledge/views/paragraph.py:176
+#: apps/knowledge/views/paragraph.py:177
+msgid "Modify paragraph data"
+msgstr ""
+
+#: no source
+msgid "Modify platform information"
+msgstr ""
+
+#: apps/knowledge/views/problem.py:198
+#: apps/knowledge/views/problem.py:199
+#: apps/knowledge/views/problem.py:200
+msgid "Modify question"
+msgstr ""
+
+#: no source
+msgid "Modify shared document"
+msgstr ""
+
+#: no source
+msgid "Modify shared document hit processing methods in batches"
+msgstr ""
+
+#: no source
+msgid "Modify shared paragraph data"
+msgstr ""
+
+#: no source
+msgid "Modify shared question"
+msgstr ""
+
+#: no source
+msgid "Modify system document"
+msgstr ""
+
+#: no source
+msgid "Modify system document hit processing methods in batches"
+msgstr ""
+
+#: no source
+msgid "Modify system paragraph data"
+msgstr ""
+
+#: no source
+msgid "Modify system question"
+msgstr ""
+
+#: apps/knowledge/views/termbase.py:199
+#: apps/knowledge/views/termbase.py:200
+#: apps/knowledge/views/termbase.py:201
+msgid "Modify termbase"
+msgstr ""
+
+#: apps/application/views/application.py:195
+#: apps/application/views/application.py:196
+#: apps/application/views/application.py:197
+msgid "Modify the application"
+msgstr ""
+
+#: apps/system_manage/views/user_resource_permission.py:61
+#: apps/system_manage/views/user_resource_permission.py:62
+msgid "Modify the resource authorization list"
+msgstr ""
+
+#: no source
+msgid "Modify the System task source trigger"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:342
+#: apps/trigger/views/trigger.py:343
+#: apps/trigger/views/trigger.py:344
+msgid "Modify the task source trigger"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:127
+#: apps/trigger/views/trigger.py:128
+#: apps/trigger/views/trigger.py:129
+msgid "Modify the trigger"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:111
+#: apps/tools/views/tool_workflow_version.py:112
+#: apps/tools/views/tool_workflow_version.py:113
+msgid "Modify tool version information"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:38
+msgid "monster style"
+msgstr ""
+
+#: apps/application/views/application.py:245
+#: apps/application/views/application.py:246
+#: apps/application/views/application.py:247
+msgid "Move an application"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:37
+msgid "Multiple dialects, supporting 23 dialects"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge_workflow.py:97
+#: apps/tools/serializers/tool_workflow.py:128
+#: apps/users/serializers/user.py:396
+msgid "Name"
+msgstr ""
+
+#: no source
+msgid "Network error or folder token error!"
+msgstr ""
+
+#: no source
+msgid "New chat"
+msgstr "A new conversation has been generated. Please ask your question again！"
+
+#: apps/knowledge/serializers/paragraph.py:802
+msgid "new_position must be an integer"
+msgstr ""
+
+#: apps/users/serializers/user.py:68
+#: apps/users/serializers/user.py:199
+msgid "Nick name"
+msgstr ""
+
+#: apps/users/serializers/user.py:242
+msgid "Nick Name"
+msgstr ""
+
+#: no source
+msgid "Nickname"
+msgstr ""
+
+#: apps/users/serializers/user.py:419
+msgid "Nickname is already in use"
+msgstr ""
+
+#: apps/system_manage/api/user_resource_permission.py:117
+msgid "nick_name"
+msgstr ""
+
+#: apps/application/serializers/application.py:259
+msgid "No citation segmentation prompt"
+msgstr ""
+
+#: apps/oss/views/file.py:85
+msgid "No permission"
+msgstr ""
+
+#: apps/folders/serializers/folder.py:228
+msgid "No permission for the target folder"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:293
+#: apps/application/serializers/application_chat_record.py:430
+#: apps/application/serializers/application_chat_record.py:504
+#: apps/common/auth/authentication.py:139
+msgid "No permission to access"
+msgstr ""
+
+#: no source
+msgid "No permission to use this function {name}"
+msgstr ""
+
+#: no source
+msgid "No permission to use this model {model_name}"
+msgstr ""
+
+#: apps/application/serializers/application.py:137
+#: apps/application/serializers/application.py:788
+msgid "No permission to use tool(s): {tool_ids}"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:77
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:47
+msgid "No reference segment settings"
+msgstr ""
+
+#: apps/application/serializers/application.py:201
+msgid "No reference status"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:83
+msgid "Node id"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:89
+msgid "Node parameters"
+msgstr ""
+
+#: apps/application/flow/common.py:267
+msgid "Node {node} is unavailable"
+msgstr ""
+
+#: no source
+msgid "Non-existent application|knowledge base id["
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:178
+msgid "Non-existent chatID"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:64
+msgid "Non-existent conversation chat_record_id"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:82
+msgid "Non-existent id"
+msgstr ""
+
+#: apps/common/field/common.py:48
+msgid "not a function"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:904
+msgid "Not a valid KB export file, missing knowledge.json"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:906
+msgid "Not a valid KB export file, missing knowledge.xlsx"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:899
+msgid "Not a valid zip file"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:17
+msgid "Not limited to style"
+msgstr ""
+
+#: apps/common/auth/authenticate.py:82
+#: apps/common/auth/authenticate.py:108
+#: apps/common/auth/authenticate.py:134
+msgid "Not logged in, please log in first"
+msgstr ""
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:24
+msgid "number"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:41
+#: apps/application/serializers/application_stats.py:28
+msgid "Number of conversations"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:42
+#: apps/application/serializers/application_stats.py:32
+msgid "Number of Likes"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:34
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:27
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:23
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:24
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:22
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:25
+#: apps/application/flow/step_node/question_node/i_question_node.py:28
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:23
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:21
+msgid "Number of multi-round conversations"
+msgstr ""
+
+#: apps/application/serializers/application_stats.py:29
+msgid "Number of new users"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:35
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:39
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:20
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:41
+msgid "Number of pictures"
+msgstr ""
+
+#: apps/homepage/serializers/homepage.py:305
+#: apps/homepage/serializers/homepage.py:490
+#: apps/homepage/serializers/homepage.py:628
+msgid "number of questions"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:44
+msgid "Number of tags"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:43
+#: apps/application/serializers/application_stats.py:34
+msgid "Number of thumbs-downs"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:18
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:15
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:24
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:24
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:24
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:24
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:17
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:16
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:22
+msgid "Number of top documents to return after reranking"
+msgstr ""
+
+#: apps/application/flow/step_node/data_source_local_node/i_data_source_local_node.py:21
+msgid "Number of uploaded files"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:29
+msgid "Number of visits"
+msgstr ""
+
+#: no source
+msgid "OAuth2 Log in"
+msgstr ""
+
+#: apps/system_manage/views/user_resource_permission.py:43
+#: apps/system_manage/views/user_resource_permission.py:44
+msgid "Obtain resource authorization list"
+msgstr ""
+
+#: apps/system_manage/views/user_resource_permission.py:85
+#: apps/system_manage/views/user_resource_permission.py:86
+#: apps/system_manage/views/user_resource_permission.py:87
+msgid "Obtain resource authorization list by page"
+msgstr ""
+
+#: no source
+msgid "OIDC Log in"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:20
+msgid "Oil painting 1"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:21
+msgid "Oil Painting 2 (Van Gogh)"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:25
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:55
+msgid "Online TTS"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:288
+msgid "Online Usage"
+msgstr ""
+
+#: no source
+msgid "Only shared knowledge can be authorized"
+msgstr ""
+
+#: no source
+msgid "Only shared tools can be authorized"
+msgstr ""
+
+#: no source
+msgid "Only shared tools can be deleted"
+msgstr ""
+
+#: apps/application/serializers/application.py:1013
+#: apps/common/utils/tool_code.py:385
+#: apps/knowledge/serializers/knowledge_workflow.py:666
+#: apps/tools/serializers/tool_workflow.py:396
+msgid "Only support transport=sse or transport=streamable_http"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:65
+msgid "Only supports and|or"
+msgstr ""
+
+#: no source
+msgid "Only update members to normal users"
+msgstr ""
+
+#: apps/chat/views/chat.py:74
+#: apps/chat/views/chat.py:75
+#: apps/chat/views/chat.py:76
+msgid "OpenAI Interface Dialogue"
+msgstr ""
+
+#: apps/application/serializers/application.py:300
+#: apps/application/serializers/application.py:353
+#: apps/application/serializers/application.py:600
+msgid "Opening remarks"
+msgstr ""
+
+#: no source
+msgid "operate"
+msgstr ""
+
+#: no source
+msgid "Operate"
+msgstr ""
+
+#: no source
+msgid "Operate Time"
+msgstr ""
+
+#: no source
+msgid "Operate user"
+msgstr ""
+
+#: no source
+msgid "operate_label"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:337
+msgid "Operation Log"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:39
+#: apps/knowledge/serializers/document.py:483
+msgid "order by"
+msgstr ""
+
+#: apps/trigger/serializers/trigger_task.py:131
+msgid "Order field"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:174
+#: apps/chat/serializers/chat.py:95
+#: apps/common/constants/permission_constants.py:338
+#: apps/common/constants/permission_constants.py:345
+msgid "Other"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:217
+msgid "Other reason content"
+msgstr ""
+
+#: no source
+msgid "OU cannot be empty"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:30
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:29
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:24
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:23
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:26
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:42
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:26
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:24
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:24
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:21
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:29
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:26
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:27
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:26
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:31
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:24
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:24
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:49
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:24
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:24
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:24
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:30
+msgid "Output the maximum Tokens"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:395
+#: apps/common/constants/permission_constants.py:408
+#: apps/common/constants/permission_constants.py:439
+msgid "Overview"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:140
+#: apps/knowledge/views/knowledge_workflow.py:141
+#: apps/knowledge/views/knowledge_workflow.py:142
+msgid "Page Knowledge workflow action"
+msgstr ""
+
+#: apps/application/api/application_api.py:61
+#: apps/application/api/application_chat.py:117
+#: apps/application/api/application_chat_record.py:81
+#: apps/homepage/api/home_page_api.py:103
+#: apps/system_manage/api/resource_mapping.py:63
+#: apps/system_manage/api/user_resource_permission.py:214
+#: apps/system_manage/api/user_resource_permission.py:280
+#: apps/trigger/api/trigger.py:100
+#: apps/trigger/api/trigger_task.py:109
+msgid "Page size"
+msgstr ""
+
+#: apps/common/result/api.py:45
+msgid "page size"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:54
+msgid "painting"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:13
+msgid "painting style"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:26
+msgid "paper cut style"
+msgstr ""
+
+#: no source
+msgid "Paragraph"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:241
+msgid "Paragraph content"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:490
+msgid "Paragraph does not exist"
+msgstr ""
+
+#: apps/application/api/application_chat_record.py:148
+msgid "Paragraph ID"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:480
+msgid "Paragraph id"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:91
+#: apps/knowledge/serializers/paragraph.py:110
+#: apps/knowledge/serializers/paragraph.py:202
+#: apps/knowledge/serializers/paragraph.py:476
+#: apps/knowledge/serializers/paragraph.py:609
+#: apps/knowledge/serializers/paragraph.py:781
+#: apps/knowledge/serializers/problem.py:36
+#: apps/knowledge/serializers/problem.py:51
+msgid "paragraph id"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:125
+#: apps/knowledge/serializers/paragraph.py:221
+msgid "Paragraph id does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:91
+#: apps/knowledge/serializers/paragraph.py:608
+msgid "paragraph id list"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:773
+msgid "Paragraph is active"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:58
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:29
+msgid "Paragraph List"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:24
+#: apps/knowledge/views/paragraph.py:25
+#: apps/knowledge/views/paragraph.py:26
+msgid "Paragraph list"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:22
+msgid "paragraph title relate problem"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:25
+msgid "paragraph title relate problem reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:18
+msgid "paragraph title relate problem type"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:67
+#: apps/models_provider/serializers/model_serializer.py:289
+msgid "parameter configuration"
+msgstr ""
+
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:40
+msgid "Parameter value error: The uploaded audio lacks file_id, and the audio upload fails"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:81
+msgid "Parameter value error: The uploaded audio lacks file_id, and the audio upload fails."
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:62
+msgid "Parameter value error: The uploaded document lacks file_id, and the document upload fails"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:71
+msgid "Parameter value error: The uploaded image lacks file_id, and the image upload fails"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:91
+msgid "Parameter value error: The uploaded video lacks file_id, and the video upload fails."
+msgstr ""
+
+#: apps/folders/models/folder.py:12
+#: apps/folders/models/folder.py:23
+#: apps/folders/serializers/folder.py:131
+msgid "parent id"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:34
+#: apps/users/api/login.py:27
+#: apps/users/api/user.py:93
+#: apps/users/serializers/login.py:33
+#: apps/users/serializers/user.py:66
+#: apps/users/serializers/user.py:185
+#: apps/users/serializers/user.py:429
+#: apps/users/serializers/user.py:977
+#: apps/users/serializers/user.py:1035
+msgid "Password"
+msgstr ""
+
+#: no source
+msgid "password"
+msgstr "Password login"
+
+#: apps/common/constants/exception_code_constants.py:43
+msgid "Password and confirmation password are inconsistent"
+msgstr ""
+
+#: no source
+msgid "Password cannot be empty"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:53
+#: apps/knowledge/serializers/document.py:200
+#: apps/knowledge/serializers/document.py:200
+msgid "patterns"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:59
+msgid "patterns reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:56
+msgid "patterns type"
+msgstr ""
+
+#: apps/models_provider/views/model.py:250
+#: apps/models_provider/views/model.py:251
+#: apps/models_provider/views/model.py:252
+msgid "Pause model download"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:56
+msgid "Peak Performance. Ultimate Value. 204K context window"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:72
+msgid "Perfecting tonal nuances with maximized timbre similarity"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1308
+msgid "period"
+msgstr ""
+
+#: apps/system_manage/api/user_resource_permission.py:28
+#: apps/system_manage/api/user_resource_permission.py:119
+#: apps/system_manage/serializers/user_resource_permission.py:53
+#: apps/system_manage/serializers/user_resource_permission.py:64
+#: apps/system_manage/serializers/user_resource_permission.py:104
+#: apps/system_manage/serializers/user_resource_permission.py:302
+#: apps/system_manage/serializers/user_resource_permission.py:308
+msgid "permission"
+msgstr ""
+
+#: no source
+msgid "Permission"
+msgstr ""
+
+#: apps/users/serializers/user.py:57
+msgid "permissions"
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:153
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:193
+msgid "Phi-3 Mini is Microsoft's 3.8B parameter, lightweight, state-of-the-art open model."
+msgstr ""
+
+#: apps/users/serializers/user.py:69
+#: apps/users/serializers/user.py:204
+#: apps/users/serializers/user.py:401
+msgid "Phone"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:50
+msgid "photography"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:54
+#: apps/application/flow/step_node/application_node/i_application_node.py:21
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:29
+#: apps/chat/serializers/chat.py:92
+#: apps/tools/serializers/tool.py:1153
+msgid "picture"
+msgstr ""
+
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:27
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:28
+msgid "Picture quality"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:23
+msgid "pixel art"
+msgstr ""
+
+#: no source
+msgid "Platform configuration"
+msgstr ""
+
+#: no source
+msgid "Platform does not exist"
+msgstr ""
+
+#: no source
+msgid "Platform type"
+msgstr ""
+
+#: apps/application/views/application.py:514
+#: apps/application/views/application.py:515
+#: apps/application/views/application.py:516
+msgid "PlayDemo"
+msgstr ""
+
+#: no source
+msgid "Please analyze the content of the image."
+msgstr ""
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:23
+msgid "Please enter the Web root address"
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:32
+msgid "Please log in first and bring the user Token"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:41
+msgid "Please outline this picture"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:54
+msgid "Please select a system voice supported by Qwen-TTS"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:51
+msgid "Portraits"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:30
+msgid "Portuguese"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:65
+msgid "Post-processor"
+msgstr ""
+
+#: apps/application/serializers/application.py:460
+#: apps/application/serializers/application.py:460
+msgid "Primary key id"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:359
+#: apps/common/constants/permission_constants.py:417
+#: apps/common/constants/permission_constants.py:427
+msgid "Problem"
+msgstr ""
+
+#: apps/knowledge/api/problem.py:40
+#: apps/knowledge/api/problem.py:53
+#: apps/knowledge/api/termbase.py:39
+#: apps/knowledge/api/termbase.py:46
+#: apps/knowledge/serializers/problem.py:42
+msgid "problem"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:215
+msgid "Problem after optimization"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:492
+msgid "Problem does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:474
+#: apps/knowledge/serializers/problem.py:27
+#: apps/knowledge/serializers/problem.py:47
+#: apps/knowledge/serializers/problem.py:57
+#: apps/knowledge/serializers/problem.py:139
+msgid "problem id"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:262
+msgid "Problem id does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/problem.py:46
+#: apps/knowledge/serializers/problem.py:56
+msgid "problem id list"
+msgstr ""
+
+#: apps/knowledge/api/problem.py:39
+#: apps/knowledge/api/problem.py:52
+#: apps/knowledge/api/termbase.py:38
+#: apps/knowledge/api/termbase.py:45
+#: apps/knowledge/serializers/problem.py:41
+msgid "problem list"
+msgstr ""
+
+#: apps/common/utils/tool_code.py:379
+msgid "Process execution timed out after {} seconds."
+msgstr ""
+
+#: no source
+msgid "product"
+msgstr ""
+
+#: no source
+msgid "project url"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:238
+#: apps/knowledge/serializers/paragraph.py:95
+msgid "prompt"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1571
+msgid "Prompt"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:54
+msgid "Prompt template"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:39
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:25
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:20
+#: apps/application/flow/step_node/question_node/i_question_node.py:25
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:19
+#: apps/application/serializers/application.py:202
+#: apps/application/serializers/application.py:253
+#: apps/knowledge/serializers/common.py:78
+msgid "Prompt word"
+msgstr ""
+
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:19
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:20
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:19
+msgid "Prompt word (negative)"
+msgstr ""
+
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:17
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:18
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:17
+msgid "Prompt word (positive)"
+msgstr ""
+
+#: apps/homepage/serializers/homepage.py:304
+#: apps/homepage/serializers/homepage.py:491
+#: apps/homepage/serializers/homepage.py:627
+msgid "proportion"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:46
+msgid "props info"
+msgstr ""
+
+#: apps/chat/api/chat_embed_api.py:31
+#: apps/chat/serializers/chat_embed_serializers.py:26
+msgid "protocol"
+msgstr ""
+
+#: apps/models_provider/api/model.py:58
+#: apps/models_provider/api/provide.py:18
+#: apps/models_provider/api/provide.py:38
+#: apps/models_provider/api/provide.py:76
+#: apps/models_provider/api/provide.py:104
+#: apps/models_provider/api/provide.py:126
+#: apps/models_provider/serializers/model_serializer.py:64
+#: apps/models_provider/serializers/model_serializer.py:286
+#: apps/models_provider/serializers/model_serializer.py:362
+#: apps/models_provider/serializers/model_serializer.py:545
+msgid "provider"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:377
+msgid "Public access link"
+msgstr ""
+
+#: no source
+msgid "Public settings"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:349
+msgid "Publish"
+msgstr ""
+
+#: apps/application/api/application_api.py:96
+#: apps/application/serializers/application.py:452
+msgid "Publish status"
+msgstr ""
+
+#: apps/application/serializers/application.py:453
+msgid "Published"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:248
 msgid "Published application count"
 msgstr ""
 
-msgid "Unpublished application count"
+#: apps/application/views/application.py:272
+#: apps/application/views/application.py:273
+#: apps/application/views/application.py:274
+msgid "Publishing an application"
 msgstr ""
 
-msgid "Total knowledge count"
+#: apps/knowledge/views/knowledge_workflow.py:253
+#: apps/knowledge/views/knowledge_workflow.py:254
+#: apps/knowledge/views/knowledge_workflow.py:255
+msgid "Publishing an knowledge"
 msgstr ""
 
-msgid "Total document count"
+#: apps/tools/views/tool_workflow.py:29
+#: apps/tools/views/tool_workflow.py:30
+#: apps/tools/views/tool_workflow.py:31
+msgid "Publishing an tool"
 msgstr ""
 
-msgid "Failed document count"
+#: apps/local_model/serializers/model_apply_serializers.py:110
+#: apps/models_provider/serializers/model_apply_serializers.py:47
+msgid "query"
 msgstr ""
 
-msgid "Total tool count"
+#: apps/models_provider/views/model.py:296
+#: apps/models_provider/views/model.py:297
+#: apps/models_provider/views/model.py:298
+msgid "Query all model list"
 msgstr ""
 
-msgid "Active tool count"
+#: apps/models_provider/views/model.py:159
+#: apps/models_provider/views/model.py:160
+#: apps/models_provider/views/model.py:161
+msgid "Query model details"
 msgstr ""
 
-msgid "Inactive tool count"
+#: apps/models_provider/views/model.py:94
+#: apps/models_provider/views/model.py:95
+#: apps/models_provider/views/model.py:96
+msgid "Query model list"
 msgstr ""
 
-msgid "Total model count"
+#: apps/models_provider/views/model.py:226
+#: apps/models_provider/views/model.py:228
+#: apps/models_provider/views/model.py:230
+msgid "Query model meta information, this interface does not carry authentication information"
 msgstr ""
 
-msgid "Active model count"
+#: apps/knowledge/serializers/knowledge.py:157
+#: apps/knowledge/serializers/knowledge.py:1362
+msgid "query text"
 msgstr ""
 
-msgid "Inactive model count"
+#: apps/common/event/listener_manage.py:114
+msgid "Query vector data: {paragraph_id_list} error {error} {traceback}"
 msgstr ""
 
-msgid "Top applications by token consumption"
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:26
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:24
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:24
+#: apps/application/serializers/application_chat_record.py:244
+msgid "question"
 msgstr ""
 
-msgid "Top applications by question count"
+#: apps/knowledge/serializers/document.py:936
+#: apps/knowledge/serializers/knowledge.py:768
+msgid "Question (optional, one per line in the cell)"
 msgstr ""
 
-msgid "Top users by token consumption"
+#: apps/application/serializers/application.py:366
+#: apps/application/serializers/application.py:610
+msgid "Question completion"
 msgstr ""
 
-msgid "Application tokens ranking list"
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:32
+#: apps/application/serializers/application.py:368
+msgid "Question completion prompt"
 msgstr ""
 
-msgid "Application question ranking list"
-msgstr ""
-
-msgid "User tokens ranking list"
-msgstr ""
-
-msgid "Application name"
-msgstr ""
-
-msgid "Total consumed tokens"
-msgstr ""
-
+#: apps/homepage/api/home_page_api.py:195
+#: apps/homepage/api/home_page_api.py:224
 msgid "Question count"
 msgstr ""
 
-msgid "Chat user ID"
+#: apps/knowledge/views/problem.py:23
+#: apps/knowledge/views/problem.py:24
+#: apps/knowledge/views/problem.py:25
+msgid "Question list"
 msgstr ""
 
-msgid "Chat user type"
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:31
+msgid "question reference address"
 msgstr ""
 
-msgid "Asker user information"
+#: apps/application/serializers/application_chat.py:223
+msgid "Question Time"
 msgstr ""
 
+#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:46
+msgid "Quickly and accurately generate images based on user text descriptions. Resolution supports 1024x1024"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:25
+msgid "Qwen-Omni"
+msgstr ""
+
+#: apps/homepage/serializers/homepage.py:301
+#: apps/homepage/serializers/homepage.py:488
+#: apps/homepage/serializers/homepage.py:624
+msgid "ranking"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:28
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:28
+msgid "Ratio"
+msgstr ""
+
+#: apps/users/serializers/user.py:443
+#: apps/users/serializers/user.py:991
+#: apps/users/serializers/user.py:1049
+msgid "Re Password"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:334
+#: apps/knowledge/views/knowledge.py:335
+#: apps/knowledge/views/knowledge.py:336
+msgid "Re-vectorize"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:346
+msgid "Read"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:391
+msgid "Read execute record"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:387
+msgid "Read Trigger"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:27
+msgid "Real-time speech recognition - Fun-ASR/Paraformer"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1427
+#: apps/tools/serializers/tool.py:1433
+msgid "record id"
+msgstr ""
+
+#: no source
+msgid "Redirect address cannot be empty"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:22
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:22
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:16
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:16
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:17
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:22
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:25
+#: apps/application/flow/step_node/question_node/i_question_node.py:22
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:16
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:17
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:16
+#: apps/application/flow/step_node/variable_assign_node/i_variable_assign_node.py:14
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:16
+msgid "Reference Field"
+msgstr ""
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:32
+msgid "Reference field cannot be empty"
+msgstr ""
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:34
+msgid "Reference field error"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:39
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:22
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:25
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:24
+#: apps/application/serializers/application.py:206
+#: apps/application/serializers/application_chat.py:218
+msgid "Reference segment number"
+msgstr ""
+
+#: apps/knowledge/views/document.py:363
+#: apps/knowledge/views/document.py:364
+#: apps/knowledge/views/document.py:365
+msgid "Refresh document vector library"
+msgstr ""
+
+#: no source
+msgid "Refresh shared document vector library"
+msgstr ""
+
+#: no source
+msgid "Refresh system knowledge vector library"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:213
+msgid "Regenerate"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:26
+msgid "Region Name"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:369
+msgid "Relate"
+msgstr ""
+
+#: apps/application/serializers/application.py:359
+#: apps/application/serializers/application.py:603
+msgid "Related Knowledge Base"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:377
+#: apps/knowledge/views/paragraph.py:378
+#: apps/knowledge/views/paragraph.py:379
+msgid "Related questions"
+msgstr ""
+
+#: no source
+msgid "Related shared questions"
+msgstr ""
+
+#: no source
+msgid "Related system questions"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:42
+msgid "relation show field dict"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:43
+msgid "relation trigger field dict"
+msgstr ""
+
+#: no source
+msgid "remark"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:366
+msgid "Remove Member"
+msgstr ""
+
+#: no source
+msgid "Remove member from chat user group"
+msgstr ""
+
+#: no source
+msgid "Remove member from system role"
+msgstr ""
+
+#: no source
+msgid "Remove member from system workspace"
+msgstr ""
+
+#: no source
+msgid "Remove member from user group"
+msgstr ""
+
+#: no source
+msgid "Remove member from workspace"
+msgstr ""
+
+#: no source
+msgid "Remove member from workspace role"
+msgstr ""
+
+#: apps/models_provider/views/model_apply.py:49
+#: apps/models_provider/views/model_apply.py:50
+#: apps/models_provider/views/model_apply.py:51
+msgid "Reorder documents"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:385
+msgid "Replace Original Document"
+msgstr ""
+
+#: apps/knowledge/views/document.py:977
+#: apps/knowledge/views/document.py:978
+msgid "Replace source file"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:40
+#: apps/tools/serializers/tool.py:248
+#: apps/tools/serializers/tool.py:274
+msgid "required"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:153
+msgid "Rerank"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:25
+msgid "Reset Token"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:20
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:16
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:16
+msgid "Resolution"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:446
+msgid "Resource"
+msgstr "Resource Management"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:26
+#: apps/system_manage/serializers/resource_mapping_serializers.py:107
+#: apps/system_manage/serializers/user_resource_permission.py:110
+#: apps/system_manage/serializers/user_resource_permission.py:322
+msgid "resource"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:329
+msgid "Resource Application"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:383
+msgid "resource authorization"
+msgstr ""
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:27
+#: apps/system_manage/serializers/resource_mapping_serializers.py:108
+msgid "resource Id"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:321
+msgid "resource id"
+msgstr ""
+
+#: no source
+msgid "Resource id"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:330
+msgid "Resource Knowledge"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:332
+msgid "Resource Model"
+msgstr ""
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:28
+#: apps/system_manage/serializers/resource_mapping_serializers.py:110
+msgid "resource Name"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:101
+msgid "resource name"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:333
+msgid "Resource Permission"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:331
+msgid "Resource Tool"
+msgstr ""
+
+#: apps/application/serializers/application.py:467
+#: apps/application/serializers/application.py:467
+msgid "Resource type"
+msgstr ""
+
+#: apps/system_manage/views/user_resource_permission.py:47
+#: apps/system_manage/views/user_resource_permission.py:66
+#: apps/system_manage/views/user_resource_permission.py:91
+#: apps/system_manage/views/user_resource_permission.py:115
+#: apps/system_manage/views/user_resource_permission.py:148
+#: apps/system_manage/views/user_resource_permission.py:181
+msgid "Resources authorization"
+msgstr ""
+
+#: apps/system_manage/views/resource_mapping.py:33
+msgid "Resources mapping"
+msgstr ""
+
+#: apps/common/result/api.py:17
+#: apps/common/result/api.py:17
+#: apps/common/result/api.py:27
+#: apps/common/result/api.py:27
+msgid "response code"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:152
+#: apps/homepage/api/home_page_api.py:182
+#: apps/homepage/api/home_page_api.py:209
+#: apps/homepage/api/home_page_api.py:242
+#: apps/homepage/api/home_page_api.py:305
+#: apps/homepage/api/home_page_api.py:342
+#: apps/homepage/api/home_page_api.py:379
+msgid "Response code"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:153
+#: apps/homepage/api/home_page_api.py:183
+#: apps/homepage/api/home_page_api.py:210
+#: apps/homepage/api/home_page_api.py:243
+#: apps/homepage/api/home_page_api.py:306
+#: apps/homepage/api/home_page_api.py:343
+#: apps/homepage/api/home_page_api.py:380
+msgid "Response message"
+msgstr ""
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:21
+msgid "Response Type"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:46
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:31
+#: apps/application/serializers/application.py:220
+msgid "Retrieval Mode"
+msgstr ""
+
+#: apps/trigger/views/trigger_task.py:53
+#: apps/trigger/views/trigger_task.py:54
+#: apps/trigger/views/trigger_task.py:55
+msgid "Retrieve detailed records of tasks executed by the trigger."
+msgstr ""
+
+#: apps/system_manage/views/resource_mapping.py:29
+#: apps/system_manage/views/resource_mapping.py:30
+#: apps/system_manage/views/resource_mapping.py:63
+#: apps/system_manage/views/resource_mapping.py:64
+msgid "Retrieve the pagination list of resource relationships"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:40
+msgid "retro anime"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:49
+#: apps/chat/serializers/chat.py:207
+#: apps/common/constants/permission_constants.py:327
+#: apps/common/constants/permission_constants.py:433
+msgid "Role"
+msgstr ""
+
+#: no source
+msgid "Role does not exist"
+msgstr ""
+
+#: apps/users/api/user.py:26
+msgid "Role ID"
+msgstr ""
+
+#: no source
+msgid "Role IDs"
+msgstr ""
+
+#: no source
+msgid "Role IDs cannot be empty"
+msgstr ""
+
+#: no source
+msgid "Role name"
+msgstr ""
+
+#: no source
+msgid "Role Name"
+msgstr ""
+
+#: no source
+msgid "Role name already exists"
+msgstr ""
+
+#: apps/application/serializers/application.py:256
+msgid "Role prompts"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:24
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:19
+#: apps/application/flow/step_node/question_node/i_question_node.py:24
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:18
+#: apps/users/api/user.py:35
+#: apps/users/api/user.py:102
+msgid "Role Setting"
+msgstr ""
+
+#: no source
+msgid "Role Setting cannot be empty"
+msgstr ""
+
+#: no source
+msgid "Role type"
+msgstr ""
+
+#: no source
+msgid "Root Directory"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:86
+msgid "Runtime node id"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:64
+msgid "Same performance, faster and more agile. 204K context window"
+msgstr ""
+
+#: no source
+msgid "SAML2 Log in"
+msgstr ""
+
+#: no source
+msgid "SAML2 Metadata"
+msgstr ""
+
+#: no source
+msgid "SAML2 SSO"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:15
+msgid "Sample Rate"
+msgstr ""
+
+#: apps/models_provider/views/model.py:201
+#: apps/models_provider/views/model.py:202
+#: apps/models_provider/views/model.py:203
+msgid "Save model parameter form"
+msgstr ""
+
+#: no source
+msgid "Scan code login type"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:171
+msgid "schedule_type must be one of %s"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:33
+msgid "science fiction style"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:887
+#: apps/knowledge/serializers/knowledge.py:1137
+#: apps/knowledge/serializers/knowledge_workflow.py:320
+#: apps/tools/serializers/tool.py:345
+#: apps/tools/serializers/tool.py:1690
+msgid "scope"
+msgstr ""
+
+#: no source
+msgid "Scope cannot be empty"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:37
+msgid "search condition list"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:34
+msgid "search condition type"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:17
+#: apps/knowledge/serializers/knowledge.py:162
+#: apps/knowledge/serializers/knowledge.py:1367
+msgid "search mode"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:20
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:47
+msgid "search scope type"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:28
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:55
+msgid "search scope variable"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:25
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:52
+msgid "search scope variable type"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1700
+#: apps/knowledge/serializers/tag.py:203
+msgid "search value"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:25
+msgid "Secret Access Key"
+msgstr ""
+
+#: no source
+msgid "Secret is required"
+msgstr ""
+
+#: apps/common/auth/handle/impl/application_key.py:27
+msgid "Secret key is expired"
+msgstr ""
+
+#: apps/chat/views/chat.py:84
+#: apps/common/auth/handle/impl/application_key.py:23
+#: apps/common/auth/handle/impl/application_key.py:25
+msgid "Secret key is invalid"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:935
+#: apps/knowledge/serializers/knowledge.py:767
+msgid "Section content (required, question answer, no more than 4096 characters)"
+msgstr ""
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:40
+#: apps/knowledge/serializers/paragraph.py:73
+#: apps/knowledge/serializers/paragraph.py:81
+#: apps/knowledge/serializers/paragraph.py:84
+#: apps/knowledge/serializers/paragraph.py:102
+#: apps/knowledge/serializers/paragraph.py:104
+#: apps/knowledge/serializers/paragraph.py:439
+msgid "section title"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:240
+msgid "Section title"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:934
+#: apps/knowledge/serializers/knowledge.py:766
+msgid "Section title (optional)"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:219
+msgid "Section title + content"
+msgstr ""
+
+#: apps/application/serializers/application.py:223
+msgid "Segment settings not referenced"
+msgstr ""
+
+#: apps/knowledge/views/document.py:224
+#: apps/knowledge/views/document.py:225
+#: apps/knowledge/views/document.py:226
+msgid "Segmented document"
+msgstr ""
+
+#: no source
+msgid "Segmented shared document"
+msgstr ""
+
+#: no source
+msgid "Segmented system document"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:37
+#: apps/knowledge/serializers/document.py:211
+msgid "selector"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1306
+msgid "semicolon"
+msgstr ""
+
+#: apps/users/views/user.py:321
+#: apps/users/views/user.py:322
+#: apps/users/views/user.py:323
+msgid "Send email"
+msgstr ""
+
+#: apps/users/views/user.py:356
+#: apps/users/views/user.py:357
+#: apps/users/views/user.py:358
+msgid "Send email to current user"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:33
+#: apps/system_manage/serializers/email_setting.py:37
+msgid "Sender's email"
+msgstr ""
+
+#: no source
+msgid "serial number"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:1346
+#: apps/common/constants/permission_constants.py:1399
+msgid "Set up user groups"
+msgstr ""
+
+#: no source
+msgid "Setting"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:129
+msgid "Share link does not exist"
+msgstr ""
+
+#: no source
+msgid "Shared generate related"
+msgstr ""
+
+#: no source
+msgid "Shared Hit test list"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:334
+msgid "Shared Knowledge"
+msgstr ""
+
+#: no source
+msgid "Shared Knowledge/Document"
+msgstr ""
+
+#: no source
+msgid "Shared Knowledge/Documentation"
+msgstr ""
+
+#: no source
+msgid "Shared Knowledge/Documentation/Paragraph"
+msgstr ""
+
+#: no source
+msgid "Shared Knowledge/Documentation/Paragraph/Question"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:335
+#: apps/models_provider/views/model.py:278
+msgid "Shared Model"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:142
+msgid "Shared models cannot be deleted or modified"
+msgstr ""
+
+#: no source
+msgid "Shared paragraph list"
+msgstr ""
+
+#: no source
+msgid "Shared question list"
+msgstr ""
+
+#: no source
+msgid "Shared Re-vectorize"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:336
+msgid "Shared Tool"
+msgstr ""
+
+#: no source
+msgid "Shared tool is not supported"
+msgstr ""
+
+#: no source
+msgid "show avatar"
+msgstr ""
+
+#: no source
+msgid "show exec"
+msgstr ""
+
+#: no source
+msgid "show forum"
+msgstr ""
+
+#: no source
+msgid "show guide"
+msgstr ""
+
+#: no source
+msgid "show history"
+msgstr ""
+
+#: no source
+msgid "show project"
+msgstr ""
+
+#: no source
+msgid "show source"
+msgstr ""
+
+#: no source
+msgid "show user avatar"
+msgstr ""
+
+#: no source
+msgid "show user manual"
+msgstr ""
+
+#: apps/users/views/login.py:55
+#: apps/users/views/login.py:56
+#: apps/users/views/login.py:57
+msgid "Sign out"
+msgstr ""
+
+#: no source
+msgid "Signature missing"
+msgstr ""
+
+#: no source
+msgid "Signing Secret is required"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:42
+msgid "Similarity"
+msgstr ""
+
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:27
+#: apps/knowledge/serializers/knowledge.py:159
+#: apps/knowledge/serializers/knowledge.py:1364
+msgid "similarity"
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:68
+msgid "Since the Chinese alignment of Llama2 itself is weak, we use the Chinese instruction set to fine-tune meta-llama/Llama-2-13b-chat-hf with LoRA so that it has strong Chinese conversation capabilities."
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:56
+msgid "sketch"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1562
+msgid "Skill file does not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:49
+msgid "Skill IDs"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:296
+msgid "Slack"
+msgstr "Slack App"
+
+#: no source
+msgid "Slack application: {user}"
+msgstr ""
+
+#: no source
+msgid "slogan"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:31
+msgid "SMTP host"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:32
+msgid "SMTP port"
+msgstr ""
+
+#: no source
+msgid "Some roles do not exist"
+msgstr ""
+
+#: no source
+msgid "Some user groups do not exist"
+msgstr ""
+
+#: no source
+msgid "Some users do not exist"
+msgstr ""
+
+#: apps/application/models/application_chat.py:120
+msgid "Sorry, no relevant content was found. Please re-describe your problem or provide more information. "
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:498
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:661
+msgid "Sorry, the AI model is not configured. Please go to the application to set up the AI model first."
+msgstr "Sorry, the agent's AI model is not configured. Please go to the agent settings to set up the AI model first."
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:30
+#: apps/application/serializers/application_chat.py:221
+#: apps/folders/serializers/folder.py:136
+#: apps/folders/serializers/folder.py:178
+#: apps/folders/serializers/folder.py:307
+#: apps/tools/serializers/tool.py:262
+#: apps/trigger/serializers/trigger.py:47
+msgid "source"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:222
+#: apps/chat/serializers/chat.py:293
+#: apps/chat/serializers/chat.py:538
+#: apps/users/serializers/user.py:70
+#: apps/users/serializers/user.py:211
+#: apps/users/serializers/user.py:257
+msgid "Source"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:141
+msgid "source file id"
+msgstr ""
+
+#: apps/oss/serializers/file.py:72
+#: apps/trigger/serializers/task_source_trigger.py:63
+#: apps/trigger/serializers/task_source_trigger.py:184
+msgid "source id"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1428
+msgid "source name"
+msgstr ""
+
+#: apps/oss/serializers/file.py:75
+#: apps/tools/serializers/tool.py:1429
+#: apps/trigger/serializers/task_source_trigger.py:62
+#: apps/trigger/serializers/task_source_trigger.py:183
+msgid "source type"
+msgstr ""
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:30
+#: apps/system_manage/serializers/resource_mapping_serializers.py:31
+msgid "source Type"
+msgstr ""
+
+#: apps/trigger/serializers/trigger_task.py:130
+msgid "Source type"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:36
+#: apps/knowledge/serializers/knowledge.py:124
+msgid "source url"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:254
+#: apps/trigger/serializers/trigger.py:276
+msgid "source_id"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1305
+msgid "space"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:33
+msgid "Spanish"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:18
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:14
+msgid "Speaker"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:18
+msgid "Speaker selection for super-humanoid TTS service"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:15
+msgid "Speaker, optional value: Please go to the console to add a trial or purchase speaker. After adding, the speaker parameter value will be displayed."
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:37
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:68
+msgid "Speaking speed"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:77
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:43
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:27
+msgid "speaking speed"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:31
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:25
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:24
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:27
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:43
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:27
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:25
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:25
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:22
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:27
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:28
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:27
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:32
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:25
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:24
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:25
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:25
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:25
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:25
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:31
+msgid "Specify the maximum number of tokens that the model can generate"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:30
+msgid "Specify the maximum number of tokens that the model can generate."
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:35
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:39
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:20
+msgid "Specify the number of generated images"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:14
+msgid "Specify the size of the generated image, such as: 1024x1024"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:22
+msgid "Specify the size of the generated Video, such as: 1024x1024"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:45
+msgid "Specify the style of generated images"
+msgstr ""
+
+#: apps/application/serializers/application.py:394
+#: apps/application/serializers/application.py:625
+msgid "Speech recognition model ID"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:77
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:43
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:27
+msgid "Speech speed, optional value: [0-100], default is 50"
+msgstr ""
+
+#: apps/application/views/application.py:435
+#: apps/application/views/application.py:436
+#: apps/application/views/application.py:437
+#: apps/application/views/application.py:461
+#: apps/application/views/application.py:462
+#: apps/application/views/application.py:463
+#: apps/chat/views/chat.py:220
+#: apps/chat/views/chat.py:221
+#: apps/chat/views/chat.py:222
+#: apps/knowledge/views/knowledge_workflow.py:458
+#: apps/knowledge/views/knowledge_workflow.py:459
+#: apps/knowledge/views/knowledge_workflow.py:460
+msgid "speech to text"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:149
+msgid "Speech2Text"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:15
+msgid "split strategy"
+msgstr ""
+
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:17
+#: apps/application/flow/step_node/variable_splitting_node/i_variable_splitting_node.py:17
+msgid "Split variables"
+msgstr ""
+
+#: apps/common/job/clean_chat_job.py:23
+msgid "start clean chat log"
+msgstr ""
+
+#: apps/common/job/clean_debug_file_job.py:20
+msgid "start clean debug file"
+msgstr ""
+
+#: apps/common/job/client_access_num_job.py:25
+msgid "start reset access_num"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:56
+#: apps/application/serializers/application_stats.py:40
+#: apps/homepage/serializers/homepage.py:91
+#: apps/homepage/serializers/homepage.py:152
+#: apps/homepage/serializers/homepage.py:217
+#: apps/homepage/serializers/homepage.py:390
+#: apps/homepage/serializers/homepage.py:517
+#: apps/homepage/serializers/homepage.py:657
+msgid "Start time"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:377
+msgid "Start--->Embedding document: {document_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:426
+msgid "Start--->Embedding document: {document_list}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:422
+msgid "Start--->Embedding knowledge: {knowledge_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:122
+msgid "Start--->Embedding paragraph: {paragraph_id_list}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:157
+msgid "Start--->Embedding paragraph: {paragraph_id}"
+msgstr ""
+
+#: apps/knowledge/task/sync.py:26
+#: apps/knowledge/task/sync.py:49
+msgid "Start--->Start synchronization web knowledge base:{knowledge_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:535
+msgid "Start--->Tokenize document: {document_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:217
+msgid "Start--->Tokenize paragraph: {paragraph_id}"
+msgstr ""
+
+#: apps/knowledge/task/embedding.py:115
+msgid "Start--->Vectorized knowledge: {knowledge_id}"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge_workflow.py:98
+#: apps/tools/serializers/tool_workflow.py:129
+msgid "State"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1430
+msgid "state"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:80
+#: apps/knowledge/serializers/document.py:227
+#: apps/knowledge/serializers/document.py:232
+#: apps/knowledge/serializers/document.py:239
+msgid "state list"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:482
+msgid "status"
+msgstr ""
+
+#: no source
+msgid "Stop"
+msgstr ""
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:26
+msgid "Strategy"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:70
+#: apps/chat/serializers/chat.py:214
+msgid "Streaming Output"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:45
+msgid "Style"
+msgstr ""
+
+#: apps/common/result/result.py:31
+msgid "Success"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:36
+#: apps/application/serializers/application_chat.py:54
+#: apps/application/serializers/application_chat.py:214
+#: apps/application/serializers/application_version.py:23
+#: apps/knowledge/serializers/knowledge_version.py:46
+#: apps/tools/serializers/tool_version.py:36
+msgid "summary"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:26
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:56
+msgid "Super Humanoid TTS"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:32
+msgid "Super-humanoid: Grant (EN)"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:36
+msgid "Super-humanoid: Huifangnv Pro"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:33
+msgid "Super-humanoid: Lila (EN)"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:38
+msgid "Super-humanoid: Lingfeibo Pro"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:25
+msgid "Super-humanoid: Lingfeiyi Flow"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:34
+msgid "Super-humanoid: Lingwanwan Pro"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:30
+msgid "Super-humanoid: Lingxiaorong Flow"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:29
+msgid "Super-humanoid: Lingxiaotang Flow"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:23
+msgid "Super-humanoid: Lingxiaoxuan Flow"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:37
+msgid "Super-humanoid: Lingxiaoying Pro"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:26
+msgid "Super-humanoid: Lingxiaoyue Flow"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:24
+msgid "Super-humanoid: Lingyuyan Flow"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:39
+msgid "Super-humanoid: Lingyuyan Pro"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:28
+msgid "Super-humanoid: Lingyuzhao Flow"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:27
+msgid "Super-humanoid: Sun Dasheng Flow"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:31
+msgid "Super-humanoid: Xinyun Flow"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:35
+msgid "Super-humanoid: Yiyi Pro"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:1301
+#: apps/users/views/user.py:96
+#: apps/users/views/user.py:97
+#: apps/users/views/user.py:98
+msgid "Switch Language"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:363
+msgid "Sync"
+msgstr ""
+
+#: no source
+msgid "Sync chat users"
+msgstr ""
+
+#: no source
+msgid "Sync chat users from external source"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1260
+msgid "sync type"
+msgstr ""
+
+#: no source
+msgid "Sync Type"
+msgstr ""
+
+#: no source
+msgid "Sync Type: LOCAL or LDAP"
+msgstr ""
+
+#: no source
+msgid "Sync users"
+msgstr ""
+
+#: no source
+msgid "Synchronization is only supported for lark documents"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:603
+#: apps/knowledge/serializers/knowledge.py:1282
+msgid "Synchronization is only supported for web site types"
+msgstr ""
+
+#: no source
+msgid "Synchronize lark document"
+msgstr ""
+
+#: no source
+msgid "Synchronize shared web site types"
+msgstr ""
+
+#: no source
+msgid "Synchronize system web site types"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:249
+#: apps/knowledge/views/knowledge.py:250
+#: apps/knowledge/views/knowledge.py:251
+msgid "Synchronize the knowledge base of the website"
+msgstr ""
+
+#: no source
+msgid "Synchronize the shared knowledge base of the website"
+msgstr ""
+
+#: no source
+msgid "Synchronize the system knowledge base of the website"
+msgstr ""
+
+#: apps/knowledge/task/sync.py:37
+#: apps/knowledge/task/sync.py:59
+msgid "Synchronize web knowledge base:{knowledge_id} error{error}{traceback}"
+msgstr ""
+
+#: apps/knowledge/views/document.py:325
+#: apps/knowledge/views/document.py:326
+#: apps/knowledge/views/document.py:327
+msgid "Synchronize web site types"
+msgstr ""
+
+#: no source
+msgid "System"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:403
+#: apps/common/constants/permission_constants.py:1312
+msgid "System API Key"
+msgstr ""
+
+#: no source
+msgid "system API key id"
+msgstr ""
+
+#: no source
+msgid "System Application"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:27
+msgid "System completes question text"
+msgstr ""
+
+#: no source
+msgid "System generate related"
+msgstr ""
+
+#: no source
+msgid "System Hit test list"
+msgstr ""
+
+#: no source
+msgid "System Knowledge"
+msgstr ""
+
+#: no source
+msgid "System Knowledge/Documentation"
+msgstr ""
+
+#: no source
+msgid "System Knowledge/Documentation/Paragraph"
+msgstr ""
+
+#: no source
+msgid "System Knowledge/Documentation/Paragraph/Question"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:339
+msgid "System Management"
+msgstr ""
+
+#: no source
+msgid "System Model"
+msgstr ""
+
+#: no source
+msgid "System operate log"
+msgstr ""
+
+#: no source
+msgid "System paragraph list"
+msgstr ""
+
+#: apps/system_manage/views/system_profile.py:25
+msgid "System parameters"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:41
+msgid "System prompt words (role)"
+msgstr ""
+
+#: no source
+msgid "System question list"
+msgstr ""
+
+#: no source
+msgid "System Re-vectorize"
+msgstr ""
+
+#: no source
+msgid "System resources authorization"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:325
+msgid "System Setting"
+msgstr ""
+
+#: no source
+msgid "System Tool"
+msgstr ""
+
+#: no source
+msgid "System tools cannot be deleted"
+msgstr ""
+
+#: no source
+msgid "System Trigger"
+msgstr ""
+
+#: no source
+msgid "System/Chat user"
+msgstr ""
+
+#: no source
+msgid "System/User Group"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:358
+#: apps/common/constants/permission_constants.py:416
+#: apps/common/constants/permission_constants.py:426
+msgid "Tag"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:484
+msgid "tag"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1776
+#: apps/knowledge/serializers/document.py:1817
+#: apps/knowledge/serializers/document.py:1844
+msgid "tag id"
+msgstr ""
+
+#: apps/knowledge/serializers/tag.py:95
+msgid "Tag ID"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1859
+#: apps/knowledge/serializers/tag.py:111
+#: apps/knowledge/serializers/tag.py:155
+msgid "Tag id does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1776
+#: apps/knowledge/serializers/document.py:1817
+msgid "tag ids"
+msgstr ""
+
+#: apps/knowledge/serializers/tag.py:169
+msgid "Tag IDs"
+msgstr ""
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:48
+#: apps/knowledge/serializers/tag.py:35
+#: apps/knowledge/serializers/tag.py:40
+msgid "Tag Key"
+msgstr ""
+
+#: apps/knowledge/serializers/tag.py:125
+msgid "Tag key already exists"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:384
+msgid "Tag Setting"
+msgstr ""
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:49
+#: apps/knowledge/serializers/tag.py:36
+#: apps/knowledge/serializers/tag.py:41
+msgid "Tag Value"
+msgstr ""
+
+#: apps/knowledge/serializers/tag.py:143
+msgid "Tag value already exists"
+msgstr ""
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:56
+#: apps/knowledge/serializers/knowledge.py:769
+#: apps/knowledge/serializers/tag.py:48
+msgid "Tags"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:605
+msgid "target document id"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:61
+msgid "target id"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:356
+#: apps/knowledge/serializers/paragraph.py:604
+msgid "target knowledge id"
+msgstr ""
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:112
+#: apps/system_manage/serializers/resource_mapping_serializers.py:113
+msgid "target Type"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:171
+msgid "Task not found"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:125
+#: apps/knowledge/serializers/document.py:145
+#: apps/knowledge/serializers/document.py:481
+msgid "task type"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:133
+#: apps/knowledge/serializers/document.py:153
+msgid "task type not support"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:21
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:16
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:15
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:14
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:13
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:17
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:17
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:15
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:15
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:12
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:20
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:17
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:18
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:17
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:22
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:13
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:15
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:14
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:40
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:15
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:15
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:15
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:21
+msgid "Temperature"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_cloud_model_provider/tencent_cloud_model_provider.py:58
+msgid "Tencent Cloud"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:133
+msgid "Tencent Hunyuan"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:85
+msgid "Tencent's Hunyuan Embedding interface can convert text into high-quality vector data. The vector dimension is 1024 dimensions."
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:356
+#: apps/common/constants/permission_constants.py:414
+#: apps/common/constants/permission_constants.py:424
 msgid "Termbase"
 msgstr ""
 
-msgid "Copy"
-msgstr "Copy"
+#: apps/knowledge/serializers/termbase.py:21
+#: apps/knowledge/serializers/termbase.py:67
+msgid "termbase id"
+msgstr ""
 
-msgid "ranking"
-msgstr "ranking"
+#: apps/knowledge/serializers/termbase.py:28
+msgid "termbase list"
+msgstr ""
 
+#: apps/knowledge/views/termbase.py:28
+#: apps/knowledge/views/termbase.py:29
+#: apps/knowledge/views/termbase.py:30
+msgid "Termbase list"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:48
+msgid "Test"
+msgstr ""
+
+#: apps/system_manage/views/email_setting.py:66
+#: apps/system_manage/views/email_setting.py:67
+msgid "Test email settings"
+msgstr ""
+
+#: no source
+msgid "Test LDAP connection"
+msgstr ""
+
+#: no source
+msgid "Test platform connection"
+msgstr ""
+
+#: apps/tools/views/tool.py:457
+#: apps/tools/views/tool.py:458
+#: apps/tools/views/tool.py:459
+msgid "Test tool connection"
+msgstr ""
+
+#: apps/application/serializers/application.py:972
+msgid "Text"
+msgstr ""
+
+#: apps/local_model/serializers/model_apply_serializers.py:104
+#: apps/models_provider/serializers/model_apply_serializers.py:41
+msgid "text"
+msgstr ""
+
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:23
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:21
+msgid "Text content"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:36
+msgid "text field"
+msgstr ""
+
+#: apps/application/views/application.py:487
+#: apps/application/views/application.py:488
+#: apps/application/views/application.py:489
+#: apps/chat/views/chat.py:239
+#: apps/chat/views/chat.py:240
+#: apps/chat/views/chat.py:241
+msgid "text to speech"
+msgstr ""
+
+#: apps/application/serializers/application.py:980
+msgid "Text to speech model ID"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:155
+msgid "Text to Video"
+msgstr ""
+
+#: apps/common/utils/common.py:156
+msgid "Text-to-speech node, the text content cannot be empty"
+msgstr ""
+
+#: apps/common/utils/common.py:154
+msgid "Text-to-speech node, the text content must be of string type"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:29
+msgid "Thai"
+msgstr ""
+
+#: no source
+msgid "The app does not enable the speech-to-text function or the speech-to-text function fails."
+msgstr ""
+
+#: apps/application/serializers/common.py:148
+msgid "The application does not exist"
+msgstr ""
+
+#: apps/application/serializers/common.py:153
+#: apps/chat/serializers/chat.py:491
+#: apps/chat/serializers/chat.py:560
+msgid "The application has not been published. Please use it after publishing."
+msgstr "The agent has not been published. Please use it after publishing."
+
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:21
+msgid "The audio file cannot be empty"
+msgstr ""
+
+#: apps/application/flow/common.py:224
+msgid "The branch {branch} of the {node} node needs to be connected"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:450
+#: apps/chat/serializers/chat.py:454
+msgid "The chat user is not authorized."
+msgstr ""
+
+#: no source
+msgid "The Chinese enhanced version developed by the Qianfan team based on Llama-2-7b has performed well on Chinese knowledge bases such as CMMLU and C-EVAL."
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:55
+msgid "The Claude 3 Haiku is Anthropic's fastest and most compact model, with near-instant responsiveness. The model can answer simple queries and requests quickly. Customers will be able to build seamless AI experiences that mimic human interactions. Claude 3 Haiku can process images and return text output, and provides 200K context windows."
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:62
+msgid "The Claude 3 Sonnet model from Anthropic strikes the ideal balance between intelligence and speed, especially when it comes to handling enterprise workloads. This model offers maximum utility while being priced lower than competing products, and it's been engineered to be a solid choice for deploying AI at scale."
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:69
+msgid "The Claude 3.5 Sonnet raises the industry standard for intelligence, outperforming competing models and the Claude 3 Opus in extensive evaluations, with the speed and cost-effectiveness of our mid-range models."
+msgstr ""
+
+#: apps/system_manage/serializers/valid_serializers.py:31
+msgid "The community version supports up to 2 users. If you need more users, please contact us (https://fit2cloud.com/)."
+msgstr ""
+
+#: apps/system_manage/serializers/valid_serializers.py:28
+msgid "The community version supports up to 5 applications. If you need more applications, please contact us (https://fit2cloud.com/)."
+msgstr ""
+
+#: apps/system_manage/serializers/valid_serializers.py:25
+msgid "The community version supports up to 50 knowledge bases. If you need more knowledge bases, please contact us (https://fit2cloud.com/)."
+msgstr ""
+
+#: apps/users/serializers/user.py:447
+#: apps/users/serializers/user.py:995
+#: apps/users/serializers/user.py:1053
+msgid "The confirmation password must be 6-20 characters long and must be a combination of letters, numbers, and special characters."
+msgstr ""
+
+#: no source
+msgid "The corresponding platform configuration for Slack was not found"
+msgstr ""
+
+#: no source
+msgid "The corresponding platform configuration was not found"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:332
+msgid "The current model is not available"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:92
+msgid "The current platform does not support downloading models"
+msgstr ""
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:25
+msgid "The default is body, you can enter .classname/#idname/tagname"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:630
+msgid "The document id does not exist [{document_id}]"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:264
+#: apps/application/serializers/application_chat_record.py:400
+#: apps/knowledge/serializers/paragraph.py:349
+msgid "The document id is incorrect"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:626
+msgid "The document to be migrated is consistent with the target document"
+msgstr ""
+
+#: apps/common/event/__init__.py:34
+msgid "The download process was interrupted, please try again"
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:35
+msgid "The email has been registered, please log in directly"
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:36
+msgid "The email is not registered, please register first"
+msgstr ""
+
+#: apps/users/serializers/user.py:1134
+msgid "The email service has not been set up. Please contact the administrator to set up the email service in [Email Settings]."
+msgstr ""
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:32
+#: apps/tools/serializers/tool.py:265
+#: apps/trigger/serializers/trigger.py:49
+msgid "The field only supports custom|reference"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:28
+msgid "The field only supports string|int|dict|array|float"
+msgstr ""
+
+#: apps/common/forms/base_field.py:64
+msgid "The field {field_label} is required"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:27
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:47
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:46
+msgid "The following fields are required: {keys}"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:43
+msgid "The following id does not exist: %s"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:62
+msgid "The following id does not exist: {error_id_list}"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:39
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:42
+msgid "The function has been deleted"
+msgstr ""
+
+#: apps/application/flow/common.py:276
+msgid "The function library for node {node} is not available"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1507
+msgid "The hit processing method must be directly_return|optimization"
+msgstr ""
+
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:15
+msgid "The image generation endpoint allows you to create raw images based on text prompts. "
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:15
+msgid "The image generation endpoint allows you to create raw images based on text prompts. The dimensions of the image can be 1024x1024, 1024x1792, or 1792x1024 pixels."
+msgstr ""
+
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:15
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:15
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:15
+msgid "The image generation endpoint allows you to create raw images based on text prompts. When using the DALL·E 3, the image size can be 1024x1024, 1024x1792 or 1792x1024 pixels."
+msgstr ""
+
+#: apps/application/serializers/application.py:248
+msgid "The knowledge base id does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:123
+#: apps/knowledge/serializers/common.py:159
+msgid "The knowledge base is inconsistent with the vector model"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:42
+msgid "The knowledge base setting is wrong, please reset the knowledge base"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge_workflow.py:214
+msgid "The knowledge base workflow has not been published"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:530
+msgid "The label field is required for the {index}th item in model_params_form"
+msgstr ""
+
+#: apps/models_provider/impl/docker_ai_model_provider/docker_ai_model_provider.py:73
+msgid "The latest gpt-3.5-turbo, updated with DockerAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:35
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:116
+#: apps/models_provider/impl/regolo_model_provider/regolo_model_provider.py:67
+#: apps/models_provider/impl/siliconCloud_model_provider/siliconCloud_model_provider.py:127
+msgid "The latest gpt-3.5-turbo, updated with OpenAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:46
+msgid "The latest gpt-4-turbo, updated with OpenAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:49
+msgid "The latest gpt-4-turbo-preview, updated with OpenAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/docker_ai_model_provider/docker_ai_model_provider.py:49
+msgid "The latest GPT-4o, cheaper and faster than gpt-4-turbo, updated with DockerAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:40
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:99
+msgid "The latest GPT-4o, cheaper and faster than gpt-4-turbo, updated with OpenAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/docker_ai_model_provider/docker_ai_model_provider.py:53
+msgid "The latest gpt-4o-mini, cheaper and faster than gpt-4o, updated with DockerAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:43
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:102
+msgid "The latest gpt-4o-mini, cheaper and faster than gpt-4o, updated with OpenAI adjustments"
+msgstr ""
+
+#: apps/application/flow/common.py:273
+msgid "The library ID of node {node} cannot be empty"
+msgstr ""
+
+#: no source
+msgid "The license is invalid"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1223
+msgid "The maximum size of the uploaded file cannot exceed {}MB"
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:48
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:53
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:50
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:47
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:48
+msgid "The model does not exist, please download the model first"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:230
+msgid "The model does not support"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:334
+msgid "The model is downloading, please try again later"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:40
+msgid "The most effective version of the current hybrid model, the trillion-level parameter scale MOE-32K long article model. Reaching the absolute leading level on various benchmarks, with complex instructions and reasoning, complex mathematical capabilities, support for function call, and application focus optimization in fields such as multi-language translation, finance, law, and medical care"
+msgstr "The most effective version of the current hybrid model, the trillion-level parameter scale MOE-32K long article model. Reaching the absolute leading level on various benchmarks, with complex instructions and reasoning, complex mathematical capabilities, support for function call, and agent focus optimization in fields such as multi-language translation, finance, law, and medical care"
+
+#: no source
+msgid "The network is busy, try again later."
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:44
+msgid "The nickname is already registered"
+msgstr ""
+
+#: apps/application/flow/common.py:257
+msgid "The node {node} model does not exist"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:321
+msgid "The number of visits exceeds today's visits"
+msgstr ""
+
+#: apps/application/serializers/application_chat_record.py:517
+msgid "The paragraph id is wrong. The current conversation record does not exist. [{paragraph_id}] paragraph id"
+msgstr ""
+
+#: no source
+msgid "The password is incorrect"
+msgstr ""
+
+#: apps/users/serializers/user.py:191
+#: apps/users/serializers/user.py:435
+#: apps/users/serializers/user.py:983
+#: apps/users/serializers/user.py:1041
+msgid "The password must be 6-20 characters long and must be a combination of letters, numbers, and special characters."
+msgstr ""
+
+#: no source
+msgid "The platform configuration corresponding to {type} was not found"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:167
+msgid "The Qwen Audio based end-to-end speech recognition model supports audio recognition within 3 minutes. At present, it mainly supports Chinese and English recognition."
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:149
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:158
+msgid "The Qwen Omni series model supports inputting multiple modalities of data, including video, audio, images, and text, and outputting audio and text."
+msgstr ""
+
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:39
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:45
+msgid "The results are displayed in the knowledge sources"
+msgstr ""
+
+#: apps/application/flow/common.py:244
+msgid "The starting node is required"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/impl/base_application_node.py:194
+msgid "The sub application cannot use the current node"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1264
+msgid "The synchronization type only supports:replace|complete"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:640
+msgid "The target document id does not exist [{document_id}]"
+msgstr ""
+
+#: apps/knowledge/serializers/paragraph.py:598
+msgid "The task is being executed, please do not send it again."
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:882
+#: apps/knowledge/serializers/document.py:920
+msgid "The task is being executed, please do not send it repeatedly."
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:265
+msgid "The template type only supports excel|csv"
+msgstr ""
+
+#: apps/application/serializers/application.py:269
+msgid "The thinking process begins to mark"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:191
+msgid "The tool has not been published. Please use it after publishing."
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:45
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:30
+#: apps/application/serializers/application.py:216
+#: apps/knowledge/serializers/knowledge.py:166
+#: apps/knowledge/serializers/knowledge.py:1371
+msgid "The type only supports embedding|keywords|blend"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:166
+#: apps/knowledge/serializers/document.py:256
+msgid "The type only supports optimization|directly_return"
+msgstr ""
+
+#: apps/users/serializers/user.py:1091
+#: apps/users/serializers/user.py:1173
+msgid "The type only supports register|reset_password"
+msgstr ""
+
+#: no source
+msgid "The user does not have permission to access the application"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:46
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:51
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:80
+msgid "The user goes to the model inference page of Volcano Ark to create an inference access point. Here, you need to enter ep-xxxxxxxxxx-yyyy to call it."
+msgstr ""
+
+#: apps/users/serializers/login.py:158
+msgid "The user has been disabled, please contact the administrator!"
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:41
+msgid "The username cannot be empty and must be between 6 and 20 characters long."
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:39
+msgid "The username has been registered, please log in directly"
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:31
+#: apps/users/serializers/login.py:150
+msgid "The username or password is incorrect"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:40
+msgid "The vector model of the associated knowledge base is inconsistent and the segmentation cannot be recalled."
+msgstr ""
+
+#: apps/common/constants/exception_code_constants.py:38
+msgid "The verification code is incorrect or the verification code has expired"
+msgstr ""
+
+#: apps/common/forms/slider_field.py:62
+msgid "The {field_label} cannot be greater than {max}"
+msgstr ""
+
+#: apps/common/forms/slider_field.py:56
+msgid "The {field_label} cannot be less than {min}"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:523
+msgid "The {index}th item in model_params_form must be a dictionary"
+msgstr ""
+
+#: no source
+msgid "theme"
+msgstr ""
+
+#: no source
+msgid "theme color"
+msgstr ""
+
+#: apps/application/flow/common.py:284
+msgid "There can only be one basic information node"
+msgstr ""
+
+#: apps/application/flow/common.py:246
+msgid "There can only be one starting node"
+msgstr ""
+
+#: apps/tools/serializers/tool_workflow.py:287
+msgid "There is a circular dependency in the tool workflow"
+msgstr ""
+
+#: no source
+msgid "Think: "
+msgstr ""
+
+#: no source
+msgid "Thinking about 【{question}】...If you want me to continue answering, please reply {trigger_message}"
+msgstr ""
+
+#: apps/application/serializers/application.py:261
+msgid "Thinking process switch"
+msgstr ""
+
+#: no source
+msgid "Thinking, please wait a moment!"
+msgstr ""
+
+#: no source
+msgid "Thinking..."
+msgstr ""
+
+#: apps/users/serializers/login.py:138
+#: apps/users/serializers/login.py:259
+msgid "This account has been locked for %s minutes, please try again later"
+msgstr ""
+
+#: apps/common/handle/impl/text/pdf_split_handle.py:381
+msgid "This document has no preface and is treated as ordinary text: {e}"
+msgstr ""
+
+#: apps/folders/serializers/folder.py:276
+msgid "This folder contains resources that you dont have permission"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:77
+msgid "This interface is used to recognize short audio files within 60 seconds. Supports Mandarin Chinese, English, Cantonese, Japanese, Vietnamese, Malay, Indonesian, Filipino, Thai, Portuguese, Turkish, Arabic, Hindi, French, German, and 23 Chinese dialects."
+msgstr ""
+
+#: no source
+msgid "This type of message is not supported yet"
+msgstr ""
+
+#: no source
+msgid "This workspace contains %s, cannot be deleted."
+msgstr ""
+
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:74
+msgid "Thousand sails large model"
+msgstr ""
+
+#: no source
+msgid "Three-party login"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:21
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:54
+msgid "Timbre"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:14
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:15
+msgid "timbre"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:222
+msgid "Time consumed (s)"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:128
+msgid "Titan Embed Text is the largest embedding model in the Amazon Titan Embed series and can handle various text embedding tasks, such as text classification, text similarity calculation, etc."
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:83
+msgid "Titan Text Premier is the most powerful and advanced model in the Titan Text series, designed to deliver exceptional performance for a variety of enterprise applications. With its cutting-edge features, it delivers greater accuracy and outstanding results, making it an excellent choice for organizations looking for a top-notch text processing solution."
+msgstr ""
+
+#: no source
+msgid "title"
+msgstr ""
+
+#: no source
+msgid "To be continued, reply \"{trigger_message}\" to continue answering the question"
+msgstr ""
+
+#: apps/chat/api/chat_embed_api.py:38
+#: apps/chat/serializers/chat_embed_serializers.py:27
+#: apps/users/serializers/login.py:48
+msgid "token"
+msgstr ""
+
+#: no source
+msgid "Token"
+msgstr ""
+
+#: no source
+msgid "Token address cannot be empty"
+msgstr ""
+
+#: apps/homepage/serializers/homepage.py:303
+#: apps/homepage/serializers/homepage.py:626
 msgid "Token consumption"
-msgstr "Token consumption"
+msgstr ""
 
-msgid "proportion"
-msgstr "proportion"
+#: no source
+msgid "token is required"
+msgstr ""
 
-msgid "number of questions"
-msgstr "number of questions"
+#: no source
+msgid "Token is required"
+msgstr ""
 
-msgid "active users"
-msgstr "active users"
+#: apps/trigger/serializers/trigger.py:248
+msgid "token is required for EVENT triggers"
+msgstr ""
 
-msgid "Average tokens per request"
-msgstr "Average tokens per request"
+#: apps/knowledge/views/document.py:401
+#: apps/knowledge/views/document.py:402
+#: apps/knowledge/views/document.py:403
+msgid "Tokenize document vector library"
+msgstr ""
 
-msgid "Average Number of Conversation Turns per Person"
-msgstr "Average Number of Conversation Turns per Person"
+#: apps/common/event/listener_manage.py:562
+msgid "Tokenize document: {document_id} error {error} {traceback}"
+msgstr ""
 
+#: apps/common/event/listener_manage.py:242
+msgid "Tokenize paragraph: {paragraph_id} error {error} {traceback}"
+msgstr ""
+
+#: apps/application/serializers/application_stats.py:33
+msgid "Tokens consumption"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:58
+#: apps/homepage/views/homepage.py:59
+msgid "Tokens data aggregation"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:184
+msgid "Tongyi Wanxiang - a large image model for text generation, supports bilingual input in Chinese and English, and supports the input of reference pictures for reference content or reference style migration. Key styles include but are not limited to watercolor, oil painting, Chinese painting, sketch, flat illustration, two-dimensional, and 3D. Cartoon."
+msgstr ""
+
+#: apps/chat/serializers/chat.py:62
+msgid "Too many messages"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:343
+#: apps/common/constants/permission_constants.py:410
+#: apps/common/constants/permission_constants.py:420
+#: apps/common/constants/permission_constants.py:437
+#: apps/knowledge/views/knowledge.py:321
+#: apps/tools/views/tool.py:50
+#: apps/tools/views/tool.py:73
+#: apps/tools/views/tool.py:104
+#: apps/tools/views/tool.py:127
+#: apps/tools/views/tool.py:154
+#: apps/tools/views/tool.py:180
+#: apps/tools/views/tool.py:211
+#: apps/tools/views/tool.py:249
+#: apps/tools/views/tool.py:287
+#: apps/tools/views/tool.py:318
+#: apps/tools/views/tool.py:351
+#: apps/tools/views/tool.py:379
+#: apps/tools/views/tool.py:409
+#: apps/tools/views/tool.py:434
+#: apps/tools/views/tool.py:462
+#: apps/tools/views/tool.py:487
+#: apps/tools/views/tool.py:506
+#: apps/tools/views/tool.py:534
+#: apps/tools/views/tool.py:553
+#: apps/tools/views/tool.py:583
+#: apps/tools/views/tool.py:616
+#: apps/tools/views/tool.py:645
+#: apps/tools/views/tool.py:674
+#: apps/tools/views/tool_workflow.py:35
+#: apps/tools/views/tool_workflow.py:74
+#: apps/tools/views/tool_workflow.py:105
+#: apps/tools/views/tool_workflow.py:135
+#: apps/tools/views/tool_workflow.py:164
+#: apps/tools/views/tool_workflow.py:198
+msgid "Tool"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:287
+#: apps/tools/serializers/tool.py:303
+#: apps/tools/serializers/tool.py:328
+#: apps/tools/serializers/tool.py:551
+msgid "tool content"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:301
+#: apps/homepage/views/homepage.py:302
+msgid "Tool data aggregation"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:285
+#: apps/tools/serializers/tool.py:300
+msgid "tool description"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:118
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:123
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:137
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:142
+#: apps/tools/serializers/tool.py:1220
+#: apps/tools/serializers/tool.py:1387
+#: apps/tools/serializers/tool.py:1559
+msgid "Tool does not exist"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:619
+#: apps/tools/serializers/tool.py:1211
+#: apps/tools/serializers/tool.py:1309
+#: apps/tools/serializers/tool.py:1376
+#: apps/tools/serializers/tool.py:1426
+#: apps/tools/serializers/tool.py:1434
+#: apps/tools/serializers/tool.py:1546
+#: apps/tools/serializers/tool_workflow.py:146
+msgid "tool id"
+msgstr ""
+
+#: apps/tools/serializers/tool_version.py:34
+#: apps/tools/serializers/tool_version.py:69
+msgid "Tool ID"
+msgstr ""
+
+#: apps/tools/serializers/tool_workflow.py:376
+msgid "Tool id"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:632
+#: apps/tools/serializers/tool.py:641
+#: apps/tools/serializers/tool.py:1162
+#: apps/tools/serializers/tool_version.py:80
+#: apps/tools/serializers/tool_workflow.py:155
+#: apps/tools/serializers/tool_workflow.py:387
+msgid "Tool id does not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:45
+msgid "Tool IDs"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:125
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:144
+msgid "Tool is not active"
+msgstr ""
+
+#: apps/application/serializers/application.py:919
+#: apps/knowledge/serializers/knowledge.py:1419
+#: apps/tools/serializers/tool.py:283
+#: apps/tools/serializers/tool.py:299
+#: apps/tools/serializers/tool.py:318
+#: apps/tools/serializers/tool.py:343
+#: apps/tools/serializers/tool.py:1194
+#: apps/tools/serializers/tool.py:1255
+#: apps/tools/serializers/tool.py:1688
+#: apps/tools/serializers/tool_workflow.py:413
+msgid "tool name"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:653
+msgid "Tool not found"
+msgstr ""
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:18
+msgid "Tool parameters"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1465
+msgid "Tool record does not exist"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:346
+#: apps/tools/serializers/tool.py:1691
+msgid "tool type"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1693
+msgid "tool type list"
+msgstr ""
+
+#: apps/tools/serializers/tool_version.py:71
+msgid "Tool version ID"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:130
+#: apps/tools/views/tool_workflow.py:131
+#: apps/tools/views/tool_workflow.py:132
+msgid "tool workflow debug"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:46
+#: apps/tools/views/tool_workflow_version.py:70
+#: apps/tools/views/tool_workflow_version.py:95
+#: apps/tools/views/tool_workflow_version.py:117
+msgid "Tool/Version"
+msgstr ""
+
+#: no source
+msgid "Tools Resource"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:158
+#: apps/homepage/views/homepage.py:159
+msgid "Top applications by question count"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:133
+#: apps/homepage/views/homepage.py:134
+msgid "Top applications by question count export"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:108
+#: apps/homepage/views/homepage.py:109
+msgid "Top applications by token consumption"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:83
+#: apps/homepage/views/homepage.py:84
+msgid "Top applications by token consumption export"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:17
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:14
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:23
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:23
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:23
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:23
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:16
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:15
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:21
+msgid "Top N"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:158
+#: apps/knowledge/serializers/knowledge.py:1363
+msgid "top number"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:207
+#: apps/homepage/views/homepage.py:208
+msgid "Top users by token consumption"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:183
+#: apps/homepage/views/homepage.py:184
+msgid "Top users by token consumption export"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:247
+msgid "Total application count"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:165
+#: apps/homepage/api/home_page_api.py:221
+msgid "Total consumed tokens"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:157
+#: apps/homepage/api/home_page_api.py:187
+#: apps/homepage/api/home_page_api.py:212
+msgid "Total count"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:311
+msgid "Total document count"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:310
+msgid "Total knowledge count"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:384
+msgid "Total model count"
+msgstr ""
+
+#: apps/common/result/api.py:43
+msgid "total number of data"
+msgstr ""
+
+#: apps/application/serializers/application_stats.py:30
+msgid "Total number of users"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:347
+msgid "Total tool count"
+msgstr ""
+
+#: no source
+msgid "trial listening"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:295
+#: apps/common/constants/permission_constants.py:344
+#: apps/trigger/handler/impl/trigger/event_trigger.py:91
+#: apps/trigger/views/trigger.py:63
+#: apps/trigger/views/trigger.py:84
+#: apps/trigger/views/trigger.py:110
+#: apps/trigger/views/trigger.py:133
+#: apps/trigger/views/trigger.py:155
+#: apps/trigger/views/trigger.py:181
+#: apps/trigger/views/trigger.py:207
+#: apps/trigger/views/trigger.py:232
+#: apps/trigger/views/trigger.py:260
+#: apps/trigger/views/trigger.py:295
+#: apps/trigger/views/trigger.py:323
+#: apps/trigger/views/trigger.py:348
+#: apps/trigger/views/trigger.py:380
+#: apps/trigger/views/trigger_task.py:33
+#: apps/trigger/views/trigger_task.py:58
+#: apps/trigger/views/trigger_task.py:83
+msgid "Trigger"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:31
+#: apps/trigger/serializers/trigger.py:298
+#: apps/trigger/serializers/trigger.py:308
+msgid "trigger description"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:60
+#: apps/trigger/serializers/trigger.py:501
+msgid "trigger id"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:306
+#: apps/trigger/serializers/trigger_task.py:42
+#: apps/trigger/serializers/trigger_task.py:66
+#: apps/trigger/serializers/trigger_task.py:126
+msgid "Trigger ID"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:72
+#: apps/trigger/serializers/trigger.py:512
+#: apps/trigger/serializers/trigger_task.py:52
+#: apps/trigger/serializers/trigger_task.py:78
+#: apps/trigger/serializers/trigger_task.py:140
+msgid "Trigger id does not exist"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:134
+#: apps/trigger/serializers/task_source_trigger.py:144
+#: apps/trigger/serializers/trigger.py:542
+#: apps/trigger/serializers/trigger.py:562
+msgid "Trigger must have at least one task"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:30
+#: apps/trigger/serializers/trigger.py:297
+#: apps/trigger/serializers/trigger.py:307
+msgid "trigger name"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:639
+#: apps/trigger/serializers/trigger_task.py:129
+msgid "Trigger name"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:119
+#: apps/trigger/serializers/task_source_trigger.py:167
+#: apps/trigger/serializers/trigger.py:525
+msgid "Trigger not found"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:33
+#: apps/trigger/serializers/trigger.py:300
+#: apps/trigger/serializers/trigger.py:310
+msgid "trigger setting"
+msgstr ""
+
+#: apps/trigger/serializers/trigger_task.py:128
+msgid "Trigger state"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:642
+msgid "Trigger task"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:395
+msgid "Trigger task can not be empty"
+msgstr ""
+
+#: apps/trigger/serializers/trigger_task.py:68
+msgid "Trigger task ID"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:46
+msgid "Trigger task number must be one"
+msgstr ""
+
+#: apps/trigger/serializers/trigger_task.py:69
+msgid "Trigger task record ID"
+msgstr ""
+
+#: apps/trigger/serializers/trigger_task.py:87
+msgid "Trigger task record id does not exist"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:44
+msgid "trigger type"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:640
+msgid "Trigger type"
+msgstr ""
+
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:16
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:16
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:16
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:16
+msgid "Try out the different sounds (Alloy, Echo, Fable, Onyx, Nova, and Sparkle) to find one that suits your desired tone and audience. The current voiceover is optimized for English."
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:150
+msgid "TTS"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:31
+msgid "Turkish"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:26
+#: apps/knowledge/serializers/document.py:268
+#: apps/knowledge/serializers/knowledge_workflow.py:299
+#: apps/knowledge/serializers/knowledge_workflow.py:300
+#: apps/system_manage/serializers/valid_serializers.py:37
+#: apps/tools/serializers/tool.py:251
+msgid "type"
+msgstr ""
+
+#: apps/users/serializers/user.py:1089
+#: apps/users/serializers/user.py:1170
+msgid "Type"
+msgstr ""
+
+#: apps/common/utils/common.py:476
+#: apps/common/utils/common.py:483
+msgid "type error"
+msgstr ""
+
+#: apps/users/serializers/user.py:486
+msgid "Unable to delete administrator"
+msgstr ""
+
+#: no source
+msgid "Universal 1.4-Vincent Chart"
+msgstr ""
+
+#: no source
+msgid "Universal 2.0-Vincent Diagram"
+msgstr ""
+
+#: no source
+msgid "Universal 2.0Pro-Vincent Chart"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:42
+msgid "Universal realistic style"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:98
+msgid "Universal text vector is Tongyi Lab's multi-language text unified vector model based on the LLM base. It provides high-level vector services for multiple mainstream languages around the world and helps developers quickly convert text data into high-quality vector data."
+msgstr ""
+
+#: no source
+msgid "Unknown application id {knowledge_id}, cannot be associated"
+msgstr "Unknown Agent ID {knowledge_id}, cannot be associated"
+
+#: apps/common/exception/handle_exception.py:35
+#: apps/common/handle/handle_exception.py:34
+msgid "Unknown exception"
+msgstr ""
+
+#: apps/application/serializers/application.py:1373
+#: apps/tools/serializers/tool_workflow.py:330
+msgid "Unknown knowledge base id {dataset_id}, unable to associate"
+msgstr ""
+
+#: apps/application/serializers/application.py:453
+msgid "Unpublished"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:249
+msgid "Unpublished application count"
+msgstr ""
+
+#: apps/application/serializers/application.py:750
+#: apps/application/serializers/application.py:1401
+#: apps/common/handle/impl/qa/zip_parse_qa_handle.py:56
+#: apps/common/handle/impl/text/zip_split_handle.py:59
+#: apps/knowledge/serializers/document.py:1166
+#: apps/knowledge/serializers/document.py:1188
+#: apps/knowledge/serializers/knowledge_workflow.py:405
+#: apps/tools/serializers/tool.py:1070
+#: apps/tools/serializers/tool.py:1092
+#: apps/tools/serializers/tool.py:1537
+msgid "Unsupported file format"
+msgstr ""
+
+#: no source
+msgid "Unsupported platform type"
+msgstr ""
+
+#: no source
+msgid "Unsupported sync type"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:74
+msgid "Update a knowledge tag"
+msgstr ""
+
+#: no source
+msgid "Update a lark knowledge base"
+msgstr ""
+
+#: no source
+msgid "Update appearance settings"
+msgstr ""
+
+#: apps/tools/views/tool.py:577
+#: apps/tools/views/tool.py:578
+#: apps/tools/views/tool.py:579
+msgid "Update Appstore tool"
+msgstr ""
+
+#: no source
+msgid "Update auth setting"
+msgstr ""
+
+#: no source
+msgid "Update chat user information"
+msgstr ""
+
+#: apps/folders/views/folder.py:93
+#: apps/folders/views/folder.py:94
+#: apps/folders/views/folder.py:95
+msgid "Update folder"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:73
+msgid "Update Knowledge Tag"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:1296
+msgid "Update License"
+msgstr ""
+
+#: no source
+msgid "Update license information"
+msgstr ""
+
+#: no source
+msgid "Update license information by uploading a new license file"
+msgstr ""
+
+#: apps/models_provider/views/model.py:82
+#: apps/models_provider/views/model.py:83
+#: apps/models_provider/views/model.py:114
+#: apps/models_provider/views/model.py:115
+#: apps/models_provider/views/model.py:116
+msgid "Update model"
+msgstr ""
+
+#: no source
+msgid "Update personal system API_KEY"
+msgstr ""
+
+#: no source
+msgid "Update platform configuration"
+msgstr ""
+
+#: no source
+msgid "Update platform status"
+msgstr ""
+
+#: no source
+msgid "Update shared knowledge"
+msgstr ""
+
+#: no source
+msgid "Update shared tool"
+msgstr ""
+
+#: no source
+msgid "Update system knowledge"
+msgstr ""
+
+#: no source
+msgid "Update system tool"
+msgstr ""
+
+#: no source
+msgid "Update SystemAPIKey"
+msgstr ""
+
+#: apps/tools/views/tool.py:121
+#: apps/tools/views/tool.py:122
+#: apps/tools/views/tool.py:123
+msgid "Update tool"
+msgstr ""
+
+#: apps/users/views/user.py:230
+#: apps/users/views/user.py:231
+#: apps/users/views/user.py:232
+msgid "Update user information"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:53
+msgid "Upgraded to MOE structure, the context window is 256k, leading many open source models in multiple evaluation sets such as NLP, code, mathematics, industry, etc."
+msgstr ""
+
+#: apps/oss/views/file.py:38
+#: apps/oss/views/file.py:39
+#: apps/oss/views/file.py:40
+msgid "Upload file"
+msgstr ""
+
+#: apps/application/flow/step_node/data_source_local_node/i_data_source_local_node.py:22
+msgid "Upload file size"
+msgstr ""
+
+#: apps/chat/views/chat.py:259
+#: apps/chat/views/chat.py:260
+#: apps/chat/views/chat.py:261
+msgid "Upload files"
+msgstr ""
+
+#: apps/tools/views/tool.py:668
+#: apps/tools/views/tool.py:669
+#: apps/tools/views/tool.py:670
+msgid "Upload skill file"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:44
+msgid "URL error, cannot parse [{source_url}]"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:220
+msgid "User"
+msgstr ""
+
+#: no source
+msgid "USER"
+msgstr "Regular User"
+
+#: no source
+msgid "user"
+msgstr ""
+
+#: no source
+msgid "user avatar"
+msgstr ""
+
+#: no source
+msgid "user avatar url"
+msgstr ""
+
+#: apps/users/serializers/user.py:471
+msgid "User does not exist"
+msgstr ""
+
+#: no source
+msgid "User does not have permission to use API Key"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:216
+msgid "User feedback"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:406
+#: apps/common/constants/permission_constants.py:430
+msgid "User Group"
+msgstr ""
+
+#: no source
+msgid "User group"
+msgstr ""
+
+#: no source
+msgid "User group does not exist"
+msgstr ""
+
+#: no source
+msgid "User Group ID"
+msgstr ""
+
+#: no source
+msgid "User group id"
+msgstr ""
+
+#: no source
+msgid "User Group IDs"
+msgstr ""
+
+#: no source
+msgid "User Group IDs cannot be empty"
+msgstr ""
+
+#: no source
+msgid "User group name"
+msgstr ""
+
+#: no source
+msgid "User group name already exists"
+msgstr ""
+
+#: no source
+msgid "User Group Names"
+msgstr ""
+
+#: no source
+msgid "User group relation IDs"
+msgstr ""
+
+#: no source
+msgid "User group relation IDs cannot be empty"
+msgstr ""
+
+#: apps/application/api/application_api.py:89
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:30
+#: apps/application/serializers/application.py:227
+#: apps/application/serializers/application.py:455
+#: apps/application/serializers/application.py:475
+#: apps/application/serializers/application.py:632
+#: apps/application/serializers/application.py:918
+#: apps/application/serializers/application.py:994
+#: apps/application/serializers/application_chat_link.py:58
+#: apps/homepage/serializers/homepage.py:90
+#: apps/homepage/serializers/homepage.py:151
+#: apps/homepage/serializers/homepage.py:216
+#: apps/homepage/serializers/homepage.py:388
+#: apps/homepage/serializers/homepage.py:515
+#: apps/homepage/serializers/homepage.py:655
+#: apps/homepage/serializers/homepage.py:737
+#: apps/homepage/serializers/homepage.py:778
+#: apps/homepage/serializers/homepage.py:827
+#: apps/homepage/serializers/homepage.py:874
+#: apps/knowledge/serializers/knowledge.py:1418
+#: apps/knowledge/serializers/knowledge.py:1473
+#: apps/knowledge/serializers/knowledge_workflow.py:647
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:14
+#: apps/models_provider/serializers/model_serializer.py:358
+#: apps/tools/serializers/tool.py:909
+#: apps/tools/serializers/tool.py:1152
+#: apps/tools/serializers/tool.py:1193
+#: apps/tools/serializers/tool.py:1209
+#: apps/tools/serializers/tool.py:1254
+#: apps/tools/serializers/tool.py:1307
+#: apps/tools/serializers/tool.py:1374
+#: apps/tools/serializers/tool.py:1530
+#: apps/tools/serializers/tool.py:1544
+#: apps/tools/serializers/tool_workflow.py:377
+#: apps/tools/serializers/tool_workflow.py:412
+#: apps/trigger/serializers/task_source_trigger.py:40
+#: apps/trigger/serializers/trigger.py:348
+#: apps/trigger/serializers/trigger.py:452
+#: apps/trigger/serializers/trigger.py:502
+#: apps/users/api/user.py:52
+#: apps/users/api/user.py:110
+#: apps/users/api/user.py:126
+#: apps/users/serializers/user.py:463
+msgid "User ID"
+msgstr ""
+
+#: apps/folders/serializers/folder.py:135
+#: apps/folders/serializers/folder.py:179
+#: apps/knowledge/serializers/document.py:1003
+#: apps/knowledge/serializers/document.py:1316
+#: apps/knowledge/serializers/knowledge.py:188
+#: apps/knowledge/serializers/knowledge.py:314
+#: apps/knowledge/serializers/knowledge.py:883
+#: apps/knowledge/serializers/knowledge.py:1134
+#: apps/knowledge/serializers/knowledge.py:1257
+#: apps/knowledge/serializers/knowledge.py:1361
+#: apps/knowledge/serializers/knowledge.py:1503
+#: apps/knowledge/serializers/knowledge_workflow.py:317
+#: apps/knowledge/serializers/knowledge_workflow.py:389
+#: apps/knowledge/serializers/knowledge_workflow.py:516
+#: apps/knowledge/serializers/knowledge_workflow.py:566
+#: apps/models_provider/serializers/model_serializer.py:129
+#: apps/models_provider/serializers/model_serializer.py:246
+#: apps/models_provider/serializers/model_serializer.py:284
+#: apps/system_manage/api/user_resource_permission.py:116
+#: apps/system_manage/serializers/user_resource_permission.py:109
+#: apps/tools/serializers/tool.py:344
+#: apps/tools/serializers/tool.py:464
+#: apps/tools/serializers/tool.py:563
+#: apps/tools/serializers/tool.py:1689
+#: apps/tools/serializers/tool_workflow.py:144
+#: apps/users/serializers/user.py:1187
+msgid "user id"
+msgstr ""
+
+#: apps/users/api/user.py:135
+#: apps/users/serializers/user.py:623
+msgid "User IDs"
+msgstr ""
+
+#: apps/users/serializers/user.py:628
+msgid "User IDs cannot be empty"
+msgstr ""
+
+#: no source
+msgid "User information address cannot be empty"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:20
+msgid "User Input Fields"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:326
+#: apps/users/views/login.py:41
+#: apps/users/views/login.py:58
+#: apps/users/views/login.py:73
+#: apps/users/views/user.py:71
+#: apps/users/views/user.py:85
+#: apps/users/views/user.py:99
+#: apps/users/views/user.py:118
+#: apps/users/views/user.py:133
+#: apps/users/views/user.py:149
+#: apps/users/views/user.py:164
+#: apps/users/views/user.py:178
+#: apps/users/views/user.py:194
+#: apps/users/views/user.py:209
+#: apps/users/views/user.py:222
+#: apps/users/views/user.py:233
+#: apps/users/views/user.py:252
+#: apps/users/views/user.py:268
+#: apps/users/views/user.py:287
+#: apps/users/views/user.py:303
+#: apps/users/views/user.py:324
+#: apps/users/views/user.py:342
+#: apps/users/views/user.py:359
+#: apps/users/views/user.py:377
+msgid "User Management"
+msgstr ""
+
+#: no source
+msgid "User management"
+msgstr "User Management"
+
+#: no source
+msgid "user manual url"
+msgstr ""
+
+#: apps/homepage/serializers/homepage.py:218
+#: apps/homepage/serializers/homepage.py:302
 msgid "User Name"
-msgstr "User Name"
+msgstr ""
 
-msgid "New chat"
-msgstr "A new conversation has been generated. Please ask your question again！"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:62
+#: apps/application/flow/step_node/application_node/i_application_node.py:17
+#: apps/application/serializers/application_chat.py:214
+#: apps/chat/serializers/chat.py:75
+msgid "User Questions"
+msgstr ""
+
+#: apps/users/serializers/user.py:1146
+msgid "User registration"
+msgstr ""
+
+#: no source
+msgid "User relation does not exist"
+msgstr ""
+
+#: no source
+msgid "User relation ID"
+msgstr ""
+
+#: no source
+msgid "User Relation ID"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:213
+msgid "User tokens ranking list"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:55
+#: apps/system_manage/api/user_resource_permission.py:118
+msgid "username"
+msgstr ""
+
+#: apps/users/api/login.py:26
+#: apps/users/api/login.py:26
+#: apps/users/api/user.py:77
+#: apps/users/serializers/login.py:32
+#: apps/users/serializers/login.py:32
+#: apps/users/serializers/user.py:65
+#: apps/users/serializers/user.py:173
+#: apps/users/serializers/user.py:236
+msgid "Username"
+msgstr ""
+
+#: apps/users/serializers/user.py:179
+msgid "Username must be 4-64 characters long"
+msgstr ""
+
+#: no source
+msgid "Username or Nickname"
+msgstr ""
+
+#: apps/system_manage/api/user_resource_permission.py:343
+#: apps/system_manage/serializers/user_resource_permission.py:323
+msgid "users_permission"
+msgstr ""
+
+#: no source
+msgid "user_group_id"
+msgstr ""
+
+#: apps/system_manage/views/valid.py:28
+msgid "Validation"
+msgstr ""
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:20
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:21
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:20
+#: apps/models_provider/api/provide.py:24
+msgid "value"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:37
+msgid "value field"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:36
+msgid "vaporwave"
+msgstr ""
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:15
+msgid "Variable"
+msgstr ""
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:13
+msgid "Variable id"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:24
+msgid "Variable Label"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:23
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:24
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:23
+msgid "Variable Name"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:247
+#: apps/tools/serializers/tool.py:323
+msgid "variable name"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:25
+msgid "Variable Source"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:26
+msgid "Variable Type"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:24
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:34
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:27
+#: apps/trigger/serializers/trigger.py:51
+msgid "Variable Value"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:324
+msgid "variable value"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:367
+msgid "Vector"
+msgstr ""
+
+#: apps/local_model/serializers/model_apply_serializers.py:95
+#: apps/local_model/serializers/model_apply_serializers.py:100
+#: apps/models_provider/serializers/model_apply_serializers.py:32
+#: apps/models_provider/serializers/model_apply_serializers.py:37
+msgid "vector text"
+msgstr ""
+
+#: apps/local_model/serializers/model_apply_serializers.py:96
+#: apps/models_provider/serializers/model_apply_serializers.py:33
+msgid "vector text list"
+msgstr ""
+
+#: apps/models_provider/views/model_apply.py:25
+#: apps/models_provider/views/model_apply.py:26
+#: apps/models_provider/views/model_apply.py:27
+#: apps/models_provider/views/model_apply.py:37
+#: apps/models_provider/views/model_apply.py:38
+#: apps/models_provider/views/model_apply.py:39
+msgid "Vectorization documentation"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:404
+msgid "Vectorized document: {document_id} error {error} {traceback}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:431
+#: apps/knowledge/task/embedding.py:132
+msgid "Vectorized knowledge: {knowledge_id} error {error} {traceback}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:138
+msgid "Vectorized paragraph: {paragraph_id_list} error {error} {traceback}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:189
+msgid "Vectorized paragraph: {paragraph_id} error {error} {traceback}"
+msgstr ""
+
+#: apps/users/serializers/user.py:1167
+msgid "Verification code"
+msgstr ""
+
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:43
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:75
+msgid "Verification failed, please check whether the parameters are correct"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:57
+msgid "Verification failed, please check whether the parameters are correct: %(error)s"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:76
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:94
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:84
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:81
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:51
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:68
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:59
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:76
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:121
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:134
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:97
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:61
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:63
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:40
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:60
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:59
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:64
+#: apps/models_provider/impl/azure_model_provider/credential/stt.py:39
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:74
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:56
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:61
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:63
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:45
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:56
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:61
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:68
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:37
+#: apps/models_provider/impl/gemini_model_provider/credential/tti.py:44
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:71
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:62
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:42
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:54
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:84
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:86
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:51
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:84
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:60
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:61
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:63
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:45
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:56
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:43
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:62
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:63
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:38
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:58
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:29
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:65
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:55
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:76
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:102
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:61
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:53
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:53
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:49
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:61
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:63
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:50
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:61
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:66
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:80
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:53
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:52
+#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:37
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:49
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:82
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:58
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:58
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:82
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:63
+#: apps/models_provider/impl/xf_model_provider/credential/zh_en_stt.py:45
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:60
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:50
+#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:37
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:75
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:55
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:61
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:62
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:57
+msgid "Verification failed, please check whether the parameters are correct: {error}"
+msgstr ""
+
+#: no source
+msgid "Verification Token is required"
+msgstr ""
+
+#: apps/application/serializers/application_version.py:36
+#: apps/knowledge/serializers/knowledge_version.py:24
+#: apps/tools/serializers/tool_version.py:22
+msgid "Version Name"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1380
+msgid "versions"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:52
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:28
+msgid "video"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:24
+msgid "Video"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:22
+msgid "Video size"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:25
+msgid "Vietnamese"
+msgstr ""
+
+#: no source
+msgid "View appearance settings"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:386
+msgid "View related resources"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:56
+msgid "vision"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:151
+msgid "Vision Model"
+msgstr ""
+
+#: apps/application/serializers/application.py:390
+#: apps/application/serializers/application.py:621
+msgid "Voice playback autoplay"
+msgstr ""
+
+#: apps/application/serializers/application.py:384
+#: apps/application/serializers/application.py:615
+msgid "Voice playback enabled"
+msgstr ""
+
+#: apps/application/serializers/application.py:386
+#: apps/application/serializers/application.py:617
+msgid "Voice playback model ID"
+msgstr ""
+
+#: apps/application/serializers/application.py:388
+#: apps/application/serializers/application.py:619
+msgid "Voice playback type"
+msgstr ""
+
+#: apps/application/serializers/application.py:396
+#: apps/application/serializers/application.py:627
+msgid "Voice recognition automatic transmission"
+msgstr ""
+
+#: apps/application/serializers/application.py:392
+#: apps/application/serializers/application.py:623
+msgid "Voice recognition enabled"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:16
+msgid "Voice Setting"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:149
+msgid "volcano engine"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:31
+msgid "Vote other content"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:28
+msgid "Vote Reason"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:58
+msgid "Voting on the current session minutes, please do not send repeated requests"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:55
+msgid "watercolor"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:22
+msgid "watercolor painting"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:33
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:36
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:22
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:22
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:49
+msgid "Watermark"
+msgstr ""
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:24
+msgid "Web knowledge selector"
+msgstr ""
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:22
+msgid "Web source url"
+msgstr ""
+
+#: no source
+msgid "WeChat Official Account: {account}"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:291
+msgid "WeChat Public Account"
+msgstr ""
+
+#: no source
+msgid "wecom"
+msgstr "WeCom"
+
+#: no source
+msgid "WeCom callback"
+msgstr ""
+
+#: no source
+msgid "WeCom configuration not found or not active"
+msgstr ""
+
+#: no source
+msgid "WeCom OAuth2 callback"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:381
+msgid "Weixin Public Account"
+msgstr ""
+
+#: no source
+msgid "Welcome to subscribe"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:33
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:36
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:22
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:22
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:49
+msgid "Whether to add watermark"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:36
+msgid "Whether to display knowledge sources"
+msgstr ""
+
+#: no source
+msgid "Whether to enable MCP"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:50
+msgid "Whether to enable MCP output"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:36
+msgid "Whether to enable SSL"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:35
+msgid "Whether to enable TLS"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:31
+msgid "Whether to enable whitelist"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:30
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:26
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:29
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:30
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:27
+#: apps/application/flow/step_node/question_node/i_question_node.py:31
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:18
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:19
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:29
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:31
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:48
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:34
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:26
+msgid "Whether to return content"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:33
+#: apps/application/serializers/application_access_token.py:34
+msgid "Whitelist"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:62
+msgid "with filter"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:68
+msgid "with filter reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:65
+msgid "with filter type"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:71
+msgid "With the GTE-Rerank text sorting series model developed by Alibaba Tongyi Lab, developers can integrate high-quality text retrieval and sorting through the LlamaIndex framework."
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:357
+#: apps/common/constants/permission_constants.py:415
+#: apps/common/constants/permission_constants.py:425
+msgid "Workflow"
+msgstr ""
+
+#: apps/application/api/application_api.py:23
+#: apps/application/serializers/application.py:298
+msgid "Workflow Objects"
+msgstr ""
+
+#: apps/application/serializers/application_version.py:91
+#: apps/application/serializers/application_version.py:107
+#: apps/knowledge/serializers/knowledge_version.py:105
+#: apps/knowledge/serializers/knowledge_version.py:123
+#: apps/tools/serializers/tool_version.py:91
+#: apps/tools/serializers/tool_version.py:107
+msgid "Workflow version does not exist"
+msgstr ""
+
+#: no source
+msgid "Workflow version id"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:328
+#: apps/common/constants/permission_constants.py:432
+msgid "Workspace"
+msgstr ""
+
+#: no source
+msgid "Workspace does not exist"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:79
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:47
+#: apps/application/serializers/application.py:474
+#: apps/application/serializers/application.py:995
+#: apps/application/serializers/application.py:1675
+#: apps/application/serializers/application_access_token.py:48
+#: apps/application/serializers/application_api_key.py:37
+#: apps/application/serializers/application_api_key.py:74
+#: apps/application/serializers/application_chat.py:53
+#: apps/application/serializers/application_chat_record.py:46
+#: apps/application/serializers/application_chat_record.py:91
+#: apps/application/serializers/application_chat_record.py:199
+#: apps/application/serializers/application_chat_record.py:248
+#: apps/application/serializers/application_chat_record.py:381
+#: apps/application/serializers/application_chat_record.py:482
+#: apps/application/serializers/application_stats.py:38
+#: apps/application/serializers/application_version.py:40
+#: apps/application/serializers/application_version.py:43
+#: apps/application/serializers/application_version.py:68
+#: apps/chat/serializers/chat.py:155
+#: apps/chat/serializers/chat.py:532
+#: apps/homepage/api/home_page_api.py:71
+#: apps/homepage/api/home_page_api.py:122
+#: apps/homepage/api/home_page_api.py:263
+#: apps/homepage/api/home_page_api.py:277
+#: apps/homepage/api/home_page_api.py:326
+#: apps/homepage/api/home_page_api.py:363
+#: apps/homepage/api/home_page_api.py:400
+#: apps/homepage/serializers/homepage.py:89
+#: apps/homepage/serializers/homepage.py:150
+#: apps/homepage/serializers/homepage.py:215
+#: apps/homepage/serializers/homepage.py:387
+#: apps/homepage/serializers/homepage.py:514
+#: apps/homepage/serializers/homepage.py:654
+#: apps/homepage/serializers/homepage.py:736
+#: apps/homepage/serializers/homepage.py:777
+#: apps/homepage/serializers/homepage.py:826
+#: apps/homepage/serializers/homepage.py:873
+#: apps/knowledge/serializers/knowledge.py:1471
+#: apps/knowledge/serializers/knowledge_version.py:50
+#: apps/knowledge/serializers/knowledge_version.py:53
+#: apps/knowledge/serializers/knowledge_version.py:81
+#: apps/knowledge/serializers/knowledge_workflow.py:648
+#: apps/knowledge/serializers/tag.py:46
+#: apps/knowledge/serializers/tag.py:93
+#: apps/knowledge/serializers/tag.py:167
+#: apps/knowledge/serializers/tag.py:201
+#: apps/tools/serializers/tool.py:1569
+#: apps/tools/serializers/tool_version.py:40
+#: apps/tools/serializers/tool_version.py:43
+#: apps/tools/serializers/tool_version.py:68
+#: apps/tools/serializers/tool_workflow.py:378
+#: apps/trigger/serializers/trigger_task.py:43
+#: apps/trigger/serializers/trigger_task.py:67
+#: apps/trigger/serializers/trigger_task.py:127
+#: apps/users/api/user.py:64
+#: apps/users/api/user.py:170
+msgid "Workspace ID"
+msgstr ""
+
+#: apps/application/serializers/application.py:631
+#: apps/folders/serializers/folder.py:130
+#: apps/folders/serializers/folder.py:134
+#: apps/folders/serializers/folder.py:177
+#: apps/folders/serializers/folder.py:306
+#: apps/knowledge/serializers/document.py:354
+#: apps/knowledge/serializers/document.py:472
+#: apps/knowledge/serializers/document.py:586
+#: apps/knowledge/serializers/document.py:684
+#: apps/knowledge/serializers/document.py:1001
+#: apps/knowledge/serializers/document.py:1206
+#: apps/knowledge/serializers/document.py:1292
+#: apps/knowledge/serializers/document.py:1314
+#: apps/knowledge/serializers/document.py:1651
+#: apps/knowledge/serializers/document.py:1697
+#: apps/knowledge/serializers/document.py:1772
+#: apps/knowledge/serializers/document.py:1813
+#: apps/knowledge/serializers/document.py:1842
+#: apps/knowledge/serializers/document.py:1878
+#: apps/knowledge/serializers/knowledge.py:315
+#: apps/knowledge/serializers/knowledge.py:884
+#: apps/knowledge/serializers/knowledge.py:1135
+#: apps/knowledge/serializers/knowledge.py:1255
+#: apps/knowledge/serializers/knowledge.py:1359
+#: apps/knowledge/serializers/knowledge.py:1502
+#: apps/knowledge/serializers/knowledge.py:1558
+#: apps/knowledge/serializers/knowledge_workflow.py:113
+#: apps/knowledge/serializers/knowledge_workflow.py:265
+#: apps/knowledge/serializers/knowledge_workflow.py:318
+#: apps/knowledge/serializers/knowledge_workflow.py:390
+#: apps/knowledge/serializers/knowledge_workflow.py:517
+#: apps/knowledge/serializers/knowledge_workflow.py:567
+#: apps/knowledge/serializers/paragraph.py:107
+#: apps/knowledge/serializers/paragraph.py:200
+#: apps/knowledge/serializers/paragraph.py:436
+#: apps/knowledge/serializers/paragraph.py:472
+#: apps/knowledge/serializers/paragraph.py:552
+#: apps/knowledge/serializers/paragraph.py:601
+#: apps/knowledge/serializers/paragraph.py:778
+#: apps/knowledge/serializers/problem.py:63
+#: apps/knowledge/serializers/problem.py:137
+#: apps/knowledge/serializers/problem.py:197
+#: apps/knowledge/serializers/problem.py:234
+#: apps/knowledge/serializers/termbase.py:35
+#: apps/knowledge/serializers/termbase.py:65
+#: apps/knowledge/serializers/termbase.py:103
+#: apps/knowledge/serializers/termbase.py:139
+#: apps/models_provider/api/model.py:30
+#: apps/models_provider/api/model.py:86
+#: apps/models_provider/api/model.py:99
+#: apps/models_provider/serializers/model_serializer.py:130
+#: apps/models_provider/serializers/model_serializer.py:255
+#: apps/models_provider/serializers/model_serializer.py:291
+#: apps/models_provider/serializers/model_serializer.py:364
+#: apps/models_provider/serializers/model_serializer.py:482
+#: apps/models_provider/serializers/model_serializer.py:541
+#: apps/system_manage/serializers/user_resource_permission.py:108
+#: apps/system_manage/serializers/user_resource_permission.py:298
+#: apps/system_manage/serializers/user_resource_permission.py:299
+#: apps/system_manage/serializers/user_resource_permission.py:306
+#: apps/system_manage/serializers/user_resource_permission.py:320
+#: apps/tools/serializers/tool.py:341
+#: apps/tools/serializers/tool.py:465
+#: apps/tools/serializers/tool.py:550
+#: apps/tools/serializers/tool.py:564
+#: apps/tools/serializers/tool.py:620
+#: apps/tools/serializers/tool.py:910
+#: apps/tools/serializers/tool.py:1151
+#: apps/tools/serializers/tool.py:1210
+#: apps/tools/serializers/tool.py:1308
+#: apps/tools/serializers/tool.py:1375
+#: apps/tools/serializers/tool.py:1425
+#: apps/tools/serializers/tool.py:1435
+#: apps/tools/serializers/tool.py:1531
+#: apps/tools/serializers/tool.py:1545
+#: apps/tools/serializers/tool.py:1628
+#: apps/tools/serializers/tool.py:1686
+#: apps/tools/serializers/tool_workflow.py:145
+#: apps/trigger/serializers/task_source_trigger.py:39
+#: apps/trigger/serializers/task_source_trigger.py:61
+#: apps/trigger/serializers/task_source_trigger.py:182
+#: apps/trigger/serializers/trigger.py:347
+#: apps/trigger/serializers/trigger.py:451
+#: apps/trigger/serializers/trigger.py:503
+#: apps/trigger/serializers/trigger.py:644
+msgid "workspace id"
+msgstr ""
+
+#: no source
+msgid "workspace id list"
+msgstr ""
+
+#: apps/users/api/user.py:30
+msgid "Workspace IDs"
+msgstr ""
+
+#: no source
+msgid "Workspace Name"
+msgstr ""
+
+#: no source
+msgid "Workspace name already exists"
+msgstr ""
+
+#: no source
+msgid "Workspace Role"
+msgstr ""
+
+#: no source
+msgid "Workspace/Chat user"
+msgstr ""
+
+#: no source
+msgid "Workspace/User Group"
+msgstr ""
+
+#: no source
+msgid "workspace_id"
+msgstr ""
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:33
+#: apps/system_manage/serializers/resource_mapping_serializers.py:115
+msgid "workspace_ids"
+msgstr ""
+
+#: no source
+msgid "WORKSPACE_MANAGE"
+msgstr "Workspace Manager"
+
+#: apps/application/serializers/application.py:1157
+msgid "work_flow is a required field"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:47
+msgid "World"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:42
+msgid "You can request 1 image at a time (requesting more images by making parallel requests), or up to 10 images at a time using the n parameter."
+msgstr ""
+
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:43
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:43
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:43
+msgid "You can use DALL·E 3 to request 1 image at a time (requesting more images by issuing parallel requests), or use DALL·E 2 with the n parameter to request up to 10 images at a time."
+msgstr ""
+
+#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:75
+msgid "zhipu AI"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:30
+msgid "[0.2,3], the default is 1, usually one decimal place is enough"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:37
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:68
+msgid "[0.5, 2], the default is 1, usually one decimal place is enough"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:61
+msgid "[Legacy] gpt-3.5-turbo snapshot on June 13, 2023, will be deprecated on June 13, 2024"
+msgstr ""
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:33
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:38
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:40
+msgid "{field}, this field is required."
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:40
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:61
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:87
+msgid "{keys} is required"
+msgstr ""
+
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:47
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:31
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:50
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:63
+#: apps/models_provider/impl/azure_model_provider/credential/stt.py:27
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:62
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:45
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:49
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:49
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:42
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:33
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:44
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:47
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:25
+#: apps/models_provider/impl/gemini_model_provider/credential/tti.py:32
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:30
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:42
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:45
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:46
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:62
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:73
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:49
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:49
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:33
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:44
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:31
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:50
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:49
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:42
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:26
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:46
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:51
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:47
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:39
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:57
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:37
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:47
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:38
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:50
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:55
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:69
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:41
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:61
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:86
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:92
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:38
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:33
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:70
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:46
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:51
+#: apps/models_provider/impl/xf_model_provider/credential/zh_en_stt.py:33
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:40
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:47
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:59
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:39
+#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:26
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:64
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:44
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:47
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:45
+msgid "{key}  is required"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:62
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:80
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:66
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:67
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:37
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:54
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:45
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:62
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:107
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:120
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:83
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:55
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:57
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:70
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:72
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:70
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:46
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:71
+msgid "{key} is required"
+msgstr ""
+
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:33
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:53
+msgid "{model_name} The model does not support"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:54
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:71
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:58
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:28
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:45
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:36
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:53
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:98
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:111
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:74
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:42
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:20
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:40
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:39
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:45
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/azure_model_provider/credential/stt.py:22
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:57
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:40
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:44
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:44
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:38
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:28
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:42
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:48
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:20
+#: apps/models_provider/impl/gemini_model_provider/credential/tti.py:27
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:48
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:26
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:38
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:61
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:40
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:63
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:34
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:61
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:39
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:44
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:37
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:41
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:44
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:44
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:28
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:45
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:44
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:38
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:21
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:41
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:18
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:47
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:51
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:42
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:38
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:34
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:39
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:32
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:42
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:33
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:45
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:50
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:64
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:29
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:49
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:33
+#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:28
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:41
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:39
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:64
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:46
+#: apps/models_provider/impl/xf_model_provider/credential/zh_en_stt.py:28
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:19
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:42
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:39
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:35
+#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:21
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:59
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:42
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:40
+msgid "{model_type} Model type is not supported"
+msgstr ""
+
+#: apps/application/flow/common.py:230
+msgid "{node} Nodes cannot be considered as end nodes"
+msgstr ""
+
+#: apps/users/serializers/user.py:1145
+msgid "【Intelligent knowledge base question and answer system-{action}】"
+msgstr ""

--- a/apps/locales/i18n_automation.py
+++ b/apps/locales/i18n_automation.py
@@ -1,0 +1,705 @@
+# coding=utf-8
+"""
+Django 国际化翻译文件自动化脚本
+功能：
+1. 缓存已翻译的内容
+2. 扫描所有Python文件中的国际化代码
+3. 合并已有翻译和新发现的内容
+4. 生成排序后的翻译文件
+"""
+
+import re
+from pathlib import Path
+from typing import Dict
+
+
+# 配置1：需要扫描的语言
+LANGUAGES = ['en_US', 'zh_CN', 'zh_Hant']
+
+# 配置2：是否保留无代码来源(遗留)的项？
+# 说明：如果想从 django.po 文件中清除它们，请将此属性设置为 False
+# 注意：为 False 时，保险起见，保留已翻译项
+KEEP_NO_SOURCE = True
+
+# 配置3：是否保留翻译与原文一样的翻译内容？
+# 说明：默认：不保留，因为与原文一样没必要保留。
+# 例：为False时：
+#   ```text
+#   msgid "xxx"
+#   msgstr "xxx"
+#   ```
+#   会被简化为
+#   ```text
+#   msgid "xxx"
+#   msgstr ""
+#   ```
+KEEP_SAME_TRANSLATION = False
+
+# 配置4：是否备份原 django.po 文件。
+# 说明：因为有VCS，所以默认不备份。
+BACKUP_PO = False
+
+
+class I18nAutomation:
+    """国际化自动化工具类"""
+
+    def __init__(self, base_dir: str):
+        """
+        初始化工具
+
+        Args:
+            base_dir: 项目根目录路径
+        """
+        self.base_dir = Path(base_dir)
+        self.locales_dir = self.base_dir / 'apps' / 'locales'
+
+        # 翻译数据存储格式: { "原文": {"zh_CN": "翻译", "zh_Hant": "翻译", "from_sources": [...] } }
+        self.translations = {}
+
+    def parse_po_file(self, po_file_path: Path) -> Dict[str, str]:
+        """
+        解析 .po 文件，提取 msgid 和 msgstr 的映射关系
+
+        Args:
+            po_file_path: .po 文件路径
+
+        Returns:
+            {msgid: msgstr} 字典
+        """
+        translations = {}
+
+        if not po_file_path.exists():
+            print(f"警告: 文件不存在 - {po_file_path}")
+            return translations
+
+        with open(po_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        # 使用更完善的解析逻辑处理多行 msgid/msgstr
+        # 先找到所有的 msgid/msgstr 块
+        entries = self._extract_po_entries(content)
+
+        for msgid, msgstr in entries.items():
+            # 跳过空字符串
+            if msgid and msgid.strip():
+                # 处理转义字符
+                msgid_unescaped = self._unescape_string(msgid)
+                msgstr_unescaped = self._unescape_string(msgstr)
+
+                if msgstr_unescaped:
+                    # 当 配置 KEEP_SAME_TRANSLATION 为 True 或 翻译内容与原文不一致，则保留
+                    if KEEP_SAME_TRANSLATION or msgstr_unescaped != msgid_unescaped:
+                        translations[msgid_unescaped] = msgstr_unescaped
+
+        return translations
+
+    def _extract_po_entries(self, content: str) -> Dict[str, str]:
+        """
+        从 .po 文件内容中提取 msgid 和 msgstr 对
+        支持多行字符串格式
+
+        Args:
+            content: .po 文件内容
+
+        Returns:
+            {msgid: msgstr} 字典
+        """
+        entries = {}
+        lines = content.split('\n')
+
+        i = 0
+        while i < len(lines):
+            line = lines[i].strip()
+
+            # 查找 msgid 开始
+            if line.startswith('msgid '):
+                # 提取 msgid 的所有行
+                msgid_parts = []
+                msgid_line = line[6:].strip()  # 去掉 'msgid '
+
+                # 如果第一行有内容（可能是 msgid "" 或 msgid "..."）
+                if msgid_line:
+                    msgid_parts.append(msgid_line)
+
+                # 继续读取后续的行（以 " 开头的 continuation lines）
+                i += 1
+                while i < len(lines):
+                    next_line = lines[i].strip()
+                    # 如果下一行以 " 开头，说明是多行字符串的延续
+                    if next_line.startswith('"'):
+                        msgid_parts.append(next_line)
+                        i += 1
+                    # 如果遇到 msgstr，停止读取 msgid
+                    elif next_line.startswith('msgstr '):
+                        break
+                    # 跳过空行和注释，继续寻找 msgstr
+                    elif next_line == '' or next_line.startswith('#'):
+                        i += 1
+                        continue
+                    # 其他情况也停止
+                    else:
+                        print(f"其他情况也停止: {next_line}")
+                        break
+
+                # 现在查找 msgstr（跳过中间的空行和注释）
+                msgstr_parts = []
+                while i < len(lines):
+                    current_line = lines[i].strip()
+                    if current_line.startswith('msgstr '):
+                        msgstr_line = current_line[7:].strip()  # 去掉 'msgstr '
+                        if msgstr_line:
+                            msgstr_parts.append(msgstr_line)
+                        i += 1
+                        break
+                    # 跳过空行和注释，继续寻找 msgstr
+                    elif current_line == '' or current_line.startswith('#'):
+                        i += 1
+                        continue
+                    else:
+                        # 遇到其他内容，说明没有 msgstr
+                        i += 1
+                        print(f"遇到其他内容，说明没有 msgstr: {current_line}")
+                        break
+
+                # 如果找到了 msgstr，继续读取其后续行
+                if msgstr_parts:
+                    while i < len(lines):
+                        next_line = lines[i].strip()
+                        if next_line.startswith('"'):
+                            msgstr_parts.append(next_line)
+                            i += 1
+                        else:
+                            break
+
+                # 合并多行字符串
+                if msgid_parts and msgstr_parts:
+                    msgid = self._join_multiline_string(msgid_parts)
+                    msgstr = self._join_multiline_string(msgstr_parts)
+                    entries[msgid] = msgstr
+            else:
+                i += 1
+
+        return entries
+
+    def _join_multiline_string(self, parts: list) -> str:
+        """
+        将多行字符串部分合并为一个字符串
+        例如: ['"第一部分"', '"第二部分"'] -> "第一部分第二部分"
+
+        Args:
+            parts: 字符串部分列表
+
+        Returns:
+            合并后的字符串
+        """
+        if not parts:
+            return ''
+
+        # 移除每个部分的引号并拼接
+        result = ''
+        for part in parts:
+            # 去除首尾的引号和空格
+            cleaned = part.strip().strip('"')
+            result += cleaned
+
+        return result
+
+    def _unescape_string(self, s: str) -> str:
+        """
+        处理转义字符串
+
+        Args:
+            s: 原始字符串
+
+        Returns:
+            处理后的字符串
+        """
+        # 处理常见的转义字符
+        s = s.replace('\\n', '\n')
+        s = s.replace('\\t', '\t')
+        s = s.replace('\\"', '"')
+        s = s.replace('\\\\', '\\')
+        return s
+
+    def _escape_string(self, s: str) -> str:
+        """
+        转义字符串用于写入 .po 文件
+
+        Args:
+            s: 原始字符串
+
+        Returns:
+            转义后的字符串
+        """
+        s = s.replace('\\', '\\\\')
+        s = s.replace('"', '\\"')
+        s = s.replace('\n', '\\n')
+        s = s.replace('\t', '\\t')
+        return s
+
+    def cache_existing_translations(self):
+        """
+        步骤1: 缓存 en_US、zh_CN 和 zh_Hant 中已翻译的内容
+        格式: { "原文": {"en_US": "翻译内容", "zh_CN": "翻译内容", "zh_Hant": "翻译内容"} }
+        """
+        print("\n" + "="*60)
+        print("步骤1: 缓存已有的翻译内容")
+        print("="*60)
+
+        cached = {}
+
+        for lang in LANGUAGES:
+            po_file = self.locales_dir / lang / 'LC_MESSAGES' / 'django.po'
+            lang_translations = self.parse_po_file(po_file)
+            print(f"从 django.po 解析到 {len(lang_translations)} 条翻译（{lang}）")
+
+            for msgid, msgstr in lang_translations.items():
+                if msgid not in cached:
+                    cached[msgid] = {}
+                cached[msgid][lang] = msgstr
+
+        self.cached_translations = cached
+        print(f"共缓存 {len(cached)} 条已有翻译")
+        return cached
+
+    def extract_i18n_from_python_files(self) -> Dict[str, dict]:
+        """
+        步骤2: 读取所有 *.py 文件中的国际化代码
+        格式: _("原文内容")
+
+        Returns:
+            { "原文": {"en_US": "", "zh_CN": "", "zh_Hant": "", "from_sources": [...]} }
+        """
+        print("\n" + "="*60)
+        print("步骤2: 扫描 Python 文件中的国际化代码")
+        print("="*60)
+
+        i18n_strings = {}
+        apps_dir = self.base_dir / 'apps'
+
+        # 匹配各种国际化字符串模式：
+        # 1. _("xxx" "yyy") 或 _('xxx' 'yyy') - 括号内多字符串拼接
+        # 2. _("""...""") 或 _('''...''') - 三引号多行字符串
+        # 3. _("...") 或 _('...') - 单行字符串
+        patterns = [
+            # 1. 匹配括号内多个字符串拼接 _("str1" "str2") 或 _("str1" 'str2') 等混合形式
+            re.compile(
+                r'\b(?:_|gettext_lazy|gettext)\(\s*'
+                r'(?:r?(?:"(?:[^"\\]|\\.)+"|\'(?:[^\'\\]|\\.)+\')\s*){2,}'
+                r'\)',
+                re.MULTILINE | re.DOTALL
+            ),
+            # 2. 匹配三引号双引号 _("""...""")
+            re.compile(r'\b(?:_|gettext_lazy|gettext)\(\s*r?"""((?:[^"\\]|\\.|"(?!"")|\n)*?)"""\s*\)', re.MULTILINE | re.DOTALL),
+            # 2. 匹配三引号单引号 _('''...''')
+            re.compile(r"\b(?:_|gettext_lazy|gettext)\(\s*r?'''((?:[^'\\]|\\.|'(?!'')|\n)*?)'''\s*\)", re.MULTILINE | re.DOTALL),
+            # 3. 匹配单行双引号 _("...")
+            re.compile(r'\b(?:_|gettext_lazy|gettext)\(\s*r?"((?:[^"\\]|\\.)+?)"\s*\)', re.MULTILINE | re.DOTALL),
+            # 3. 匹配单行单引号 _('...')
+            re.compile(r"\b(?:_|gettext_lazy|gettext)\(\s*r?'((?:[^'\\]|\\.)+?)'\s*\)", re.MULTILINE | re.DOTALL),
+        ]
+
+        # 递归查找所有 .py 文件
+        py_files = list(apps_dir.rglob('*.py'))
+        print(f"找到 {len(py_files)} 个 Python 文件")
+
+        scanned_count = 0
+        for py_file in py_files:
+            # 跳过 __pycache__、migrations 和 locales 目录
+            if '__pycache__' in str(py_file) or 'migrations' in str(py_file) or 'locales' in str(py_file):
+                continue
+
+            try:
+                with open(py_file, 'r', encoding='utf-8') as f:
+                    content = f.read()
+
+                file_scanned = False
+                for index, pattern in enumerate(patterns):
+                    matches = pattern.finditer(content)
+                    current_pattern_current_file_line_no_array = []  # 同正则同文件匹配到的代码行号，用于保留同匹配串在同一行匹配到多个时多次显示该行号
+                    for match in matches:
+                        full_match = match.group(0)
+
+                        # 对于多字符串拼接模式，需要特殊处理提取内容
+                        if index == 0:  # 注：必须将该正则放在 patterns 的第一位
+                            # 提取括号内所有的字符串并拼接
+                            msgid = self._extract_concatenated_strings(full_match)
+                        else:
+                            # 普通模式，直接提取捕获组
+                            msgid = match.group(1) if match.lastindex else None
+
+                        if msgid is None:
+                            continue
+
+                        msgid = self._unescape_string(msgid)
+
+                        if msgid and msgid.strip():
+                            msgid = msgid.replace("\\'", "'").replace('\\"', '"')
+                            if msgid not in i18n_strings:
+                                i18n_strings[msgid] = {
+                                    'en_US': '',
+                                    'zh_CN': '',
+                                    'zh_Hant': '',
+                                    'from_sources': {}
+                                }
+
+                            # 记录来源文件和行号
+                            relative_path = str(py_file.relative_to(self.base_dir)).replace("\\", "/")
+                            line_no = content[:match.start()].count('\n') + 1
+
+                            if relative_path not in i18n_strings[msgid]['from_sources']:
+                                i18n_strings[msgid]['from_sources'][relative_path] = [line_no]
+                                current_pattern_current_file_line_no_array.append(line_no)
+                                file_scanned = True
+                            else:
+                                if line_no not in i18n_strings[msgid]['from_sources'][relative_path] or line_no in current_pattern_current_file_line_no_array:
+                                    i18n_strings[msgid]['from_sources'][relative_path].append(line_no)
+                                    current_pattern_current_file_line_no_array.append(line_no)
+
+                if file_scanned:
+                    scanned_count += 1
+
+            except Exception as e:
+                print(f"处理文件 {py_file} 时出错: {e}")
+
+        print(f"扫描了 {scanned_count} 个文件")
+        print(f"提取到 {len(i18n_strings)} 条国际化字符串")
+
+        self.scanned_i18n = i18n_strings
+        return i18n_strings
+
+    def _extract_concatenated_strings(self, match_str: str) -> str:
+        """
+        从括号内的多个字符串拼接中提取完整内容
+        例如: _("Hello" " World") -> "Hello World"
+
+        Args:
+            match_str: 完整的匹配字符串，如 _("str1" "str2")
+
+        Returns:
+            拼接后的字符串内容
+        """
+        # 找到第一个 ( 和最后一个 ) 之间的内容
+        start = match_str.find('(')
+        end = match_str.rfind(')')
+        if start == -1 or end == -1:
+            return ''
+
+        inner = match_str[start+1:end].strip()
+
+        # 移除开头的 r (原始字符串标记)
+        if inner.startswith('r') or inner.startswith('R'):
+            inner = inner[1:]
+
+        # 提取所有字符串字面量并拼接
+        result = []
+        i = 0
+        while i < len(inner):
+            # 跳过空白
+            if inner[i].isspace():
+                i += 1
+                continue
+
+            # 检测字符串开始
+            if inner[i] in ('"', "'"):
+                quote_char = inner[i]
+                i += 1
+                string_chars = []
+
+                # 检查是否是三引号
+                if i < len(inner) - 1 and inner[i:i+2] == quote_char * 2:
+                    # 三引号
+                    i += 2
+                    while i < len(inner) - 2:
+                        if inner[i:i+3] == quote_char * 3:
+                            i += 3
+                            break
+                        elif inner[i] == '\\' and i + 1 < len(inner):
+                            string_chars.append(inner[i:i+2])
+                            i += 2
+                        else:
+                            string_chars.append(inner[i])
+                            i += 1
+                    else:
+                        # 未闭合，跳出
+                        break
+                else:
+                    # 单引号
+                    while i < len(inner):
+                        if inner[i] == quote_char:
+                            i += 1
+                            break
+                        elif inner[i] == '\\' and i + 1 < len(inner):
+                            string_chars.append(inner[i:i+2])
+                            i += 2
+                        else:
+                            string_chars.append(inner[i])
+                            i += 1
+
+                result.append(''.join(string_chars))
+            else:
+                i += 1
+
+        return ''.join(result)
+
+    def merge_translations(self):
+        """
+        步骤3: 将缓存的翻译内容覆盖到新数据中
+        """
+        print("\n" + "="*60)
+        print("步骤3: 合并已有翻译")
+        print("="*60)
+
+        # 以扫描到的国际化字符串为基础
+        merged = dict(self.scanned_i18n)
+
+        # 将缓存的翻译覆盖进去
+        for msgid, translations in self.cached_translations.items():
+            if msgid in merged:
+                # 如果该字符串在代码中存在，更新翻译
+                for lang in LANGUAGES:
+                    if lang in translations:
+                        merged[msgid][lang] = translations[lang]
+            else:
+                # 如果该字符串在代码中不存在，但仍然保留（可能是遗留的翻译）
+                merged[msgid] = {
+                    'en_US': translations.get('en_US', ''),
+                    'zh_CN': translations.get('zh_CN', ''),
+                    'zh_Hant': translations.get('zh_Hant', ''),
+                    'from_sources': {}
+                }
+
+        self.merged_translations = merged
+        print(f"合并完成，共 {len(merged)} 条翻译项")
+        print(f"其中有翻译内容的: {sum(1 for v in merged.values() if v['en_US'] or v['zh_CN'] or v['zh_Hant'])}")
+
+        return merged
+
+    def generate_po_file_content(self, lang: str, translations: Dict) -> str:
+        """
+        生成 .po 文件内容
+
+        Args:
+            lang: 语言代码 (zh_CN, zh_Hant, en_US)
+            translations: 翻译数据字典
+
+        Returns:
+            .po 文件内容字符串
+        """
+        lines = []
+
+        # 文件头
+        header = '''# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\\n"
+"Report-Msgid-Bugs-To: \\n"
+"POT-Creation-Date: 2025-06-18 17:33+0800\\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+"Language-Team: LANGUAGE <LL@li.org>\\n"
+"Language: \\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+'''
+        lines.append(header)
+
+        # 按原文排序：移除前面的空白符并转大写后排序
+        sorted_keys = sorted(translations.keys(), key=lambda x: re.sub(r'^\s+', '', x).upper())
+
+        for msgid in sorted_keys:
+            data = translations[msgid]
+
+            # 获取该语言的翻译
+            msgstr = data.get(lang, '')
+
+            # 获取来源信息
+            from_sources = data.get('from_sources')
+
+            # 无代码来源(遗留)的，说明后端源码中已经移除，所以从 django.po 文件中移除（保险起见，保留已翻译项）
+            if not KEEP_NO_SOURCE and not from_sources and not msgstr:
+                continue
+
+            if from_sources:
+                # 分组显示
+                for relative_path, line_no_list in sorted(from_sources.items()):
+                    line_no_list.sort()
+                    for line_no in line_no_list:
+                        lines.append(f"#: {relative_path}:{line_no}")
+            else:
+                lines.append("#: no source")
+
+            # 添加 msgid 和 msgstr
+            escaped_msgid = self._escape_string(msgid)
+            escaped_msgstr = self._escape_string(msgstr)
+
+            lines.append(f'msgid "{escaped_msgid}"')
+            lines.append(f'msgstr "{escaped_msgstr}"')
+            lines.append('')  # 空行分隔
+
+        return '\n'.join(lines)
+
+    def write_po_files(self):
+        """
+        步骤4: 将数据按原文排序，分别写入三个翻译文件
+        """
+        print("\n" + "="*60)
+        print("步骤4: 生成翻译文件")
+        print("="*60)
+
+        for lang in LANGUAGES:
+            po_file_path = self.locales_dir / lang / 'LC_MESSAGES' / 'django.po'
+
+            # 生成文件内容
+            content = self.generate_po_file_content(lang, self.merged_translations)
+
+            # 备份原文件
+            if BACKUP_PO:
+                backup_path = po_file_path.with_suffix('.po.bak')
+                if po_file_path.exists():
+                    import shutil
+                    shutil.copy2(po_file_path, backup_path)
+                    print(f"已备份原文件: {backup_path}")
+
+            # 写入新文件
+            with open(po_file_path, 'w', encoding='utf-8') as f:
+                f.write(content)
+
+            # 统计信息
+            translated_count = sum(1 for v in self.merged_translations.values()
+                                   if v.get(lang, ''))
+            total_count = len(self.merged_translations)
+
+            print(f"{lang}:{'  ' if len(lang) < 7 else ''} 共 {total_count} 条，已翻译 {translated_count} 条")
+
+        print("\n所有翻译文件已生成完成！！！")
+
+    def generate_report(self):
+        """
+        生成翻译报告
+        """
+        print("\n\n" + "="*60)
+        print("翻译统计报告")
+        print("="*60)
+
+        total = len(self.merged_translations)
+        en_us_translated = sum(1 for v in self.merged_translations.values() if v['en_US'])
+        zh_cn_translated = sum(1 for v in self.merged_translations.values() if v['zh_CN'])
+        zh_hant_translated = sum(1 for v in self.merged_translations.values() if v['zh_Hant'])
+        has_source = sum(1 for v in self.merged_translations.values() if v['from_sources'])
+        no_source = total - has_source
+
+        print(f"\n总翻译条目数: {total}")
+        print(f"英文已翻译: {en_us_translated} ({en_us_translated/total*100:.2f}%)")
+        print(f"简体中文已翻译: {zh_cn_translated} ({zh_cn_translated/total*100:.2f}%)")
+        print(f"繁体中文已翻译: {zh_hant_translated} ({zh_hant_translated/total*100:.2f}%)")
+        print(f"有代码来源: {has_source}")
+        print(f"无代码来源(遗留): {no_source} （可将脚本中的 `KEEP_NO_SOURCE = False` 来自动清除这些项）")
+
+        # 找出未翻译的项目示例
+        print("\n\n" + "="*60)
+        print("前10个未翻译简体中文的项目:")
+        print("="*60)
+        count = 0
+        for msgid, data in self.merged_translations.items():
+            if not data['zh_CN'] and count < 10:
+                print(f"- {msgid[:80]}{'...' if len(msgid) > 80 else ''}")
+                count += 1
+
+        # 打印简体翻译但繁体未翻译，或繁体翻译但简体未翻译的项
+        print("\n" + "="*60)
+        print("不一致翻译项（简体已翻译但繁体未翻译，或繁体已翻译但简体未翻译）:")
+        print("="*60)
+
+        simplified_only = []  # 简体已翻译但繁体未翻译
+        traditional_only = []  # 繁体已翻译但简体未翻译
+
+        for msgid, data in self.merged_translations.items():
+            has_zh_cn = bool(data['zh_CN'])
+            has_zh_hant = bool(data['zh_Hant'])
+
+            if has_zh_cn and not has_zh_hant:
+                simplified_only.append(msgid)
+            elif has_zh_hant and not has_zh_cn:
+                traditional_only.append(msgid)
+
+        if simplified_only:
+            print(f"简体已翻译但繁体未翻译 ({len(simplified_only)} 项):")
+            for i, msgid in enumerate(simplified_only[:20], 1):
+                preview = msgid[:80] + '...' if len(msgid) > 80 else msgid
+                translation = self.merged_translations[msgid]['zh_CN']
+                trans_preview = translation[:50] + '...' if len(translation) > 50 else translation
+                print(f"  {i}. 原文: {preview}")
+                print(f"     简体: {trans_preview}")
+
+            if len(simplified_only) > 20:
+                print(f"  ... 还有 {len(simplified_only) - 20} 项")
+
+        if traditional_only:
+            if simplified_only:
+                print("")  # 换行
+            print(f"繁体已翻译但简体未翻译 ({len(traditional_only)} 项):")
+            for i, msgid in enumerate(traditional_only[:20], 1):
+                preview = msgid[:80] + '...' if len(msgid) > 80 else msgid
+                translation = self.merged_translations[msgid]['zh_Hant']
+                trans_preview = translation[:50] + '...' if len(translation) > 50 else translation
+                print(f"  {i}. 原文: {preview}")
+                print(f"     繁体: {trans_preview}")
+
+            if len(traditional_only) > 20:
+                print(f"  ... 还有 {len(traditional_only) - 20} 项")
+
+        if not simplified_only and not traditional_only:
+            print("\n无不一致翻译项 ✓")
+
+    def run(self):
+        """
+        执行完整流程
+        """
+        print("开始 Django 国际化翻译文件自动化处理")
+        print(f"项目根目录: {self.base_dir}")
+
+        # 步骤1: 缓存已有翻译
+        self.cache_existing_translations()
+
+        # 步骤2: 扫描 Python 文件
+        self.extract_i18n_from_python_files()
+
+        # 步骤3: 合并翻译
+        self.merge_translations()
+
+        # 步骤4: 写入文件
+        self.write_po_files()
+
+        # 生成报告
+        self.generate_report()
+
+        print("\n" + "="*60)
+        print("处理完成！")
+        print("="*60)
+
+
+def main():
+    """主函数"""
+    # 获取当前脚本所在的项目根目录
+    # 假设脚本在项目根目录下运行
+    base_dir = Path(__file__).parent.parent.parent
+
+    # 或者可以手动指定
+    # base_dir = Path(r'E:\Workspace_Java\3rd-party\1Panel-dev\MaxKB')
+
+    print(f"使用项目根目录: {base_dir}")
+
+    # 创建工具实例并运行
+    tool = I18nAutomation(str(base_dir))
+    tool.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/apps/locales/i18n_automation.py
+++ b/apps/locales/i18n_automation.py
@@ -6,6 +6,7 @@ Django 国际化翻译文件自动化脚本
 2. 扫描所有Python文件中的国际化代码
 3. 合并已有翻译和新发现的内容
 4. 生成排序后的翻译文件
+5. 扫描所有Python文件中未使用国际化功能的代码，并写入 `not_internationalized.txt` 文件中
 """
 
 import re
@@ -38,6 +39,17 @@ KEEP_SAME_TRANSLATION = False
 # 配置4：是否备份原 django.po 文件。
 # 说明：因为有VCS，所以默认不备份。
 BACKUP_PO = False
+
+# 配置5：是否扫描未国际化的代码？
+SCAN_NOT_INTERNATIONALIZED = True
+
+# 配置6：忽略 `未国际化的代码` 数组
+NOT_INTERNATIONALIZED_IGNORE_ARRAYS = frozenset([
+    "Error: ",
+    "data: ",
+    "date: ",
+    "v: ",
+])
 
 
 class I18nAutomation:
@@ -580,6 +592,158 @@ msgstr ""
 
         print("\n所有翻译文件已生成完成！！！")
 
+    def scan_non_i18n_strings(self):
+        """
+        步骤5: 扫描 Python 文件中应该国际化但未国际化的字符串
+
+        Returns:
+            包含未国际化字符串信息的列表
+        """
+        print("\n" + "="*60)
+        print("步骤5: 扫描未国际化的字符串")
+        print("="*60)
+
+        non_i18n_list = []
+        apps_dir = self.base_dir / 'apps'
+
+        # 匹配常见的需要国际化的字符串模式
+        # 1. 用户可见的提示消息、错误消息等
+        patterns = [
+            # 匹配 raise Exception("...") 或 raise ValidationError("...") 等异常消息
+            re.compile(r'\braise\s+\w+[\w\.]*\s*\(\s*r?["\']((?:[^"\'\\]|\\.)*?)["\']', re.MULTILINE | re.DOTALL),
+            # 匹配 logger.error("..."), logger.warning("..."), logger.info("...") 等日志消息
+            re.compile(r'\blogger\.(?:error|warning|info|debug|critical)\s*\(\s*r?["\']((?:[^"\'\\]|\\.)*?)["\']', re.MULTILINE | re.DOTALL),
+            # 匹配 print("...")
+            re.compile(r'\bprint\s*\(\s*r?["\']((?:[^"\'\\]|\\.)*?)["\']', re.MULTILINE | re.DOTALL),
+            # 匹配 return "..." (常见于 API 响应消息)
+            re.compile(r'\breturn\s+r?["\']((?:[^"\'\\]|\\.)*?)["\']', re.MULTILINE | re.DOTALL),
+        ]
+
+        # 排除模式：不应该被国际化的内容
+        exclude_patterns = [
+            re.compile(r'^[a-zA-Z0-9_\-\.\/\:\{\}]+$', re.MULTILINE),  # 纯技术标识符、路径、JSON等
+            re.compile(r'^\s*$'),  # 空字符串
+            re.compile(r'^(?:[{}[\]:,.\-\s*\n<>|│├─]|%s)+$'),  # 纯标点符号
+        ]
+
+        # 递归查找所有 .py 文件
+        py_files = list(apps_dir.rglob('*.py'))
+        print(f"找到 {len(py_files)} 个 Python 文件")
+
+        scanned_count = 0
+        for py_file in py_files:
+            # 跳过 __pycache__、migrations 和 locales 目录
+            if '__pycache__' in str(py_file) or 'migrations' in str(py_file) or 'locales' in str(py_file):
+                continue
+
+            try:
+                with open(py_file, 'r', encoding='utf-8') as f:
+                    content = f.read()
+
+                file_has_non_i18n = False
+                for pattern in patterns:
+                    matches = pattern.finditer(content)
+                    for match in matches:
+                        msgid = match.group(1) if match.lastindex else None
+
+                        if msgid is None:
+                            continue
+
+                        msgid = self._unescape_string(msgid)
+
+                        # 过滤掉不应该国际化的内容
+                        if not msgid or not msgid.strip():
+                            continue
+
+                        should_exclude = False
+                        for exclude_pattern in exclude_patterns:
+                            if exclude_pattern.match(msgid):
+                                should_exclude = True
+                                break
+
+                        if should_exclude:
+                            continue
+
+                        # 检查该字符串是否已经被国际化（在已扫描的 i18n 列表中）
+                        if hasattr(self, 'scanned_i18n') and msgid in self.scanned_i18n:
+                            continue
+
+                        # 记录未国际化的字符串
+                        relative_path = str(py_file.relative_to(self.base_dir)).replace("\\", "/")
+                        line_no = content[:match.start()].count('\n') + 1
+
+                        if msgid not in NOT_INTERNATIONALIZED_IGNORE_ARRAYS:
+                            non_i18n_list.append({
+                                'file': relative_path,
+                                'line_no': line_no,
+                                'msgid': msgid
+                            })
+                            file_has_non_i18n = True
+
+                if file_has_non_i18n:
+                    scanned_count += 1
+
+            except Exception as e:
+                print(f"处理文件 {py_file} 时出错: {e}")
+
+        print(f"扫描了 {scanned_count} 个文件")
+        print(f"发现 {len(non_i18n_list)} 条未国际化的字符串")
+
+        self.non_i18n_strings = non_i18n_list
+        return non_i18n_list
+
+    def write_not_internationalized_file(self):
+        """
+        将未国际化的字符串写入 not_internationalized.txt 文件
+        """
+        print("\n" + "="*60)
+        print("步骤6: 写入 not_internationalized.txt 文件")
+        print("="*60)
+
+        output_file = self.locales_dir / 'not_internationalized.txt'
+
+        if not hasattr(self, 'non_i18n_strings'):
+            self.non_i18n_strings = []
+
+        # 按 msgid 分组，相同 msgid 的合并到一起
+        msgid_groups = {}
+        for item in self.non_i18n_strings:
+            msgid = item['msgid']
+            if msgid not in msgid_groups:
+                msgid_groups[msgid] = []
+            msgid_groups[msgid].append({
+                'file': item['file'],
+                'line_no': item['line_no']
+            })
+
+        # 按 msgid 排序
+        sorted_msgids = sorted(msgid_groups.keys(), key=lambda x: re.sub(r'^\s+', '', x).upper())
+
+        # 生成文件内容
+        lines = []
+        for msgid in sorted_msgids:
+            locations = msgid_groups[msgid]
+
+            # 对同一 msgid 的位置按文件路径和行号排序
+            locations.sort(key=lambda x: (x['file'], x['line_no']))
+
+            # 添加所有位置信息
+            for loc in locations:
+                lines.append(f"#: {loc['file']}:{loc['line_no']}")
+
+            # 添加 msgid
+            escaped_content = self._escape_string(msgid)
+            lines.append(f'msgid "{escaped_content}"')
+            lines.append('')  # 空行分隔
+
+        content = '\n'.join(lines)
+
+        # 写入文件
+        with open(output_file, 'w', encoding='utf-8') as f:
+            f.write(content)
+
+        print(f"已写入 {len(sorted_msgids)} 条未国际化字符串到: {output_file}")
+
     def generate_report(self):
         """
         生成翻译报告
@@ -676,6 +840,13 @@ msgstr ""
 
         # 步骤4: 写入文件
         self.write_po_files()
+
+        if SCAN_NOT_INTERNATIONALIZED:
+            # 步骤5: 扫描未国际化的字符串
+            self.scan_non_i18n_strings()
+
+            # 步骤6: 写入 not_internationalized.txt
+            self.write_not_internationalized_file()
 
         # 生成报告
         self.generate_report()

--- a/apps/locales/not_internationalized.txt
+++ b/apps/locales/not_internationalized.txt
@@ -1,0 +1,240 @@
+#: apps/common/management/commands/services/services/celery_base.py:16
+msgid "\n- Start Celery as Distributed Task Queue: {}"
+
+#: apps/common/management/commands/services/services/local_model.py:26
+msgid "\n- Start Gunicorn Local Model WSGI HTTP Server"
+
+#: apps/common/management/commands/services/services/gunicorn.py:17
+msgid "\n- Start Gunicorn WSGI HTTP Server"
+
+#: apps/common/management/commands/services/services/scheduler.py:17
+msgid "\n- Start Scheduler Server"
+
+#: apps/models_provider/impl/tencent_model_provider/model/llm.py:24
+msgid "All of "
+
+#: apps/common/db/compiler.py:158
+msgid "annotate() + distinct(fields) is not implemented."
+
+#: apps/chat/mcp/tools.py:18
+msgid "API Key is expired"
+
+#: apps/chat/mcp/tools.py:22
+msgid "Application is not found or not published"
+
+#: apps/oss/serializers/file.py:327
+msgid "Authentication part contains suspicious content"
+
+#: apps/knowledge/models/knowledge.py:387
+msgid "bytea参数不能为空"
+
+#: apps/ops/celery/signal_handler.py:101
+msgid "Clean period tasks: [{}]"
+
+#: apps/common/locale/manager.py:219
+msgid "Copied all locale files from admin to chat directory"
+
+#: apps/models_provider/impl/xinference_model_provider/model/embedding.py:43
+#: apps/models_provider/impl/xinference_model_provider/model/reranker.py:45
+msgid "Could not import RESTfulClient from xinference. Please install it"
+
+#: apps/models_provider/impl/tencent_model_provider/model/hunyuan.py:259
+msgid "Could not import tencentcloud python package. "
+
+#: apps/common/utils/tool_code.py:148
+msgid "Execution interrupted or tampered"
+
+#: apps/maxkb/conf.py:179
+msgid "expected at most 1 positional argument, got %d"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py:93
+msgid "Failed to generate audio"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py:87
+msgid "Failed to get audio data from response: "
+
+#: apps/common/db/compiler.py:134
+msgid "FOR NO KEY UPDATE is not supported on this "
+
+#: apps/common/db/compiler.py:130
+msgid "FOR UPDATE OF is not supported on this database backend."
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/model/stt.py:350
+msgid "format should in wav or mp3"
+
+#: apps/common/utils/common.py:393
+#: apps/tools/serializers/tool.py:125
+msgid "global "
+
+#: apps/models_provider/impl/gemini_model_provider/model/ttv.py:100
+msgid "Google API returned empty result."
+
+#: apps/application/long_term_memory/__init__.py:296
+#: apps/trigger/handler/impl/trigger/scheduled_trigger.py:17
+msgid "hour/minute out of range"
+
+#: apps/models_provider/impl/tencent_model_provider/model/hunyuan.py:253
+msgid "Hunyuan secret key is not set."
+
+#: apps/common/utils/common.py:275
+msgid "import pysilk failed, wechaty voice message will not be supported."
+
+#: apps/trigger/handler/impl/task/application_task.py:152
+msgid "Incorrect application workflow information"
+
+#: apps/ops/celery/decorator.py:53
+msgid "Interval and crontab must set one"
+
+#: apps/application/long_term_memory/__init__.py:503
+#: apps/trigger/handler/impl/trigger/scheduled_trigger.py:178
+msgid "interval_value must be positive"
+
+#: apps/chat/mcp/tools.py:16
+msgid "Invalid API Key"
+
+#: apps/application/long_term_memory/__init__.py:437
+#: apps/trigger/handler/impl/trigger/scheduled_trigger.py:115
+msgid "invalid day of month"
+
+#: apps/ops/celery/hmac_signed_serializer.py:22
+msgid "Invalid signed data packet"
+
+#: apps/oss/serializers/file.py:337
+msgid "Invalid URL: missing hostname"
+
+#: apps/application/long_term_memory/__init__.py:305
+#: apps/trigger/handler/impl/trigger/scheduled_trigger.py:25
+msgid "invalid weekday"
+
+#: apps/common/locale/config_helper.py:193
+msgid "Language cache invalidated"
+
+#: apps/common/db/compiler.py:110
+msgid "LIMIT/OFFSET is not supported with "
+
+#: apps/application/flow/step_node/mcp_node/impl/base_mcp_node.py:25
+msgid "MCP tool ID is required when mcp_source is "
+
+#: apps/models_provider/impl/minimax_model_provider/model/tts.py:75
+msgid "MiniMax TTS API returned empty audio data"
+
+#: apps/ops/celery/decorator.py:49
+msgid "Must set crontab or interval one"
+
+#: apps/common/utils/tool_code.py:151
+msgid "No result found."
+
+#: apps/ops/celery/logger.py:202
+msgid "Not found thread task file"
+
+#: apps/common/management/commands/services/hands.py:12
+msgid "Not found __version__: {}"
+
+#: apps/common/utils/common.py:246
+msgid "Not support file type: {}"
+
+#: apps/common/db/compiler.py:122
+msgid "NOWAIT is not supported on this database backend."
+
+#: apps/oss/serializers/file.py:314
+msgid "Only http and https are allowed"
+
+#: apps/ops/celery/signal_handler.py:81
+msgid "Periodic task [{}] is disabled!"
+
+#: apps/models_provider/impl/xinference_model_provider/model/embedding.py:49
+msgid "Please provide server URL"
+
+#: apps/models_provider/impl/xinference_model_provider/model/embedding.py:52
+msgid "Please provide the model UID"
+
+#: apps/common/management/commands/services/hands.py:13
+msgid "Python is: "
+
+#: apps/ops/celery/hmac_signed_serializer.py:29
+msgid "Security Alert: Task signature mismatch! Potential tampering detected."
+
+#: apps/common/db/compiler.py:102
+msgid "select_for_update cannot be used outside of a transaction."
+
+#: apps/models_provider/impl/xf_model_provider/model/stt.py:133
+msgid "sid:%s call success!,data is:%s"
+
+#: apps/common/db/compiler.py:126
+msgid "SKIP LOCKED is not supported on this database backend."
+
+#: apps/ops/celery/signal_handler.py:77
+msgid "Start need start task: [{}]"
+
+#: apps/common/management/commands/services/utils.py:63
+msgid "Start stop services"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tti.py:101
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tti.py:117
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tti.py:154
+msgid "sync_call Failed, status_code: %s, code: %s, message: %s"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:49
+msgid "Task interrupted"
+
+#: apps/oss/serializers/file.py:307
+msgid "URL contains dangerous characters"
+
+#: apps/oss/serializers/file.py:293
+msgid "URL is required"
+
+#: apps/common/locale/config_helper.py:79
+msgid "Using cached languages list"
+
+#: apps/models_provider/impl/gemini_model_provider/model/ttv.py:93
+msgid "Video generation timed out after 20 minutes"
+
+#: apps/models_provider/impl/xf_model_provider/model/stt.py:101
+#: apps/models_provider/impl/xf_model_provider/model/tts/tts.py:99
+msgid "websocket url :"
+
+#: apps/ops/celery/signal_handler.py:76
+msgid "Work ready signal recv"
+
+#: apps/ops/celery/signal_handler.py:100
+msgid "Worker shutdown signal recv"
+
+#: apps/common/management/commands/services/services/base.py:147
+msgid "\\033[31m Error\\033[0m"
+
+#: apps/common/management/commands/services/services/base.py:138
+msgid "\\033[31m No process found\\033[0m"
+
+#: apps/common/management/commands/services/services/base.py:149
+msgid "\\033[32m Ok\\033[0m"
+
+#: apps/common/db/compiler.py:37
+msgid "{} is not supported on this database backend."
+
+#: apps/trigger/handler/simple_tools.py:32
+msgid "不支持的处理器类型"
+
+#: apps/trigger/handler/simple_tools.py:45
+#: apps/trigger/handler/simple_tools.py:57
+msgid "不支持的触发器类型"
+
+#: apps/application/flow/step_node/intent_node/impl/base_intent_node.py:141
+msgid "你是一个专业的意图识别助手，请根据用户输入和意图选项，准确识别用户的真实意图。"
+
+#: apps/application/flow/step_node/search_knowledge_node/impl/base_search_knowledge_node.py:31
+msgid "关联知识库的向量模型不一致，无法召回分段。"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/ttv.py:64
+msgid "多次重试后仍无法连接到 DashScope API，请检查代理或网络配置"
+
+#: apps/models_provider/impl/minimax_model_provider/model/ttv.py:76
+msgid "多次重试后仍无法连接到 MiniMax API，请检查代理或网络配置"
+
+#: apps/common/log/log.py:81
+msgid "操作菜单"
+
+#: apps/application/flow/step_node/search_knowledge_node/impl/base_search_knowledge_node.py:33
+msgid "知识库设置错误,请重新设置知识库"
+
+#: apps/models_provider/impl/xf_model_provider/model/zh_en_stt.py:110
+msgid "连接成功"

--- a/apps/locales/zh_CN/LC_MESSAGES/django.po
+++ b/apps/locales/zh_CN/LC_MESSAGES/django.po
@@ -16,4850 +16,1422 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: apps/application/api/application_api.py:21
-#: apps/application/serializers/application.py:153
-msgid "Workflow Objects"
-msgstr "工作流对象"
 
-#: apps/application/api/application_api.py:52
-#: apps/application/api/application_chat.py:104
-#: apps/application/api/application_chat_record.py:74
-#: apps/role_setting/api/role_setting.py:171 apps/shared/api/shared_tool.py:79
-#: apps/shared/api/shared_tool.py:119 apps/workspace/api/workspace.py:110
-#: apps/xpack/api/user_group.py:61
-msgid "Current page"
-msgstr "当前页"
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:39
+msgid "%(key)s is required"
+msgstr ""
 
-#: apps/application/api/application_api.py:59
-#: apps/application/api/application_chat.py:111
-#: apps/application/api/application_chat_record.py:81
-#: apps/role_setting/api/role_setting.py:178 apps/shared/api/shared_tool.py:86
-#: apps/shared/api/shared_tool.py:126 apps/workspace/api/workspace.py:117
-#: apps/xpack/api/user_group.py:68
-msgid "Page size"
-msgstr "每页大小"
+#: apps/trigger/serializers/trigger.py:446
+msgid "%s id does not exist"
+msgstr "%s id 不存在"
 
-#: apps/application/api/application_api.py:66
-#: apps/application/serializers/application.py:156
-#: apps/application/serializers/application.py:195
-#: apps/application/serializers/application.py:274
-#: apps/folders/serializers/folder.py:97 apps/folders/serializers/folder.py:139
-#: apps/knowledge/serializers/knowledge.py:52
-#: apps/knowledge/serializers/knowledge.py:59
-#: apps/tools/serializers/tool.py:453
-#: apps/xpack/serializers/dataset_lark_serializer.py:55
-msgid "folder id"
-msgstr "文件夹 ID"
+#: apps/knowledge/serializers/knowledge.py:324
+msgid "%s must be a boolean"
+msgstr ""
 
-#: apps/application/api/application_api.py:73
-#: apps/application/serializers/application.py:149
-#: apps/application/serializers/application.py:275
-#: apps/application/serializers/application.py:282
-#: apps/application/serializers/application.py:368
-#| msgid "Application"
-msgid "Application Name"
-msgstr "智能体名称"
+#: apps/trigger/serializers/trigger.py:69
+#: apps/trigger/serializers/trigger.py:92
+msgid "%s must be a dict"
+msgstr "%s 必须是字典类型"
 
-#: apps/application/api/application_api.py:80
-#: apps/application/serializers/application.py:152
-#: apps/application/serializers/application.py:276
-#: apps/application/serializers/application.py:283
-#: apps/application/serializers/application.py:284
-#: apps/application/serializers/application.py:370
-#| msgid "Application/Version"
-msgid "Application Description"
-msgstr "智能体描述"
+#: apps/trigger/serializers/trigger.py:132
+msgid "%s must be an array"
+msgstr "%s 必须是数组类型"
 
-#: apps/application/api/application_api.py:87
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:78
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:30
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:47
-#: apps/application/serializers/application.py:99
-#: apps/application/serializers/application.py:277
-#: apps/application/serializers/application.py:295
-#: apps/application/serializers/application.py:413
-#: apps/application/serializers/application.py:540
-#: apps/role_setting/api/role_setting.py:144 apps/tools/serializers/tool.py:357
-#: apps/tools/serializers/tool.py:390 apps/users/api/user.py:52
-#: apps/users/api/user.py:110 apps/users/api/user.py:126
-#: apps/users/serializers/user.py:325 apps/workspace/api/workspace.py:82
-#: apps/workspace/serializers/workspace_serializers.py:270
-#: apps/workspace/serializers/workspace_serializers.py:306
-#: apps/xpack/api/chat_user.py:49 apps/xpack/api/chat_user.py:92
-#: apps/xpack/serializers/chat_user.py:301
-msgid "User ID"
-msgstr "用户 ID"
+#: apps/trigger/serializers/trigger.py:135
+msgid "%s must not be empty"
+msgstr "%s 不能为空"
 
-#: apps/application/api/application_chat.py:70
-#: apps/application/serializers/application_chat.py:56
-msgid "Minimum number of likes"
-msgstr "最小点赞数"
+#: apps/trigger/serializers/trigger.py:125
+msgid "%s type requires %s field"
+msgstr "%s 类型需要 %s 字段"
 
-#: apps/application/api/application_chat.py:76
-#: apps/application/serializers/application_chat.py:58
-msgid "Minimum number of clicks"
-msgstr "最小点击数"
+#: apps/trigger/serializers/trigger.py:146
+msgid "%s values must be between %s and %s"
+msgstr "%s 的值必须在 %s 到 %s 之间"
 
-#: apps/application/api/application_chat.py:82
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:18
-#: apps/application/serializers/application_chat.py:59
-msgid "Comparator"
-msgstr "比较器"
-
-#: apps/application/api/application_chat_record.py:46
-#: apps/application/api/application_chat_record.py:115
-#: apps/application/serializers/application_chat.py:47
-#: apps/application/serializers/application_chat_record.py:76
-#| msgid "Chat"
-msgid "Chat ID"
-msgstr "对话 ID"
-
-#: apps/application/api/application_chat_record.py:53
-#: apps/application/serializers/application_chat_record.py:77
-msgid "Is it in order"
-msgstr "是否有序"
-
-#: apps/application/api/application_chat_record.py:122
-msgid "Chat Record ID"
-msgstr "对话记录 ID"
-
-#: apps/application/api/application_chat_record.py:129
-#: apps/shared/api/shared_knowledge.py:235
-#: apps/shared/api/shared_knowledge.py:256 apps/xpack/api/knowledge_lark.py:47
-#: apps/xpack/api/knowledge_lark.py:79 apps/xpack/api/knowledge_lark.py:111
-#| msgid "Knowledge"
-msgid "Knowledge ID"
-msgstr "知识库 ID"
-
-#: apps/application/api/application_chat_record.py:136
-#: apps/shared/api/shared_knowledge.py:263 apps/xpack/api/knowledge_lark.py:86
-#| msgid "Document"
-msgid "Document ID"
-msgstr "文档 ID"
-
-#: apps/application/api/application_chat_record.py:148
-#| msgid "Paragraph list"
-msgid "Paragraph ID"
-msgstr "段落 ID"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:26
-#| msgid "type error"
-msgid "Model type error"
-msgstr "模型类型错误"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:36
-#: apps/common/field/common.py:24 apps/common/field/common.py:37
-#| msgid "type error"
-msgid "Message type error"
-msgstr "消息类型错误"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:55
-#| msgid "Question list"
-msgid "Conversation list"
-msgstr "对话列表"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:56
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:29
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:18
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:12
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:13
-#: apps/application/flow/step_node/question_node/i_question_node.py:18
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:12
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:13
-#: apps/application/serializers/application.py:101
-#: apps/application/serializers/application.py:285
-#: apps/knowledge/serializers/common.py:71 apps/shared/api/shared_model.py:76
-#: apps/shared/api/shared_model.py:98
-msgid "Model id"
-msgstr "模型ID"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:58
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:29
-#| msgid "Paragraph list"
-msgid "Paragraph List"
-msgstr "段落列表"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:60
-#: apps/application/serializers/application_chat.py:182
-#: apps/application/serializers/application_chat_record.py:41
-#: apps/application/serializers/application_chat_record.py:140
-#: apps/application/serializers/application_chat_record.py:179
-#: apps/application/serializers/application_chat_record.py:247
-#: apps/application/serializers/application_chat_record.py:312
-#: apps/chat/serializers/chat.py:98 apps/chat/serializers/chat.py:114
-#| msgid "User relation ID"
-msgid "Conversation ID"
-msgstr "对话 ID"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:62
-#: apps/application/flow/step_node/application_node/i_application_node.py:14
-#: apps/application/serializers/application_chat.py:182
-#: apps/chat/serializers/chat.py:40
-#| msgid "Question list"
-msgid "User Questions"
-msgstr "用户问题"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:65
-msgid "Post-processor"
-msgstr "后置处理器"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:68
-#| msgid "Create question"
-msgid "Completion Question"
-msgstr "完成问题"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:70
-msgid "Streaming Output"
-msgstr "流式输出"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:71
-#: apps/xpack/serializers/resource_chat_user.py:93
-#| msgid "user id"
-msgid "Chat user id"
-msgstr "对话用户 ID"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:73
-#| msgid "Create user"
-msgid "Chat user Type"
-msgstr "对话用户类型"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:76
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:47
-msgid "No reference segment settings"
-msgstr "无参考段设置"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:81
-msgid "Model settings"
-msgstr "模型设置"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:84
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:29
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:29
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:28
-#: apps/application/flow/step_node/question_node/i_question_node.py:29
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:20
-msgid "Model parameter settings"
-msgstr "模型参数设置"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:91
-msgid "message type error"
-msgstr "消息类型错误"
-
-#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:224
-#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:270
-msgid ""
-"Sorry, the AI model is not configured. Please go to the application to set "
-"up the AI model first."
-msgstr "抱歉，AI 模型未配置，请先前往智能体设置 AI 模型。"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:26
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:24
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:24
-#: apps/application/serializers/application_chat_record.py:172
-msgid "question"
-msgstr "问题"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:32
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:27
-msgid "History Questions"
-msgstr "历史问题"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:34
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:23
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:20
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:18
-#: apps/application/flow/step_node/question_node/i_question_node.py:24
-msgid "Number of multi-round conversations"
-msgstr "多轮对话的数量"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:37
-msgid "Maximum length of the knowledge base paragraph"
-msgstr "知识库段落的最大长度"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:39
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:21
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:16
-#: apps/application/flow/step_node/question_node/i_question_node.py:21
-#: apps/application/serializers/application.py:79
-#: apps/application/serializers/application.py:124
-#: apps/knowledge/serializers/common.py:72
-msgid "Prompt word"
-msgstr "提示词"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:41
-msgid "System prompt words (role)"
-msgstr "系统提示词（角色）"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:44
-msgid "Completion problem"
-msgstr "完成问题"
-
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:32
-#: apps/application/serializers/application.py:215
-msgid "Question completion prompt"
-msgstr "问题完成提示"
-
-#: apps/application/chat_pipeline/step/reset_problem_step/impl/base_reset_problem_step.py:20
-#: apps/application/serializers/common.py:87
-#, python-brace-format
-msgid ""
-"() contains the user's question. Answer the guessed user's question based on "
-"the context ({question}) Requirement: Output a complete question and put it "
-"in the <data></data> tag"
+#: apps/application/chat_pipeline/step/reset_problem_step/impl/base_reset_problem_step.py:19
+#: apps/application/serializers/common.py:233
+msgid "() contains the user's question. Answer the guessed user's question based on the context ({question}) Requirement: Output a complete question and put it in the <data></data> tag"
 msgstr " () 包含用户的问题。根据上下文（{question}）要求：输出一个完整的问题并提出在<data></data>标签中"
 
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:27
-msgid "System completes question text"
-msgstr "系统完成问题文本"
+#: no source
+msgid "\n ------------\n[To be continued, reply \"Continue to answer the question]"
+msgstr "\n------------\n[待续，回复 \"继续回答问题]"
 
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:30
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:39
-msgid "Dataset id list"
-msgstr "知识库 ID 列表"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:33
-msgid "List of document ids to exclude"
-msgstr "排除的文档 ID 列表"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:36
-msgid "List of exclusion vector ids"
-msgstr "排除的向量 ID 列表"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:39
-#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:21
-#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:24
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:24
-#: apps/application/serializers/application.py:84
-#: apps/application/serializers/application_chat.py:185
-msgid "Reference segment number"
-msgstr "引用分段数"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:42
-msgid "Similarity"
-msgstr "相似度"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:45
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:30
-#: apps/application/serializers/application.py:91
-#: apps/knowledge/serializers/knowledge.py:100
-#: apps/knowledge/serializers/knowledge.py:643
-msgid "The type only supports embedding|keywords|blend"
-msgstr "类型仅支持嵌入|关键字|混合"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:46
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:31
-#: apps/application/serializers/application.py:92
-msgid "Retrieval Mode"
-msgstr "检索模式"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:31
-#: apps/application/serializers/application.py:113
-#: apps/application/serializers/application.py:657
-#: apps/application/serializers/application.py:664
-#: apps/application/serializers/application.py:671
-#: apps/knowledge/serializers/document.py:643
-#: apps/knowledge/serializers/knowledge.py:220
-#: apps/models_provider/serializers/model_serializer.py:116
-#: apps/models_provider/serializers/model_serializer.py:134
-#: apps/models_provider/serializers/model_serializer.py:370
-#: apps/models_provider/tools.py:111 apps/shared/serializers/shared_model.py:32
-#: apps/shared/serializers/shared_model.py:65
-#: apps/shared/serializers/shared_model.py:82
-msgid "Model does not exist"
-msgstr "模型不存在"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:33
-msgid "No permission to use this model {model_name}"
-msgstr "无权限使用此模型{model_name}"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:42
-msgid ""
-"The vector model of the associated knowledge base is inconsistent and the "
-"segmentation cannot be recalled."
-msgstr "关联的知识库的向量模型不一致，无法回调分段。"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:44
-msgid "The knowledge base setting is wrong, please reset the knowledge base"
-msgstr "知识库设置错误，请重置知识库"
-
-#: apps/application/flow/common.py:206
-#, python-brace-format
-msgid "The branch {branch} of the {node} node needs to be connected"
-msgstr "需要连接 {node} 节点的 {branch} 分支"
-
-#: apps/application/flow/common.py:212
-#, python-brace-format
-msgid "{node} Nodes cannot be considered as end nodes"
-msgstr "{node} 节点不能被视为结束节点"
-
-#: apps/application/flow/common.py:226
-msgid "The starting node is required"
-msgstr "开始节点是必需的"
-
-#: apps/application/flow/common.py:228
-msgid "There can only be one starting node"
-msgstr "只能有一个开始节点"
-
-#: apps/application/flow/common.py:236
-msgid "The node {node} model does not exist"
-msgstr "节点 {node} 模型不存在"
-
-#: apps/application/flow/common.py:246
-#, python-brace-format
-msgid "Node {node} is unavailable"
-msgstr "节点 {node} 不可用"
-
-#: apps/application/flow/common.py:252
-#, python-brace-format
-msgid "The library ID of node {node} cannot be empty"
-msgstr "工具库 ID {node} 不能为空"
-
-#: apps/application/flow/common.py:255
-#, python-brace-format
-msgid "The function library for node {node} is not available"
-msgstr "工具库 {node} 不可用"
-
-#: apps/application/flow/common.py:261
-msgid "Basic information node is required"
-msgstr "基本信息节点是必需的"
-
-#: apps/application/flow/common.py:263
-msgid "There can only be one basic information node"
-msgstr "只能有一个基本信息节点"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:20
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:15
-#: apps/application/flow/step_node/question_node/i_question_node.py:20
-#: apps/users/api/user.py:35 apps/users/api/user.py:102
-msgid "Role Setting"
-msgstr "角色设置"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:26
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:25
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:30
-#: apps/application/flow/step_node/function_node/i_function_node.py:48
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:26
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:23
-#: apps/application/flow/step_node/question_node/i_question_node.py:27
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:15
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:16
-msgid "Whether to return content"
-msgstr "是否返回内容"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:33
-msgid "Context Type"
-msgstr "上下文类型"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:35
-msgid "Whether to enable MCP"
-msgstr "是否启用 MCP"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:36
-msgid "MCP Server"
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:43
+msgid "1 as default"
 msgstr ""
 
-#: apps/application/flow/step_node/application_node/i_application_node.py:12
-#: apps/application/serializers/application.py:539
-#: apps/application/serializers/application_access_token.py:44
-#: apps/application/serializers/application_chat.py:38
-#: apps/application/serializers/application_chat.py:54
-#: apps/application/serializers/application_chat_record.py:43
-#: apps/application/serializers/application_chat_record.py:75
-#: apps/application/serializers/application_stats.py:35
-#: apps/application/serializers/application_version.py:21
-#: apps/application/serializers/application_version.py:67
-#: apps/chat/serializers/chat.py:118
-#: apps/chat/serializers/chat_authentication.py:80
-#: apps/xpack/api/application_setting.py:31 apps/xpack/api/platform.py:29
-#: apps/xpack/api/platform.py:70
-msgid "Application ID"
-msgstr "智能体 ID"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:15
-msgid "API Input Fields"
-msgstr "API 输入字段"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:17
-msgid "User Input Fields"
-msgstr "用户输入字段"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:18
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:25
-#: apps/chat/serializers/chat.py:57 apps/tools/serializers/tool.py:391
-msgid "picture"
-msgstr "图片"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:19
-#: apps/application/flow/step_node/document_extract_node/i_document_extract_node.py:12
-#: apps/chat/serializers/chat.py:58
-msgid "document"
-msgstr "文档"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:20
-#: apps/chat/serializers/chat.py:59
-msgid "Audio"
-msgstr "音频"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:22
-#: apps/chat/serializers/chat.py:62
-msgid "Child Nodes"
-msgstr "子节点"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:23
-#: apps/application/flow/step_node/form_node/i_form_node.py:21
-msgid "Form Data"
-msgstr "表单数据"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:57
-msgid ""
-"Parameter value error: The uploaded document lacks file_id, and the document "
-"upload fails"
-msgstr "参数值错误：上传的文档缺少 file_id，文档上传失败"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:66
-msgid ""
-"Parameter value error: The uploaded image lacks file_id, and the image "
-"upload fails"
-msgstr "参数值错误：上传的图片缺少 file_id，图片上传失败"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:76
-msgid ""
-"Parameter value error: The uploaded audio lacks file_id, and the audio "
-"upload fails."
-msgstr "参数值错误：上传的音频缺少 file_id，音频上传失败"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:19
-#: apps/models_provider/api/provide.py:24
-msgid "value"
-msgstr "值"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:20
-msgid "Fields"
-msgstr "字段"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:24
-msgid "Branch id"
-msgstr "分支 ID"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:25
-msgid "Branch Type"
-msgstr "分支类型"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:26
-msgid "Condition or|and"
-msgstr "条件 或|与"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:20
-msgid "Response Type"
-msgstr "响应类型"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:21
-#: apps/application/flow/step_node/variable_assign_node/i_variable_assign_node.py:13
-msgid "Reference Field"
-msgstr "引用字段"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:23
-msgid "Direct answer content"
-msgstr "直接回答内容"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:31
-msgid "Reference field cannot be empty"
-msgstr "引用字段不能为空"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:33
-msgid "Reference field error"
-msgstr "引用字段错误"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:36
-msgid "Content cannot be empty"
-msgstr "内容不能为空"
-
-#: apps/application/flow/step_node/form_node/i_form_node.py:19
-msgid "Form Configuration"
-msgstr "表单配置"
-
-#: apps/application/flow/step_node/form_node/i_form_node.py:20
-msgid "Form output content"
-msgstr "表单输出内容"
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:22
-#: apps/application/flow/step_node/function_node/i_function_node.py:24
-msgid "Variable Name"
-msgstr "变量名称"
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:23
-#: apps/application/flow/step_node/function_node/i_function_node.py:34
-msgid "Variable Value"
-msgstr "变量名称"
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:27
-msgid "Library ID"
-msgstr "工具 ID"
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:36
-msgid "The function has been deleted"
-msgstr "工具已被删除"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:43
-msgid "Field: {name} No value set"
-msgstr "字段：{name} 未设置值"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:59
-msgid "Field: {name} Type: {_type} Value: {value} Unsupported this type"
-msgstr "字段：{name} 类型：{_type} 值：{value} 不支持该类型"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:63
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:100
-msgid "Field: {name} Type: {_type} Value: {value} Type error"
-msgstr "字段：{name} 类型：{_type} 值：{value} 类型转换错误"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:91
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:96
-#: apps/tools/serializers/tool.py:254 apps/tools/serializers/tool.py:259
-msgid "type error"
-msgstr "类型错误"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:106
-#: apps/tools/serializers/tool.py:398
-msgid "Function does not exist"
-msgstr "工具不存在"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:108
-msgid "No permission to use this function {name}"
-msgstr "无权限使用此工具 {name}"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:110
-#, python-brace-format
-msgid "Function {name} is unavailable"
-msgstr "工具 {name} 不可用"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:25
-msgid "Is this field required"
-msgstr "{keys} 是必填项"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:26
-#: apps/knowledge/serializers/document.py:203
-#: apps/tools/serializers/tool.py:120
-msgid "type"
-msgstr "类型"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:28
-msgid "The field only supports string|int|dict|array|float"
-msgstr "字段仅支持字符串|整数|字典|数组|浮点数"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:30
-#: apps/folders/serializers/folder.py:106
-#: apps/folders/serializers/folder.py:141
-#: apps/folders/serializers/folder.py:196 apps/tools/serializers/tool.py:124
-msgid "source"
-msgstr "来源"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:32
-#: apps/tools/serializers/tool.py:126
-msgid "The field only supports custom|reference"
-msgstr "字段仅支持自定义|引用"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:40
-msgid "{field}, this field is required."
-msgstr "{field} 字段是必填项"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:46
-msgid "function"
-msgstr "工具内容"
-
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:14
-msgid "Prompt word (positive)"
-msgstr "提示词 (正向)"
-
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:16
-msgid "Prompt word (negative)"
-msgstr "提示词 (负向)"
-
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:23
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:20
-msgid "Conversation storage type"
-msgstr "对话存储类型"
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:13
-msgid "Mcp servers"
-msgstr ""
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:16
-msgid "Mcp server"
-msgstr ""
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:18
-msgid "Mcp tool"
-msgstr "Mcp 工具"
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:21
-msgid "Tool parameters"
-msgstr "工具参数"
-
-#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:26
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:33
-msgid "Maximum number of words in a quoted segment"
-msgstr "引用段落的最大字数"
-
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:27
-#: apps/knowledge/serializers/knowledge.py:97
-#: apps/knowledge/serializers/knowledge.py:640
-msgid "similarity"
-msgstr "相似度"
-
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:18
-msgid "The audio file cannot be empty"
-msgstr "音频文件不能为空"
-
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:33
-msgid ""
-"Parameter value error: The uploaded audio lacks file_id, and the audio "
-"upload fails"
-msgstr "参数错误：上传的音频缺少 file_id，音频上传失败"
-
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:18
-msgid "Text content"
-msgstr "文本内容"
-
-#: apps/application/models/application_chat.py:79
-#: apps/xpack/serializers/channel/chat_manage.py:94
-#: apps/xpack/serializers/channel/chat_manage.py:152
-msgid ""
-"Sorry, no relevant content was found. Please re-describe your problem or "
-"provide more information. "
-msgstr "不好意思，没有找到相关内容。请重新描述您的问题或提供更多信息。"
-
-#: apps/application/serializers/application.py:78
-msgid "No reference status"
-msgstr "无参考状态"
-
-#: apps/application/serializers/application.py:86
-msgid "Acquaintance"
-msgstr "相似度"
-
-#: apps/application/serializers/application.py:88
-msgid "Maximum number of quoted characters"
-msgstr "引用字符的最大数量"
-
-#: apps/application/serializers/application.py:95
-msgid "Segment settings not referenced"
-msgstr "引用段设置未引用"
-
-#: apps/application/serializers/application.py:104
-#: apps/application/serializers/application_chat_record.py:176
-#: apps/application/serializers/application_chat_record.py:252
-#: apps/application/serializers/application_chat_record.py:317
-msgid "Knowledge base id"
-msgstr "知识库"
-
-#: apps/application/serializers/application.py:105
-msgid "Knowledge Base List"
-msgstr "知识库列表"
-
-#: apps/application/serializers/application.py:119
-msgid "The knowledge base id does not exist"
-msgstr "知识库 ID 不存在"
-
-#: apps/application/serializers/application.py:126
-msgid "Role prompts"
-msgstr "角色提示"
-
-#: apps/application/serializers/application.py:128
-msgid "No citation segmentation prompt"
-msgstr "无引用段落提示"
-
-#: apps/application/serializers/application.py:130
-msgid "Thinking process switch"
-msgstr "思考过程开关"
-
-#: apps/application/serializers/application.py:134
-msgid "The thinking process begins to mark"
-msgstr "思考过程开始标记"
-
-#: apps/application/serializers/application.py:138
-msgid "End of thinking process marker"
-msgstr "思考过程结束标记"
-
-#: apps/application/serializers/application.py:155
-#: apps/application/serializers/application.py:203
-#: apps/application/serializers/application.py:378
-msgid "Opening remarks"
-msgstr "开始提示"
-
-#: apps/application/serializers/application.py:191
-msgid "application name"
-msgstr "智能体名称"
-
-#: apps/application/serializers/application.py:194
-msgid "application describe"
-msgstr "智能体描述"
-
-#: apps/application/serializers/application.py:197
-#: apps/application/serializers/application.py:372
-#: apps/common/constants/permission_constants.py:226
-#: apps/common/constants/permission_constants.py:259
-#: apps/common/constants/permission_constants.py:264
-#: apps/models_provider/views/model.py:63
-#: apps/models_provider/views/model.py:95
-#: apps/models_provider/views/model.py:113
-#: apps/models_provider/views/model.py:130
-#: apps/models_provider/views/model.py:145
-#: apps/models_provider/views/model.py:160
-#: apps/models_provider/views/model.py:173
-#: apps/models_provider/views/model.py:194
-#: apps/models_provider/views/model.py:210
-#: apps/models_provider/views/model_apply.py:29
-#: apps/models_provider/views/model_apply.py:41
-#: apps/models_provider/views/model_apply.py:53
-#: apps/models_provider/views/provide.py:25
-#: apps/models_provider/views/provide.py:48
-#: apps/models_provider/views/provide.py:62
-#: apps/models_provider/views/provide.py:80
-#: apps/models_provider/views/provide.py:97
-msgid "Model"
-msgstr "模型"
-
-#: apps/application/serializers/application.py:201
-#: apps/application/serializers/application.py:376
-msgid "Historical chat records"
-msgstr "历史聊天记录"
-
-#: apps/application/serializers/application.py:206
-#: apps/application/serializers/application.py:380
-msgid "Related Knowledge Base"
-msgstr "相关知识库"
-
-#: apps/application/serializers/application.py:213
-#: apps/application/serializers/application.py:390
-msgid "Question completion"
-msgstr "问题完成"
-
-#: apps/application/serializers/application.py:217
-msgid "Application Type"
-msgstr "智能体类型"
-
-#: apps/application/serializers/application.py:221
-msgid "Application type only supports SIMPLE|WORK_FLOW"
-msgstr "智能体类型仅支持 SIMPLE|WORK_FLOW"
-
-#: apps/application/serializers/application.py:226
-#: apps/application/serializers/application.py:394
-msgid "Model parameters"
-msgstr "模型参数"
-
-#: apps/application/serializers/application.py:228
-#: apps/application/serializers/application.py:396
-msgid "Voice playback enabled"
-msgstr "开启语音播放"
-
-#: apps/application/serializers/application.py:230
-#: apps/application/serializers/application.py:398
-msgid "Voice playback model ID"
-msgstr "语音播放模型 ID"
-
-#: apps/application/serializers/application.py:232
-#: apps/application/serializers/application.py:400
-msgid "Voice playback type"
-msgstr "语音播放类型"
-
-#: apps/application/serializers/application.py:234
-#: apps/application/serializers/application.py:402
-msgid "Voice playback autoplay"
-msgstr "自动播放语音"
-
-#: apps/application/serializers/application.py:236
-#: apps/application/serializers/application.py:404
-msgid "Voice recognition enabled"
-msgstr "开启语音识别"
-
-#: apps/application/serializers/application.py:238
-#: apps/application/serializers/application.py:406
-msgid "Speech recognition model ID"
-msgstr "语音识别模型 ID"
-
-#: apps/application/serializers/application.py:240
-#: apps/application/serializers/application.py:408
-msgid "Voice recognition automatic transmission"
-msgstr "语音识别自动播放"
-
-#: apps/application/serializers/application.py:281
-msgid "Primary key id"
-msgstr ""
-
-#: apps/application/serializers/application.py:286
-msgid "Application type"
-msgstr "智能体类型"
-
-#: apps/application/serializers/application.py:287
-#: apps/xpack/serializers/resource_chat_user.py:34
-#: apps/xpack/serializers/resource_chat_user.py:110
-#: apps/xpack/serializers/resource_chat_user_group.py:17
-#: apps/xpack/serializers/resource_chat_user_group.py:85
-msgid "Resource type"
-msgstr "资源类型"
-
-#: apps/application/serializers/application.py:288
-msgid "Affiliation user"
-msgstr "关联用户"
-
-#: apps/application/serializers/application.py:289
-msgid "Creation time"
-msgstr "创建时间"
-
-#: apps/application/serializers/application.py:290
-msgid "Modification time"
-msgstr "修改时间"
-
-#: apps/application/serializers/application.py:294
-#: apps/application/serializers/application_chat_record.py:42
-#: apps/application/serializers/application_chat_record.py:323
-#: apps/application/serializers/application_version.py:40
-#: apps/chat/serializers/chat.py:318 apps/role_setting/api/role_setting.py:147
-#: apps/users/api/user.py:64 apps/users/api/user.py:170
-#: apps/workspace/api/workspace.py:46 apps/workspace/api/workspace.py:66
-#: apps/workspace/api/workspace.py:85 apps/workspace/api/workspace.py:103
-#: apps/workspace/serializers/workspace_serializers.py:239
-#: apps/xpack/api/application_setting.py:24 apps/xpack/api/knowledge_lark.py:40
-#: apps/xpack/api/knowledge_lark.py:72 apps/xpack/api/knowledge_lark.py:104
-#: apps/xpack/api/platform.py:22 apps/xpack/api/platform.py:63
-msgid "Workspace ID"
-msgstr "工作空间 ID"
-
-#: apps/application/serializers/application.py:363
-#: apps/knowledge/serializers/document.py:157
-#: apps/knowledge/serializers/document.py:162 apps/oss/serializers/file.py:57
-#: apps/tools/serializers/tool.py:356
-msgid "file"
-msgstr "文件"
-
-#: apps/application/serializers/application.py:384
-msgid "Dataset settings"
-msgstr "知识库设置"
-
-#: apps/application/serializers/application.py:387
-msgid "Model setup"
-msgstr "模型设置"
-
-#: apps/application/serializers/application.py:391
-msgid "Icon"
-msgstr ""
-
-#: apps/application/serializers/application.py:412
-#: apps/application/serializers/application_api_key.py:33
-#: apps/application/serializers/application_api_key.py:64
-#: apps/folders/serializers/folder.py:101
-#: apps/folders/serializers/folder.py:140
-#: apps/folders/serializers/folder.py:195
-#: apps/knowledge/serializers/document.py:253
-#: apps/knowledge/serializers/document.py:347
-#: apps/knowledge/serializers/document.py:408
-#: apps/knowledge/serializers/document.py:502
-#: apps/knowledge/serializers/document.py:736
-#: apps/knowledge/serializers/document.py:888
-#: apps/knowledge/serializers/document.py:963
-#: apps/knowledge/serializers/document.py:983
-#: apps/knowledge/serializers/document.py:1166
-#: apps/knowledge/serializers/knowledge.py:208
-#: apps/knowledge/serializers/knowledge.py:448
-#: apps/knowledge/serializers/knowledge.py:557
-#: apps/knowledge/serializers/knowledge.py:635
-#: apps/knowledge/serializers/paragraph.py:134
-#: apps/knowledge/serializers/paragraph.py:346
-#: apps/knowledge/serializers/paragraph.py:438
-#: apps/knowledge/serializers/paragraph.py:558
-#: apps/knowledge/serializers/problem.py:176
-#: apps/knowledge/serializers/problem.py:204
-#: apps/models_provider/api/model.py:30 apps/models_provider/api/model.py:86
-#: apps/models_provider/api/model.py:99
-#: apps/models_provider/serializers/model_serializer.py:259
-#: apps/models_provider/serializers/model_serializer.py:323
-#: apps/models_provider/serializers/model_serializer.py:392
-#: apps/shared/api/shared_knowledge.py:131
-#: apps/shared/api/shared_knowledge.py:164 apps/shared/api/shared_tool.py:60
-#: apps/shared/api/shared_tool.py:147
-#: apps/shared/serializers/shared_knowledge.py:61
-#: apps/shared/serializers/shared_knowledge.py:109
-#: apps/shared/serializers/shared_knowledge.py:157
-#: apps/shared/serializers/shared_model.py:110
-#: apps/shared/serializers/shared_tool.py:45
-#: apps/shared/serializers/shared_tool.py:86
-#: apps/system_manage/serializers/user_resource_permission.py:74
-#: apps/tools/serializers/tool.py:188 apps/tools/serializers/tool.py:210
-#: apps/tools/serializers/tool.py:268 apps/tools/serializers/tool.py:358
-#: apps/tools/serializers/tool.py:389 apps/tools/serializers/tool.py:425
-#: apps/tools/serializers/tool.py:452
-#: apps/xpack/serializers/dataset_lark_serializer.py:45
-#: apps/xpack/serializers/resource_chat_user.py:33
-#: apps/xpack/serializers/resource_chat_user.py:109
-#: apps/xpack/serializers/resource_chat_user_group.py:16
-#: apps/xpack/serializers/resource_chat_user_group.py:84
-msgid "workspace id"
-msgstr "工作空间ID"
-
-#: apps/application/serializers/application.py:459
-msgid ""
-"The community version supports up to 5 applications. If you need more "
-"applications, please contact us (https://fit2cloud.com/)."
-msgstr ""
-"社区版支持最多5个智能体，如需更多智能体，请联系我们（https://fit2cloud.com/）。"
-
-#: apps/application/serializers/application.py:471
-#: apps/common/handle/impl/qa/zip_parse_qa_handle.py:56
-#: apps/common/handle/impl/text/zip_split_handle.py:69
-#: apps/knowledge/serializers/document.py:864
-#: apps/knowledge/serializers/document.py:871
-#: apps/tools/serializers/tool.py:370
-msgid "Unsupported file format"
-msgstr "不支持的文件格式"
-
-#: apps/application/serializers/application.py:545
-msgid "Application id does not exist"
-msgstr "智能体 ID 不存在"
-
-#: apps/application/serializers/application.py:591
-msgid "work_flow is a required field"
-msgstr "工作流是必填字段"
-
-#: apps/application/serializers/application.py:695
-msgid "Unknown knowledge base id {dataset_id}, unable to associate"
-msgstr "未知知识库 ID {dataset_id}，无法关联"
-
-#: apps/application/serializers/application_access_token.py:24
-msgid "Reset Token"
-msgstr "重置令牌"
-
-#: apps/application/serializers/application_access_token.py:25
-msgid "Is it enabled"
-msgstr "是否开启"
-
-#: apps/application/serializers/application_access_token.py:28
-msgid "Number of visits"
-msgstr "访问次数"
-
-#: apps/application/serializers/application_access_token.py:30
-msgid "Whether to enable whitelist"
-msgstr "是否启用白名单"
-
-#: apps/application/serializers/application_access_token.py:32
-#: apps/application/serializers/application_access_token.py:33
-msgid "Whitelist"
-msgstr "白名单"
-
-#: apps/application/serializers/application_access_token.py:35
-msgid "Whether to display knowledge sources"
-msgstr "是否展示知识来源"
-
-#: apps/application/serializers/application_access_token.py:37
-#: apps/users/serializers/user.py:665
-#: apps/xpack/serializers/application_setting_serializer.py:37
-msgid "language"
-msgstr "语言"
-
-#: apps/application/serializers/application_api_key.py:21
-msgid "Availability"
-msgstr "可用"
-
-#: apps/application/serializers/application_api_key.py:24
-msgid "Is cross-domain allowed"
-msgstr "是否允许跨域"
-
-#: apps/application/serializers/application_api_key.py:28
-msgid "Cross-domain address"
-msgstr "跨域地址"
-
-#: apps/application/serializers/application_api_key.py:29
-msgid "Cross-domain list"
-msgstr "跨域列表"
-
-#: apps/application/serializers/application_api_key.py:34
-#: apps/application/serializers/application_api_key.py:65
-#: apps/knowledge/serializers/knowledge.py:72
-#: apps/xpack/serializers/application_setting_serializer.py:77
-#: apps/xpack/serializers/dataset_lark_serializer.py:295
-msgid "application id"
-msgstr "智能体 ID"
-
-#: apps/application/serializers/application_api_key.py:41
-#: apps/chat/serializers/chat.py:277 apps/chat/serializers/chat.py:332
-#: apps/xpack/serializers/application_setting_serializer.py:103
-#: apps/xpack/serializers/platform_serializer.py:81
-#: apps/xpack/serializers/platform_serializer.py:103
-#: apps/xpack/serializers/platform_serializer.py:138
-#: apps/xpack/serializers/platform_serializer.py:149
-msgid "Application does not exist"
-msgstr "智能体不存在"
-
-#: apps/application/serializers/application_api_key.py:66
-msgid "ApiKeyId"
-msgstr "ApiKey ID"
-
-#: apps/application/serializers/application_api_key.py:87
-msgid "APIKey does not exist"
-msgstr "APIKey 不存在"
-
-#: apps/application/serializers/application_chat.py:33
-msgid "chat id"
-msgstr "对话 ID"
-
-#: apps/application/serializers/application_chat.py:34
-#: apps/application/serializers/application_chat.py:51
-#: apps/application/serializers/application_chat.py:182
-#: apps/application/serializers/application_version.py:23
-msgid "summary"
-msgstr "摘要"
-
-#: apps/application/serializers/application_chat.py:35
-msgid "Chat User ID"
-msgstr "对话用户 ID"
-
-#: apps/application/serializers/application_chat.py:36
-msgid "Chat User Type"
-msgstr "对话用户类型"
-
-#: apps/application/serializers/application_chat.py:37
-msgid "Is delete"
-msgstr "删除"
-
-#: apps/application/serializers/application_chat.py:39
-#: apps/application/serializers/application_stats.py:25
-msgid "Number of conversations"
-msgstr "对话数量"
-
-#: apps/application/serializers/application_chat.py:40
-#: apps/application/serializers/application_stats.py:29
-msgid "Number of Likes"
-msgstr "点赞数量"
-
-#: apps/application/serializers/application_chat.py:41
-#: apps/application/serializers/application_stats.py:31
-msgid "Number of thumbs-downs"
-msgstr "点踩数量"
-
-#: apps/application/serializers/application_chat.py:42
-msgid "Number of tags"
-msgstr "标签数量"
-
-#: apps/application/serializers/application_chat.py:46
-msgid "Chat ID List"
-msgstr "对话 ID 列表"
-
-#: apps/application/serializers/application_chat.py:52
-#: apps/application/serializers/application_stats.py:36
-#: apps/xpack/serializers/operate_log_serializer.py:55
-msgid "Start time"
-msgstr "开始时间"
-
-#: apps/application/serializers/application_chat.py:53
-#: apps/application/serializers/application_stats.py:37
-#: apps/xpack/serializers/operate_log_serializer.py:56
-msgid "End time"
-msgstr "结束时间"
-
-#: apps/application/serializers/application_chat.py:61
-msgid "Only supports and|or"
-msgstr "只支持 与|或"
-
-#: apps/application/serializers/application_chat.py:183
-msgid "Problem after optimization"
-msgstr "优化后的问题"
-
-#: apps/application/serializers/application_chat.py:184
-msgid "answer"
-msgstr "回答"
-
-#: apps/application/serializers/application_chat.py:184
-msgid "User feedback"
-msgstr "用户反馈"
-
-#: apps/application/serializers/application_chat.py:186
-msgid "Section title + content"
-msgstr "分段标题 + 内容"
-
-#: apps/application/serializers/application_chat.py:187
-#: apps/application/views/application_chat_record.py:139
-#: apps/application/views/application_chat_record.py:140
-#: apps/application/views/application_chat_record.py:141
-#: apps/common/constants/permission_constants.py:248
-msgid "Annotation"
-msgstr "标注"
-
-#: apps/application/serializers/application_chat.py:187
-msgid "Consuming tokens"
-msgstr "消耗的令牌"
-
-#: apps/application/serializers/application_chat.py:188
-msgid "Time consumed (s)"
-msgstr "耗时 (s)"
-
-#: apps/application/serializers/application_chat.py:189
-msgid "Question Time"
-msgstr "提问时间"
-
-#: apps/application/serializers/application_chat_record.py:44
-#: apps/application/serializers/application_chat_record.py:143
-#: apps/application/serializers/application_chat_record.py:250
-#: apps/application/serializers/application_chat_record.py:315
-#: apps/chat/serializers/chat.py:45
-msgid "Conversation record id"
-msgstr "对话记录 ID"
-
-#: apps/application/serializers/application_chat_record.py:51
-msgid "Application authentication information does not exist"
-msgstr "智能体认证信息不存在"
-
-#: apps/application/serializers/application_chat_record.py:53
-msgid "Displaying knowledge sources is not enabled"
-msgstr "知识库来源展示未开启"
-
-#: apps/application/serializers/application_chat_record.py:70
-#: apps/chat/serializers/chat.py:127 apps/chat/serializers/chat.py:274
-msgid "Conversation does not exist"
-msgstr "对话不存在"
-
-#: apps/application/serializers/application_chat_record.py:152
-#: apps/application/serializers/application_chat_record.py:279
-#: apps/application/serializers/application_chat_record.py:336
-#: apps/chat/serializers/chat.py:205
-msgid "Conversation record does not exist"
-msgstr "对话记录不存在"
-
-#: apps/application/serializers/application_chat_record.py:168
-msgid "Section title"
-msgstr "章节标题"
-
-#: apps/application/serializers/application_chat_record.py:169
-msgid "Paragraph content"
-msgstr "段落内容"
-
-#: apps/application/serializers/application_chat_record.py:177
-#: apps/application/serializers/application_chat_record.py:254
-#: apps/application/serializers/application_chat_record.py:319
-msgid "Document id"
-msgstr "文档 ID"
-
-#: apps/application/serializers/application_chat_record.py:184
-#: apps/application/serializers/application_chat_record.py:260
-#: apps/knowledge/serializers/paragraph.py:246
-msgid "The document id is incorrect"
-msgstr "文档 ID 不正确"
-
-#: apps/application/serializers/application_chat_record.py:203
-msgid "Conversation records that do not exist"
-msgstr "对话记录不存在"
-
-#: apps/application/serializers/application_chat_record.py:321
-msgid "Paragraph id"
-msgstr "段落 ID"
-
-#: apps/application/serializers/application_chat_record.py:340
-#, python-brace-format
-msgid ""
-"The paragraph id is wrong. The current conversation record does not exist. "
-"[{paragraph_id}] paragraph id"
-msgstr "段落 ID 错误。当前对话记录不存在。[{paragraph_id}] 段落 ID"
-
-#: apps/application/serializers/application_stats.py:26
-msgid "Number of new users"
-msgstr "新用户数量"
-
-#: apps/application/serializers/application_stats.py:27
-msgid "Total number of users"
-msgstr "总用户数"
-
-#: apps/application/serializers/application_stats.py:28
-msgid "date"
-msgstr "日期"
-
-#: apps/application/serializers/application_stats.py:30
-msgid "Tokens consumption"
-msgstr "消耗的令牌"
-
-#: apps/application/serializers/application_version.py:36
-msgid "Version Name"
-msgstr "版本名称"
-
-#: apps/application/serializers/application_version.py:69
-msgid "Workflow version id"
-msgstr "工作流版本 ID"
-
-#: apps/application/serializers/application_version.py:79
-#: apps/application/serializers/application_version.py:94
-msgid "Workflow version does not exist"
-msgstr "工作流版本不存在"
-
-#: apps/application/views/application.py:41
-#: apps/application/views/application.py:42
-#: apps/application/views/application.py:43
-msgid "Create an application"
-msgstr "创建一个智能体程序"
-
-#: apps/application/views/application.py:47
-#: apps/application/views/application.py:65
-#: apps/application/views/application.py:82
-#: apps/application/views/application.py:103
-#: apps/application/views/application.py:123
-#: apps/application/views/application.py:145
-#: apps/application/views/application.py:166
-#: apps/application/views/application.py:187
-#: apps/application/views/application.py:206
-#: apps/application/views/application_access_token.py:32
-#: apps/application/views/application_access_token.py:47
-#: apps/application/views/application_chat.py:102
-#: apps/application/views/application_chat.py:122
-#: apps/application/views/application_stats.py:33
-#: apps/common/constants/permission_constants.py:224
-#: apps/common/constants/permission_constants.py:234
-#: apps/xpack/views/application_setting.py:29
-#: apps/xpack/views/application_setting.py:47
-msgid "Application"
-msgstr "智能体"
-
-#: apps/application/views/application.py:60
-#: apps/application/views/application.py:61
-#: apps/application/views/application.py:62
-msgid "Get the application list"
-msgstr "获取智能体列表"
-
-#: apps/application/views/application.py:77
-#: apps/application/views/application.py:78
-#: apps/application/views/application.py:79
-msgid "Get the application list by page"
-msgstr "分页获取智能体列表"
-
-#: apps/application/views/application.py:97
-#: apps/application/views/application.py:98
-#: apps/application/views/application.py:99
-msgid "Import Application"
-msgstr "导入智能体"
-
-#: apps/application/views/application.py:117
-#: apps/application/views/application.py:118
-#: apps/application/views/application.py:119
-msgid "Export application"
-msgstr "导出智能体"
-
-#: apps/application/views/application.py:140
-#: apps/application/views/application.py:141
-#: apps/application/views/application.py:142
-msgid "Deleting application"
-msgstr "删除智能体"
-
-#: apps/application/views/application.py:160
-#: apps/application/views/application.py:161
-#: apps/application/views/application.py:162
-msgid "Modify the application"
-msgstr "修改智能体"
-
-#: apps/application/views/application.py:181
-#: apps/application/views/application.py:182
-#: apps/application/views/application.py:183
-msgid "Get application details"
-msgstr "获取智能体详情"
-
-#: apps/application/views/application.py:200
-#: apps/application/views/application.py:201
-#: apps/application/views/application.py:202
-msgid "Publishing an application"
-msgstr "发布智能体"
-
-#: apps/application/views/application_access_token.py:27
-#: apps/application/views/application_access_token.py:28
-#: apps/application/views/application_access_token.py:29
-msgid "Modify application access restriction information"
-msgstr "修改智能体访问限制信息"
-
-#: apps/application/views/application_access_token.py:43
-#: apps/application/views/application_access_token.py:44
-#: apps/application/views/application_access_token.py:45
-msgid "Get application access restriction information"
-msgstr "获取智能体访问限制信息"
-
-#: apps/application/views/application_api_key.py:31
-#: apps/application/views/application_api_key.py:32
-#: apps/application/views/application_api_key.py:33
-msgid "Create application ApiKey"
-msgstr "创建智能体 API 密钥"
-
-#: apps/application/views/application_api_key.py:37
-#: apps/application/views/application_api_key.py:57
-#: apps/application/views/application_api_key.py:77
-#: apps/application/views/application_api_key.py:99
-msgid "Application Api Key"
-msgstr "智能体 API 密钥"
-
-#: apps/application/views/application_api_key.py:52
-msgid "GET application ApiKey List"
-msgstr "获取智能体的 API 密钥列表"
-
-#: apps/application/views/application_api_key.py:53
-#: apps/application/views/application_api_key.py:54
-msgid "Create application ApiKey List"
-msgstr "创建智能体 API 密钥列表"
-
-#: apps/application/views/application_api_key.py:71
-#: apps/application/views/application_api_key.py:72
-#: apps/application/views/application_api_key.py:73
-msgid "Modify application API_KEY"
-msgstr "修改智能体 API 密钥"
-
-#: apps/application/views/application_api_key.py:93
-#: apps/application/views/application_api_key.py:94
-#: apps/application/views/application_api_key.py:95
-msgid "Delete Application API_KEY"
-msgstr "删除智能体 API 密钥"
-
-#: apps/application/views/application_chat.py:35
-#: apps/application/views/application_chat.py:36
-#: apps/application/views/application_chat.py:37
-msgid "Get the conversation list"
-msgstr "获取对话列表"
-
-#: apps/application/views/application_chat.py:41
-#: apps/application/views/application_chat.py:61
-#: apps/application/views/application_chat.py:82
-#: apps/application/views/application_chat_record.py:37
-#: apps/application/views/application_chat_record.py:58
-#: apps/application/views/application_chat_record.py:82
-#: apps/application/views/application_chat_record.py:106
-#: apps/application/views/application_chat_record.py:125
-#: apps/application/views/application_chat_record.py:145
-#: apps/application/views/application_chat_record.py:171
-msgid "Application/Conversation Log"
-msgstr "智能体/对话日志"
-
-#: apps/application/views/application_chat.py:55
-#: apps/application/views/application_chat.py:56
-#: apps/application/views/application_chat.py:57
-msgid "Get the conversation list by page"
-msgstr "分页获取对话列表"
-
-#: apps/application/views/application_chat.py:76
-#: apps/application/views/application_chat.py:77
-#: apps/application/views/application_chat.py:78
-msgid "Export conversation"
-msgstr "导出对话"
-
-#: apps/application/views/application_chat.py:97
-#: apps/application/views/application_chat.py:98
-#: apps/application/views/application_chat.py:99
-msgid "Get a temporary session id based on the application id"
-msgstr "获取智能体的临时会话 ID"
-
-#: apps/application/views/application_chat.py:116
-#: apps/application/views/application_chat.py:117
-#: apps/application/views/application_chat.py:118 apps/chat/views/chat.py:93
-#: apps/chat/views/chat.py:94 apps/chat/views/chat.py:95
-msgid "dialogue"
-msgstr "对话"
-
-#: apps/application/views/application_chat_record.py:31
-#: apps/application/views/application_chat_record.py:32
-#: apps/application/views/application_chat_record.py:33
-msgid "Get the conversation record list"
-msgstr "获取对话记录列表"
-
-#: apps/application/views/application_chat_record.py:52
-#: apps/application/views/application_chat_record.py:53
-#: apps/application/views/application_chat_record.py:54
-msgid "Get the conversation record list by page"
-msgstr "分页获取对话记录列表"
-
-#: apps/application/views/application_chat_record.py:76
-#: apps/application/views/application_chat_record.py:77
-#: apps/application/views/application_chat_record.py:78
-msgid "Get conversation record details"
-msgstr "获取对话记录详情"
-
-#: apps/application/views/application_chat_record.py:100
-#: apps/application/views/application_chat_record.py:101
-#: apps/application/views/application_chat_record.py:102
-msgid "Add to Knowledge Base"
-msgstr "添加到知识库"
-
-#: apps/application/views/application_chat_record.py:119
-#: apps/application/views/application_chat_record.py:120
-#: apps/application/views/application_chat_record.py:121
-msgid "Get the list of marked paragraphs"
-msgstr "获取标记段落列表"
-
-#: apps/application/views/application_chat_record.py:165
-#: apps/application/views/application_chat_record.py:166
-#: apps/application/views/application_chat_record.py:167
-msgid "Delete a Annotation"
-msgstr "删除注释"
-
-#: apps/application/views/application_stats.py:28
-#: apps/application/views/application_stats.py:29
-#: apps/application/views/application_stats.py:30
-msgid "Dialogue-related statistical trends"
-msgstr "与对话有关的统计趋势"
-
-#: apps/application/views/application_version.py:30
-#: apps/application/views/application_version.py:31
-#: apps/application/views/application_version.py:32
-msgid "Get the application version list"
-msgstr "获取智能体版本列表"
-
-#: apps/application/views/application_version.py:35
-#: apps/application/views/application_version.py:55
-#: apps/application/views/application_version.py:76
-#: apps/application/views/application_version.py:94
-msgid "Application/Version"
-msgstr "智能体/ 版本"
-
-#: apps/application/views/application_version.py:50
-#: apps/application/views/application_version.py:51
-#: apps/application/views/application_version.py:52
-msgid "Get the list of application versions by page"
-msgstr "分页获取智能体版本列表"
-
-#: apps/application/views/application_version.py:71
-#: apps/application/views/application_version.py:72
-#: apps/application/views/application_version.py:73
-msgid "Get application version details"
-msgstr "获取智能体版本详情"
-
-#: apps/application/views/application_version.py:88
-#: apps/application/views/application_version.py:89
-#: apps/application/views/application_version.py:90
-msgid "Modify application version information"
-msgstr "修改智能体版本信息"
-
-#: apps/chat/api/chat_authentication_api.py:38
-#: apps/chat/serializers/chat_authentication.py:28
-#: apps/chat/serializers/chat_authentication.py:54
-#: apps/xpack/serializers/chat_auth.py:25
-msgid "access_token"
-msgstr ""
-
-#: apps/chat/api/chat_embed_api.py:24
-msgid "host"
-msgstr ""
-
-#: apps/chat/api/chat_embed_api.py:31
-#: apps/chat/serializers/chat_embed_serializers.py:25
-msgid "protocol"
-msgstr "协议"
-
-#: apps/chat/api/chat_embed_api.py:38
-#: apps/chat/serializers/chat_embed_serializers.py:26
-#: apps/users/serializers/login.py:36
-msgid "token"
-msgstr "令牌"
-
-#: apps/chat/serializers/chat.py:42
-msgid "Is the answer in streaming mode"
-msgstr "是否流式回答"
-
-#: apps/chat/serializers/chat.py:43
-msgid "Do you want to reply again"
-msgstr "是否重新回复"
-
-#: apps/chat/serializers/chat.py:48
-msgid "Node id"
-msgstr "节点 ID"
-
-#: apps/chat/serializers/chat.py:51
-msgid "Runtime node id"
-msgstr "运行时节点 ID"
-
-#: apps/chat/serializers/chat.py:54
-msgid "Node parameters"
-msgstr "节点参数"
-
-#: apps/chat/serializers/chat.py:56
-msgid "Global variables"
-msgstr "全局变量"
-
-#: apps/chat/serializers/chat.py:60
-#: apps/common/constants/permission_constants.py:222
-#: apps/common/constants/permission_constants.py:228
-msgid "Other"
-msgstr "其他"
-
-#: apps/chat/serializers/chat.py:115 apps/chat/serializers/chat.py:320
-msgid "Client id"
-msgstr "客户端 ID"
-
-#: apps/chat/serializers/chat.py:116 apps/chat/serializers/chat.py:321
-msgid "Client Type"
-msgstr "客户端类型"
-
-#: apps/chat/serializers/chat.py:119 apps/chat/serializers/chat.py:322
-#: apps/common/constants/permission_constants.py:240
-msgid "Debug"
-msgstr "调试"
-
-#: apps/chat/serializers/chat.py:146
-msgid "The number of visits exceeds today's visits"
-msgstr "今天的访问次数超过限制"
-
-#: apps/chat/serializers/chat.py:157
-msgid "The current model is not available"
-msgstr "当前模型不可用"
-
-#: apps/chat/serializers/chat.py:159
-msgid "The model is downloading, please try again later"
-msgstr "下载过程被中断，请重试"
-
-#: apps/chat/serializers/chat.py:306 apps/chat/serializers/chat.py:357
-msgid "The application has not been published. Please use it after publishing."
-msgstr "智能体未发布，请发布后使用。"
-
-#: apps/chat/serializers/chat_authentication.py:50
-#: apps/xpack/serializers/chat_auth.py:53
-msgid "Invalid access_token"
-msgstr "access_token 无效"
-
-#: apps/chat/serializers/chat_authentication.py:89
-msgid "Illegal User"
-msgstr "非法用户"
-
-#: apps/chat/serializers/chat_embed_serializers.py:24
-msgid "Host"
-msgstr ""
-
-#: apps/chat/views/chat.py:37 apps/chat/views/chat.py:38
-#: apps/chat/views/chat.py:39
-msgid "Application Anonymous Certification"
-msgstr "智能体匿名认证"
-
-#: apps/chat/views/chat.py:42 apps/chat/views/chat.py:64
-#: apps/chat/views/chat.py:81 apps/chat/views/chat.py:99
-#: apps/chat/views/chat.py:120 apps/chat/views/chat_embed.py:27
-#: apps/xpack/views/chat_user_auth.py:419
-msgid "Chat"
-msgstr "对话"
-
-#: apps/chat/views/chat.py:59 apps/chat/views/chat.py:60
-#: apps/chat/views/chat.py:61
-msgid "Get application related information"
-msgstr "获取智能体相关信息"
-
-#: apps/chat/views/chat.py:76 apps/chat/views/chat.py:77
-#: apps/chat/views/chat.py:78
-msgid "Get application authentication information"
-msgstr "获取智能体认证信息"
-
-#: apps/chat/views/chat.py:115 apps/chat/views/chat.py:116
-#: apps/chat/views/chat.py:117
-msgid "Get the session id according to the application id"
-msgstr "根据智能体 ID 获取会话 ID"
-
-#: apps/chat/views/chat.py:131 apps/chat/views/chat.py:132
-#: apps/chat/views/chat.py:133 apps/users/views/login.py:70
-#: apps/users/views/login.py:71 apps/users/views/login.py:72
-msgid "Get captcha"
-msgstr "获取验证码"
-
-#: apps/chat/views/chat.py:134
-#: apps/common/constants/permission_constants.py:210
-#: apps/users/views/login.py:41 apps/users/views/login.py:58
-#: apps/users/views/login.py:73 apps/users/views/user.py:63
-#: apps/users/views/user.py:77 apps/users/views/user.py:91
-#: apps/users/views/user.py:108 apps/users/views/user.py:123
-#: apps/users/views/user.py:136 apps/users/views/user.py:150
-#: apps/users/views/user.py:164 apps/users/views/user.py:180
-#: apps/users/views/user.py:193 apps/users/views/user.py:206
-#: apps/users/views/user.py:217 apps/users/views/user.py:235
-#: apps/users/views/user.py:251 apps/users/views/user.py:269
-#: apps/users/views/user.py:286 apps/users/views/user.py:303
-#: apps/users/views/user.py:321 apps/users/views/user.py:338
-#: apps/users/views/user.py:356 apps/xpack/views/chat_user_auth.py:206
-msgid "User Management"
-msgstr "用户管理"
-
-#: apps/chat/views/chat_embed.py:22 apps/chat/views/chat_embed.py:23
-#: apps/chat/views/chat_embed.py:24
-msgid "Get embedded js"
-msgstr "获取嵌入式 JavaScript"
-
-#: apps/common/auth/authenticate.py:80
-msgid "Not logged in, please log in first"
-msgstr "未登录，请先登录"
-
-#: apps/common/auth/authenticate.py:82 apps/common/auth/authenticate.py:89
-#: apps/common/auth/authenticate.py:95
-msgid "Authentication information is incorrect! illegal user"
-msgstr "身份验证信息不正确！非法用户"
-
-#: apps/common/auth/authentication.py:98
-msgid "No permission to access"
-msgstr "无权限访问"
-
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:39
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:41
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:43
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:49
-#: apps/xpack/auth/chat_user_token.py:41 apps/xpack/auth/chat_user_token.py:43
-#: apps/xpack/auth/chat_user_token.py:45 apps/xpack/auth/chat_user_token.py:49
-msgid "Authentication information is incorrect"
-msgstr "身份验证信息不正确"
-
-#: apps/common/auth/handle/impl/user_token.py:265
-msgid "Login expired"
-msgstr "登录已过期"
-
-#: apps/common/constants/exception_code_constants.py:31
-#: apps/users/serializers/login.py:53
-#: apps/xpack/serializers/chat_user_serializer.py:123
-msgid "The username or password is incorrect"
-msgstr "用户名或密码不正确"
-
-#: apps/common/constants/exception_code_constants.py:32
-msgid "Please log in first and bring the user Token"
-msgstr "请先登录并携带用户 Token"
-
-#: apps/common/constants/exception_code_constants.py:33
-#: apps/users/serializers/user.py:630
-msgid "Email sending failed"
-msgstr "邮件发送失败"
-
-#: apps/common/constants/exception_code_constants.py:34
-msgid "Email format error"
-msgstr "邮箱格式错误"
-
-#: apps/common/constants/exception_code_constants.py:35
-msgid "The email has been registered, please log in directly"
-msgstr "该邮箱已注册，请直接登录"
-
-#: apps/common/constants/exception_code_constants.py:36
-msgid "The email is not registered, please register first"
-msgstr "该邮箱未注册，请先注册"
-
-#: apps/common/constants/exception_code_constants.py:38
-msgid "The verification code is incorrect or the verification code has expired"
-msgstr "验证码不正确或已过期"
-
-#: apps/common/constants/exception_code_constants.py:39
-msgid "The username has been registered, please log in directly"
-msgstr "用户名已注册，请直接登录"
-
-#: apps/common/constants/exception_code_constants.py:41
-msgid ""
-"The username cannot be empty and must be between 6 and 20 characters long."
-msgstr "用户名不能为空，且长度在6到20个字符之间。"
-
-#: apps/common/constants/exception_code_constants.py:43
-msgid "Password and confirmation password are inconsistent"
-msgstr "密码和确认密码不一致"
-
-#: apps/common/constants/exception_code_constants.py:44
-msgid "The nickname is already registered"
-msgstr "姓名已注册"
-
-#: apps/common/constants/permission_constants.py:209
-msgid "System Setting"
-msgstr "系统设置"
-
-#: apps/common/constants/permission_constants.py:211
-#: apps/common/constants/permission_constants.py:272
-#: apps/role_setting/views/role_setting.py:44
-#: apps/role_setting/views/role_setting.py:67
-#: apps/role_setting/views/role_setting.py:84
-#: apps/role_setting/views/role_setting.py:103
-#: apps/role_setting/views/role_setting.py:125
-#: apps/role_setting/views/role_setting.py:145
-#: apps/role_setting/views/role_setting.py:167
-#: apps/role_setting/views/role_setting.py:191
-#: apps/role_setting/views/role_setting.py:210
-msgid "Role"
-msgstr "角色"
-
-#: apps/common/constants/permission_constants.py:212
-#: apps/common/constants/permission_constants.py:270
-#: apps/workspace/views/workspace.py:37 apps/workspace/views/workspace.py:49
-#: apps/workspace/views/workspace.py:63 apps/workspace/views/workspace.py:80
-#: apps/workspace/views/workspace.py:101 apps/workspace/views/workspace.py:119
-#: apps/workspace/views/workspace.py:138 apps/workspace/views/workspace.py:155
-#: apps/workspace/views/workspace.py:170 apps/workspace/views/workspace.py:188
-#: apps/workspace/views/workspace.py:207 apps/workspace/views/workspace.py:223
-#: apps/workspace/views/workspace.py:236 apps/workspace/views/workspace.py:250
-msgid "Workspace"
-msgstr "工作空间"
-
-#: apps/common/constants/permission_constants.py:213
-msgid "Resource Application"
-msgstr "资源管理-智能体"
-
-#: apps/common/constants/permission_constants.py:214
-msgid "Resource Knowledge"
-msgstr "资源管理-知识库"
-
-#: apps/common/constants/permission_constants.py:215
-msgid "Resource Tool"
-msgstr "资源管理-工具"
-
-#: apps/common/constants/permission_constants.py:216
-msgid "Resource Model"
-msgstr "资源管理-模型"
-
-#: apps/common/constants/permission_constants.py:217
-msgid "Resource Permission"
-msgstr "资源授权"
-
-#: apps/common/constants/permission_constants.py:218
-#: apps/shared/views/shared_dataset_lark_views.py:30
-#: apps/shared/views/shared_dataset_lark_views.py:50
-#: apps/shared/views/shared_knowledge.py:33
-#: apps/shared/views/shared_knowledge.py:53
-#: apps/shared/views/shared_knowledge.py:76
-#: apps/shared/views/shared_knowledge.py:91
-#: apps/shared/views/shared_knowledge.py:106
-#: apps/shared/views/shared_knowledge.py:125
-#: apps/shared/views/shared_knowledge.py:151
-#: apps/shared/views/shared_knowledge.py:178
-#: apps/shared/views/shared_knowledge.py:196
-#: apps/shared/views/shared_knowledge.py:214
-#: apps/shared/views/shared_knowledge.py:235
-#: apps/shared/views/shared_knowledge.py:256
-#: apps/shared/views/shared_knowledge.py:276
-#: apps/shared/views/shared_knowledge.py:297
-#: apps/shared/views/shared_knowledge.py:312
-#: apps/shared/views/shared_knowledge.py:331
-#: apps/shared/views/shared_knowledge.py:354
-#: apps/shared/views/shared_knowledge.py:386
-#: apps/shared/views/shared_knowledge.py:407
-msgid "Shared Knowledge"
-msgstr "共享资源-知识库"
-
-#: apps/common/constants/permission_constants.py:219
-#: apps/models_provider/views/model.py:227 apps/shared/views/shared_model.py:58
-#: apps/shared/views/shared_model.py:89 apps/shared/views/shared_model.py:107
-#: apps/shared/views/shared_model.py:124 apps/shared/views/shared_model.py:138
-#: apps/shared/views/shared_model.py:153 apps/shared/views/shared_model.py:166
-#: apps/shared/views/shared_model.py:186 apps/shared/views/shared_model.py:202
-#: apps/shared/views/shared_model.py:219 apps/shared/views/shared_model.py:234
-#: apps/shared/views/shared_model.py:253 apps/shared/views/shared_model.py:270
-msgid "Shared Model"
-msgstr "共享资源-模型"
-
-#: apps/common/constants/permission_constants.py:220
-#: apps/shared/views/shared_tool.py:30 apps/shared/views/shared_tool.py:49
-#: apps/shared/views/shared_tool.py:68 apps/shared/views/shared_tool.py:83
-#: apps/shared/views/shared_tool.py:98 apps/shared/views/shared_tool.py:116
-#: apps/shared/views/shared_tool.py:139 apps/shared/views/shared_tool.py:157
-#: apps/shared/views/shared_tool.py:175 apps/shared/views/shared_tool.py:194
-#: apps/shared/views/shared_tool.py:218 apps/shared/views/shared_tool.py:239
-#: apps/shared/views/shared_tool.py:254 apps/shared/views/shared_tool.py:273
-#: apps/shared/views/shared_tool.py:294
-msgid "Shared Tool"
-msgstr "共享资源-工具"
-
-#: apps/common/constants/permission_constants.py:221
-msgid "Operation Log"
-msgstr "操作日志"
-
-#: apps/common/constants/permission_constants.py:223
-msgid "System Management"
-msgstr "系统管理"
-
-#: apps/common/constants/permission_constants.py:225
-#: apps/common/constants/permission_constants.py:235
-#: apps/common/constants/permission_constants.py:260
-#: apps/common/constants/permission_constants.py:265
-msgid "Knowledge"
-msgstr "知识库"
-
-#: apps/common/constants/permission_constants.py:227
-#: apps/common/constants/permission_constants.py:258
-#: apps/common/constants/permission_constants.py:263
-#: apps/tools/views/tool.py:39 apps/tools/views/tool.py:61
-#: apps/tools/views/tool.py:82 apps/tools/views/tool.py:104
-#: apps/tools/views/tool.py:127 apps/tools/views/tool.py:146
-#: apps/tools/views/tool.py:172 apps/tools/views/tool.py:201
-#: apps/tools/views/tool.py:223 apps/tools/views/tool.py:250
-#: apps/tools/views/tool.py:274
-msgid "Tool"
-msgstr "工具"
-
-#: apps/common/constants/permission_constants.py:229
-msgid "Read"
-msgstr "查看"
-
-#: apps/common/constants/permission_constants.py:230
-msgid "Edit"
-msgstr "编辑"
-
-#: apps/common/constants/permission_constants.py:231
-msgid "Create"
-msgstr "创建"
-
-#: apps/common/constants/permission_constants.py:232
-msgid "Delete"
-msgstr "删除"
-
-#: apps/common/constants/permission_constants.py:233
-msgid "Email Setting"
-msgstr "邮箱设置"
-
-#: apps/common/constants/permission_constants.py:236
-#: apps/common/constants/permission_constants.py:261
-#: apps/common/constants/permission_constants.py:266
-msgid "Document"
-msgstr "文档"
-
-#: apps/common/constants/permission_constants.py:237
-#: apps/common/constants/permission_constants.py:262
-#: apps/common/constants/permission_constants.py:267
-msgid "Problem"
-msgstr "问题"
-
-#: apps/common/constants/permission_constants.py:238
-msgid "Import"
-msgstr "导入"
-
-#: apps/common/constants/permission_constants.py:239
-msgid "Export"
-msgstr "导出"
-
-#: apps/common/constants/permission_constants.py:241
-msgid "Sync"
-msgstr "同步"
-
-#: apps/common/constants/permission_constants.py:242
-msgid "Generate"
-msgstr "生成问题"
-
-#: apps/common/constants/permission_constants.py:243
-msgid "Add Member"
-msgstr "添加成员"
-
-#: apps/common/constants/permission_constants.py:244
-msgid "Remove Member"
-msgstr "移除成员"
-
-#: apps/common/constants/permission_constants.py:245
-msgid "Vector"
-msgstr "向量化"
-
-#: apps/common/constants/permission_constants.py:246
-msgid "Migrate"
-msgstr "迁移"
-
-#: apps/common/constants/permission_constants.py:247
-msgid "Relate"
-msgstr "关联分段"
-
-#: apps/common/constants/permission_constants.py:249
-msgid "Clear Policy"
-msgstr "清除策略"
-
-#: apps/common/constants/permission_constants.py:250
-msgid "Login Auth"
-msgstr "登录认证"
-
-#: apps/common/constants/permission_constants.py:251
-msgid "Display Settings"
-msgstr "显示设置"
-
-#: apps/common/constants/permission_constants.py:252
-#: apps/common/constants/permission_constants.py:720
-#: apps/xpack/views/system_api_key.py:23 apps/xpack/views/system_api_key.py:38
-#: apps/xpack/views/system_api_key.py:56 apps/xpack/views/system_api_key.py:71
-msgid "System API Key"
-msgstr "系统 API Key"
-
-#: apps/common/constants/permission_constants.py:253
-#: apps/xpack/views/system_params.py:26 apps/xpack/views/system_params.py:42
-msgid "Appearance Settings"
-msgstr "外观设置"
-
-#: apps/common/constants/permission_constants.py:254
-#: apps/common/constants/permission_constants.py:269
-#: apps/xpack/views/system_chat_user.py:339
-#: apps/xpack/views/system_chat_user.py:362
-msgid "Chat User"
-msgstr "对话用户"
-
-#: apps/common/constants/permission_constants.py:255
-#: apps/common/constants/permission_constants.py:268
-msgid "User Group"
-msgstr "用户组"
-
-#: apps/common/constants/permission_constants.py:256
-msgid "Chat User Auth"
-msgstr "对话用户认证"
-
-#: apps/common/constants/permission_constants.py:257
-msgid "Overview"
-msgstr "概览"
-
-#: apps/common/constants/permission_constants.py:271
-#: apps/common/constants/permission_constants.py:671
-#: apps/common/constants/permission_constants.py:677
-#: apps/common/constants/permission_constants.py:683
-#: apps/common/constants/permission_constants.py:689
-msgid "Dialogue log"
-msgstr "对话日志"
-
-#: apps/common/constants/permission_constants.py:641
-msgid "Embed third party"
-msgstr "嵌入第三方"
-
-#: apps/common/constants/permission_constants.py:647
-msgid "Access restrictions"
-msgstr "访问限制"
-
-#: apps/common/constants/permission_constants.py:653
-msgid "Display settings"
-msgstr "显示设置"
-
-#: apps/common/constants/permission_constants.py:659
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:44
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:16
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:75
-msgid "API Key"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:665
-msgid "Public settings"
-msgstr "公共访问连接"
-
-#: apps/common/constants/permission_constants.py:704
-msgid "About"
-msgstr "关于"
-
-#: apps/common/constants/permission_constants.py:709
-#: apps/users/views/user.py:88 apps/users/views/user.py:89
-#: apps/users/views/user.py:90
-msgid "Switch Language"
-msgstr "切换语言"
-
-#: apps/common/constants/permission_constants.py:714
-msgid "Change Password"
-msgstr "修改密码"
-
-#: apps/common/constants/permission_constants.py:734
-msgid "Sync users"
-msgstr "同步用户"
-
-#: apps/common/constants/permission_constants.py:755
-#: apps/common/constants/permission_constants.py:808
-msgid "Set up user groups"
-msgstr "设置用户组"
-
-#: apps/common/event/__init__.py:27
-msgid "The download process was interrupted, please try again"
-msgstr "下载过程被中断，请重试"
-
-#: apps/common/event/listener_manage.py:90
-#, python-brace-format
-msgid "Query vector data: {paragraph_id_list} error {error} {traceback}"
-msgstr "查询向量数据：{paragraph_id_list} 错误：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:95
-#, python-brace-format
-msgid "Start--->Embedding paragraph: {paragraph_id_list}"
-msgstr "开始--->向量段落: {paragraph_id_list}"
-
-#: apps/common/event/listener_manage.py:107
-#, python-brace-format
-msgid "Vectorized paragraph: {paragraph_id_list} error {error} {traceback}"
-msgstr "向量段落: {paragraph_id_list} 错误：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:113
-#, python-brace-format
-msgid "End--->Embedding paragraph: {paragraph_id_list}"
-msgstr "结束--->向量段落: {paragraph_id_list}"
-
-#: apps/common/event/listener_manage.py:122
-#, python-brace-format
-msgid "Start--->Embedding paragraph: {paragraph_id}"
-msgstr "开始--->向量段落: {paragraph_id}"
-
-#: apps/common/event/listener_manage.py:147
-#, python-brace-format
-msgid "Vectorized paragraph: {paragraph_id} error {error} {traceback}"
-msgstr "向量段落: {paragraph_id} 错误：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:152
-#, python-brace-format
-msgid "End--->Embedding paragraph: {paragraph_id}"
-msgstr "结束--->向量段落: {paragraph_id}"
-
-#: apps/common/event/listener_manage.py:268
-#, python-brace-format
-msgid "Start--->Embedding document: {document_id}"
-msgstr "开始--->向量文档: {document_id}"
-
-#: apps/common/event/listener_manage.py:288
-#, python-brace-format
-msgid "Vectorized document: {document_id} error {error} {traceback}"
-msgstr "向量文档: {document_id} 错误：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:293
-#, python-brace-format
-msgid "End--->Embedding document: {document_id}"
-msgstr "结束--->向量文档: {document_id}"
-
-#: apps/common/event/listener_manage.py:304
-#, python-brace-format
-msgid "Start--->Embedding knowledge: {knowledge_id}"
-msgstr "开始--->向量知识库: {knowledge_id}"
-
-#: apps/common/event/listener_manage.py:308
-#, python-brace-format
-msgid "Start--->Embedding document: {document_list}"
-msgstr "开始--->向量文档: {document_list}"
-
-#: apps/common/event/listener_manage.py:312
-#: apps/knowledge/task/embedding.py:116
-#, python-brace-format
-msgid "Vectorized knowledge: {knowledge_id} error {error} {traceback}"
-msgstr "向量知识库: {knowledge_id} 错误：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:315
-#, python-brace-format
-msgid "End--->Embedding knowledge: {knowledge_id}"
-msgstr "结束--->向量知识库: {knowledge_id}"
-
-#: apps/common/exception/handle_exception.py:32
-#: apps/common/handle/handle_exception.py:33
-msgid "Unknown exception"
-msgstr "未知错误"
-
-#: apps/common/field/common.py:48
-msgid "not a function"
-msgstr "不是函数"
-
-#: apps/common/forms/base_field.py:64
-#, python-brace-format
-msgid "The field {field_label} is required"
-msgstr "{field_label} 字段是必填项"
-
-#: apps/common/forms/slider_field.py:56
-#, python-brace-format
-msgid "The {field_label} cannot be less than {min}"
-msgstr "{field_label} 不能小于{min}"
-
-#: apps/common/forms/slider_field.py:62
-#, python-brace-format
-msgid "The {field_label} cannot be greater than {max}"
-msgstr "{field_label} 不能大于{max}"
-
-#: apps/common/handle/impl/text/pdf_split_handle.py:281
-#, python-brace-format
-msgid "This document has no preface and is treated as ordinary text: {e}"
-msgstr "该文档没有前言，视为普通文本: {e}"
-
-#: apps/common/job/clean_chat_job.py:23
-msgid "start clean chat log"
-msgstr "开始清理聊天日志"
-
-#: apps/common/job/clean_chat_job.py:69
-msgid "end clean chat log"
-msgstr "结束清理聊天日志"
-
-#: apps/common/job/clean_debug_file_job.py:21
-msgid "start clean debug file"
-msgstr "开始清理调试文件"
-
-#: apps/common/job/clean_debug_file_job.py:25
-msgid "end clean debug file"
-msgstr "结束清理调试文件"
-
-#: apps/common/result/api.py:17 apps/common/result/api.py:27
-msgid "response code"
-msgstr "响应码"
-
-#: apps/common/result/api.py:18 apps/common/result/api.py:19
-#: apps/common/result/api.py:28 apps/common/result/api.py:29
-msgid "error prompt"
-msgstr "错误提示"
-
-#: apps/common/result/api.py:43
-msgid "total number of data"
-msgstr "总数据"
-
-#: apps/common/result/api.py:44
-msgid "current page"
-msgstr "当前页"
-
-#: apps/common/result/api.py:45
-msgid "page size"
-msgstr "每页大小"
-
-#: apps/common/result/result.py:31
-#: apps/xpack/serializers/operate_log_serializer.py:134
-msgid "Success"
-msgstr "成功"
-
-#: apps/common/utils/common.py:91
-msgid "Text-to-speech node, the text content must be of string type"
-msgstr "文本转语音节点，文本内容必须是字符串类型"
-
-#: apps/common/utils/common.py:93
-msgid "Text-to-speech node, the text content cannot be empty"
-msgstr "文本转语音节点，文本内容不能为空"
-
-#: apps/common/utils/common.py:246
-#, python-brace-format
-msgid "Limit {count} exceeded, please contact us (https://fit2cloud.com/)."
-msgstr "超过限制 {count}，请联系我们 (https://fit2cloud.com/)."
-
-#: apps/folders/models/folder.py:6 apps/folders/models/folder.py:17
-#: apps/folders/serializers/folder.py:98
-msgid "folder name"
-msgstr "文件夹名称"
-
-#: apps/folders/models/folder.py:8 apps/folders/models/folder.py:19
-#: apps/folders/serializers/folder.py:99
-msgid "folder description"
-msgstr "文件夹描述"
-
-#: apps/folders/models/folder.py:12 apps/folders/models/folder.py:23
-#: apps/folders/serializers/folder.py:102
-msgid "parent id"
-msgstr "父级 ID"
-
-#: apps/folders/serializers/folder.py:75
-msgid "Folder depth cannot exceed 5 levels"
-msgstr "文件夹深度不能超过5级"
-
-#: apps/folders/serializers/folder.py:100
-msgid "folder user id"
-msgstr "文件夹用户 ID"
-
-#: apps/folders/serializers/folder.py:105
-#: apps/knowledge/serializers/knowledge.py:112
-#: apps/knowledge/serializers/knowledge.py:207
-#: apps/knowledge/serializers/knowledge.py:447
-#: apps/knowledge/serializers/knowledge.py:559
-#: apps/knowledge/serializers/knowledge.py:637
-#: apps/models_provider/serializers/model_serializer.py:108
-#: apps/models_provider/serializers/model_serializer.py:212
-#: apps/models_provider/serializers/model_serializer.py:252
-#: apps/shared/serializers/shared_knowledge.py:107
-#: apps/shared/serializers/shared_knowledge.py:156
-#: apps/shared/serializers/shared_tool.py:84
-#: apps/system_manage/serializers/user_resource_permission.py:75
-#: apps/tools/serializers/tool.py:187 apps/tools/serializers/tool.py:209
-#: apps/tools/serializers/tool.py:455 apps/users/serializers/user.py:664
-#: apps/xpack/serializers/dataset_lark_serializer.py:46
-#: apps/xpack/serializers/dataset_lark_serializer.py:285
-#: apps/xpack/serializers/system_api_key.py:23
-msgid "user id"
-msgstr "用户ID"
-
-#: apps/folders/serializers/folder.py:123
-msgid "Folder name already exists"
-msgstr "文件夹名称已存在"
-
-#: apps/folders/serializers/folder.py:150
-#: apps/folders/serializers/folder.py:182
-msgid "Folder does not exist"
-msgstr "文件夹不存在"
-
-#: apps/folders/serializers/folder.py:184
-msgid "Cannot delete root folder"
-msgstr "无法删除根文件夹"
-
-#: apps/folders/views/folder.py:31 apps/folders/views/folder.py:32
-#: apps/folders/views/folder.py:33
-msgid "Create folder"
-msgstr "创建文件夹"
-
-#: apps/folders/views/folder.py:37 apps/folders/views/folder.py:63
-#: apps/folders/views/folder.py:86 apps/folders/views/folder.py:110
-#: apps/folders/views/folder.py:129
-msgid "Folder"
-msgstr "文件夹"
-
-#: apps/folders/views/folder.py:58 apps/folders/views/folder.py:59
-#: apps/folders/views/folder.py:60
-msgid "Get folder tree"
-msgstr "获取文件夹树"
-
-#: apps/folders/views/folder.py:80 apps/folders/views/folder.py:81
-#: apps/folders/views/folder.py:82
-msgid "Update folder"
-msgstr "更新文件夹"
-
-#: apps/folders/views/folder.py:105 apps/folders/views/folder.py:106
-#: apps/folders/views/folder.py:107
-msgid "Get folder"
-msgstr "获取文件夹"
-
-#: apps/folders/views/folder.py:124 apps/folders/views/folder.py:125
-#: apps/folders/views/folder.py:126
-msgid "Delete folder"
-msgstr "删除文件夹"
-
-#: apps/knowledge/api/problem.py:39 apps/knowledge/api/problem.py:52
-#: apps/knowledge/serializers/problem.py:40
-msgid "problem list"
-msgstr "问题列表"
-
-#: apps/knowledge/api/problem.py:40 apps/knowledge/api/problem.py:53
-#: apps/knowledge/serializers/problem.py:41
-msgid "problem"
-msgstr "问题 ID"
-
-#: apps/knowledge/serializers/common.py:32
-#: apps/knowledge/serializers/knowledge.py:62
-#: apps/shared/serializers/shared_knowledge.py:29
-msgid "source url"
-msgstr "来源"
-
-#: apps/knowledge/serializers/common.py:33
-#: apps/knowledge/serializers/document.py:152
-msgid "selector"
-msgstr "选择器"
-
-#: apps/knowledge/serializers/common.py:40
-#, python-brace-format
-msgid "URL error, cannot parse [{source_url}]"
-msgstr "URL 错误，无法解析 [{source_url}]"
-
-#: apps/knowledge/serializers/common.py:48
-#: apps/knowledge/serializers/document.py:78
-#: apps/knowledge/serializers/document.py:170
-#: apps/knowledge/serializers/document.py:186
-msgid "id list"
-msgstr "ID 列表"
-
-#: apps/knowledge/serializers/common.py:58
-#, python-brace-format
-msgid "The following id does not exist: {error_id_list}"
-msgstr "以下ID不存在: {error_id_list}"
-
-#: apps/knowledge/serializers/common.py:74
-#: apps/knowledge/serializers/document.py:166
-#: apps/knowledge/serializers/document.py:171
-#: apps/knowledge/serializers/document.py:178
-msgid "state list"
-msgstr "状态列表"
-
-#: apps/knowledge/serializers/common.py:117
-#: apps/knowledge/serializers/common.py:141
-msgid "The knowledge base is inconsistent with the vector model"
-msgstr "知识库与向量模型不一致"
-
-#: apps/knowledge/serializers/common.py:119
-#: apps/knowledge/serializers/common.py:143
-msgid "Knowledge base setting error, please reset the knowledge base"
-msgstr "知识库设置错误，请重置知识库"
-
-#: apps/knowledge/serializers/document.py:79
-#: apps/knowledge/serializers/document.py:97
-#: apps/knowledge/serializers/document.py:353
-msgid "task type"
-msgstr "任务类型"
-
-#: apps/knowledge/serializers/document.py:87
-#: apps/knowledge/serializers/document.py:105
-msgid "task type not support"
-msgstr "任务类型不支持"
-
-#: apps/knowledge/serializers/document.py:91
-#: apps/knowledge/serializers/document.py:110
-#: apps/knowledge/serializers/document.py:350
-msgid "document name"
-msgstr "文档名称"
-
-#: apps/knowledge/serializers/document.py:93
-msgid "source file id"
-msgstr "源文件 ID"
-
-#: apps/knowledge/serializers/document.py:113
-#: apps/knowledge/serializers/document.py:194
-msgid "The type only supports optimization|directly_return"
-msgstr "该类型仅支持优化|直接返回"
-
-#: apps/knowledge/serializers/document.py:115
-#: apps/knowledge/serializers/document.py:187
-#: apps/knowledge/serializers/document.py:351
-msgid "hit handling method"
-msgstr "命中处理方法"
-
-#: apps/knowledge/serializers/document.py:118
-#: apps/knowledge/serializers/document.py:189
-msgid "directly return similarity"
-msgstr "直接返回相似度"
-
-#: apps/knowledge/serializers/document.py:120
-#: apps/knowledge/serializers/document.py:352
-msgid "document is active"
-msgstr "文档已激活"
-
-#: apps/knowledge/serializers/document.py:139
-#: apps/knowledge/serializers/document.py:156
-#: apps/knowledge/serializers/document.py:161
-msgid "file list"
-msgstr "文件 列表"
-
-#: apps/knowledge/serializers/document.py:140
-msgid "limit"
-msgstr "限制"
-
-#: apps/knowledge/serializers/document.py:143
-#: apps/knowledge/serializers/document.py:144
-msgid "patterns"
-msgstr "分割符"
-
-#: apps/knowledge/serializers/document.py:146
-msgid "Auto Clean"
-msgstr "自动清理"
-
-#: apps/knowledge/serializers/document.py:150
-#: apps/knowledge/serializers/document.py:151
-msgid "document url list"
-msgstr "文档 URL 列表"
-
-#: apps/knowledge/serializers/document.py:175
-#: apps/knowledge/serializers/document.py:182
-msgid "document id list"
-msgstr "文档 ID 列表"
-
-#: apps/knowledge/serializers/document.py:176
-#: apps/knowledge/serializers/paragraph.py:58
-#: apps/models_provider/api/model.py:105
-#: apps/models_provider/serializers/model_apply_serializers.py:51
-#: apps/models_provider/serializers/model_serializer.py:107
-#: apps/models_provider/serializers/model_serializer.py:364
-#: apps/shared/api/shared_model.py:61
-#: apps/shared/serializers/shared_model.py:54
-msgid "model id"
-msgstr "模型ID"
-
-#: apps/knowledge/serializers/document.py:177
-#: apps/knowledge/serializers/paragraph.py:59
-msgid "prompt"
-msgstr "提示词"
-
-#: apps/knowledge/serializers/document.py:201
-msgid "The template type only supports excel|csv"
-msgstr "模板类型仅支持 excel|csv"
-
-#: apps/knowledge/serializers/document.py:254
-#: apps/knowledge/serializers/document.py:348
-#: apps/knowledge/serializers/document.py:409
-#: apps/knowledge/serializers/document.py:504
-#: apps/knowledge/serializers/document.py:889
-#: apps/knowledge/serializers/document.py:964
-#: apps/knowledge/serializers/document.py:984
-#: apps/knowledge/serializers/document.py:1167
-#: apps/knowledge/serializers/knowledge.py:209
-#: apps/knowledge/serializers/knowledge.py:558
-#: apps/knowledge/serializers/paragraph.py:70
-#: apps/knowledge/serializers/paragraph.py:138
-#: apps/knowledge/serializers/paragraph.py:239
-#: apps/knowledge/serializers/paragraph.py:321
-#: apps/knowledge/serializers/paragraph.py:347
-#: apps/knowledge/serializers/paragraph.py:398
-#: apps/knowledge/serializers/paragraph.py:439
-#: apps/knowledge/serializers/paragraph.py:559
-#: apps/knowledge/serializers/problem.py:62
-#: apps/knowledge/serializers/problem.py:126
-#: apps/knowledge/serializers/problem.py:177
-#: apps/knowledge/serializers/problem.py:205
-#: apps/shared/api/shared_knowledge.py:196
-#: apps/shared/api/shared_knowledge.py:218
-#: apps/shared/serializers/shared_knowledge.py:158
-#: apps/shared/serializers/shared_knowledge.py:205
-#: apps/xpack/serializers/dataset_lark_serializer.py:104
-#: apps/xpack/serializers/dataset_lark_serializer.py:263
-#: apps/xpack/serializers/dataset_lark_serializer.py:284
-msgid "knowledge id"
-msgstr "知识库 ID"
-
-#: apps/knowledge/serializers/document.py:255
-#: apps/knowledge/serializers/paragraph.py:441
-msgid "target knowledge id"
-msgstr "当前知识库 ID"
-
-#: apps/knowledge/serializers/document.py:256
-msgid "document list"
-msgstr "文档列表"
-
-#: apps/knowledge/serializers/document.py:257
-#: apps/knowledge/serializers/document.py:410
-#: apps/knowledge/serializers/document.py:503
-#: apps/knowledge/serializers/document.py:737
-#: apps/knowledge/serializers/paragraph.py:61
-#: apps/knowledge/serializers/paragraph.py:71
-#: apps/knowledge/serializers/paragraph.py:140
-#: apps/knowledge/serializers/paragraph.py:240
-#: apps/knowledge/serializers/paragraph.py:322
-#: apps/knowledge/serializers/paragraph.py:349
-#: apps/knowledge/serializers/paragraph.py:399
-#: apps/knowledge/serializers/paragraph.py:440
-#: apps/knowledge/serializers/paragraph.py:560
-#: apps/knowledge/serializers/problem.py:36
-#: apps/knowledge/serializers/problem.py:51
-#: apps/xpack/serializers/dataset_lark_serializer.py:160
-msgid "document id"
-msgstr "文档 ID"
-
-#: apps/knowledge/serializers/document.py:354 apps/xpack/api/license.py:25
-#: apps/xpack/serializers/operate_log_serializer.py:60
-#: apps/xpack/serializers/operate_log_serializer.py:174
-msgid "status"
-msgstr "状态"
-
-#: apps/knowledge/serializers/document.py:355
-msgid "order by"
-msgstr "排序"
-
-#: apps/knowledge/serializers/document.py:417
-#: apps/knowledge/serializers/document.py:510
-#: apps/xpack/serializers/dataset_lark_serializer.py:167
-#: apps/xpack/serializers/dataset_lark_serializer.py:189
-msgid "document id not exist"
-msgstr "文档 ID 不存在"
-
-#: apps/knowledge/serializers/document.py:419
-#: apps/knowledge/serializers/knowledge.py:570
-msgid "Synchronization is only supported for web site types"
-msgstr "仅支持网站类型的同步"
-
-#: apps/knowledge/serializers/document.py:661
-msgid "The task is being executed, please do not send it repeatedly."
-msgstr "任务正在执行，请勿重复发送。"
-
-#: apps/knowledge/serializers/document.py:674
-msgid "Section title (optional)"
-msgstr "章节标题"
-
-#: apps/knowledge/serializers/document.py:675
-msgid ""
-"Section content (required, question answer, no more than 4096 characters)"
-msgstr "章节内容（必填，问答，不超过4096个字符）"
-
-#: apps/knowledge/serializers/document.py:676
-msgid "Question (optional, one per line in the cell)"
-msgstr "问题（可选，每个单元格一行）"
-
-#: apps/knowledge/serializers/document.py:742
-msgid "knowledge id not exist"
-msgstr "知识库 ID 不存在"
-
-#: apps/knowledge/serializers/document.py:898
-msgid "The maximum size of the uploaded file cannot exceed {}MB"
-msgstr "上传文件的最大大小不能超过 {}MB"
-
-#: apps/knowledge/serializers/document.py:976
-msgid "space"
-msgstr "空格"
-
-#: apps/knowledge/serializers/document.py:977
-msgid "semicolon"
-msgstr "分号"
-
-#: apps/knowledge/serializers/document.py:977
-msgid "comma"
-msgstr "逗号"
-
-#: apps/knowledge/serializers/document.py:978
-msgid "period"
-msgstr "句号"
-
-#: apps/knowledge/serializers/document.py:978
-msgid "enter"
-msgstr "回车"
-
-#: apps/knowledge/serializers/document.py:979
-msgid "blank line"
-msgstr "空行"
-
-#: apps/knowledge/serializers/document.py:1140
-msgid "Hit handling method is required"
-msgstr "命中处理方法是必需的"
-
-#: apps/knowledge/serializers/document.py:1142
-msgid "The hit processing method must be directly_return|optimization"
-msgstr "命中处理方法必须是直接返回|优化"
-
-#: apps/knowledge/serializers/knowledge.py:51
-#: apps/knowledge/serializers/knowledge.py:58
-#: apps/knowledge/serializers/knowledge.py:67
-#: apps/knowledge/serializers/knowledge.py:108
-#: apps/shared/api/shared_knowledge.py:117
-#: apps/shared/api/shared_knowledge.py:150
-#: apps/shared/serializers/shared_knowledge.py:20
-#: apps/shared/serializers/shared_knowledge.py:26
-#: apps/shared/serializers/shared_knowledge.py:59
-#: apps/shared/serializers/shared_knowledge.py:106
-#: apps/xpack/serializers/dataset_lark_serializer.py:51
-#: apps/xpack/serializers/dataset_lark_serializer.py:289
-msgid "knowledge name"
-msgstr "知识库名称"
-
-#: apps/knowledge/serializers/knowledge.py:53
-#: apps/knowledge/serializers/knowledge.py:60
-#: apps/knowledge/serializers/knowledge.py:68
-#: apps/knowledge/serializers/knowledge.py:110
-#: apps/shared/api/shared_knowledge.py:124
-#: apps/shared/api/shared_knowledge.py:157
-#: apps/shared/serializers/shared_knowledge.py:21
-#: apps/shared/serializers/shared_knowledge.py:27
-#: apps/shared/serializers/shared_knowledge.py:60
-#: apps/shared/serializers/shared_knowledge.py:108
-#: apps/xpack/serializers/dataset_lark_serializer.py:53
-#: apps/xpack/serializers/dataset_lark_serializer.py:291
-msgid "knowledge description"
-msgstr "知识库描述"
-
-#: apps/knowledge/serializers/knowledge.py:54
-#: apps/knowledge/serializers/knowledge.py:61
-#: apps/shared/serializers/shared_knowledge.py:22
-#: apps/shared/serializers/shared_knowledge.py:28
-msgid "knowledge embedding"
-msgstr "知识库向量"
-
-#: apps/knowledge/serializers/knowledge.py:63
-#: apps/shared/serializers/shared_knowledge.py:30
-msgid "knowledge selector"
-msgstr "知识库选择器"
-
-#: apps/knowledge/serializers/knowledge.py:73
-#: apps/xpack/serializers/dataset_lark_serializer.py:296
-msgid "application id list"
-msgstr "智能体 ID 列表"
-
-#: apps/knowledge/serializers/knowledge.py:75
-msgid "file size limit"
-msgstr "文件大小限制"
-
-#: apps/knowledge/serializers/knowledge.py:76
-msgid "file count limit"
-msgstr "文件数量限制"
-
-#: apps/knowledge/serializers/knowledge.py:95
-#: apps/knowledge/serializers/knowledge.py:638
-msgid "query text"
-msgstr "查询文本"
-
-#: apps/knowledge/serializers/knowledge.py:96
-#: apps/knowledge/serializers/knowledge.py:639
-msgid "top number"
-msgstr "Top 数量"
-
-#: apps/knowledge/serializers/knowledge.py:98
-#: apps/knowledge/serializers/knowledge.py:641
-msgid "search mode"
-msgstr "搜索模式"
-
-#: apps/knowledge/serializers/knowledge.py:113
-msgid "knowledge scope"
-msgstr "知识库范围"
-
-#: apps/knowledge/serializers/knowledge.py:169
-#: apps/tools/serializers/tool.py:434 apps/tools/serializers/tool.py:464
-msgid "Folder not found"
-msgstr "文件夹不存在"
-
-#: apps/knowledge/serializers/knowledge.py:236
-#: apps/knowledge/serializers/knowledge.py:265
-msgid "Failed to send the vectorization task, please try again later!"
-msgstr "发送向量化任务失败，请稍后再试！"
-
-#: apps/knowledge/serializers/knowledge.py:315
-#: apps/knowledge/serializers/knowledge.py:471
-#: apps/knowledge/serializers/knowledge.py:533
-#: apps/xpack/serializers/dataset_lark_serializer.py:82
-#: apps/xpack/serializers/dataset_lark_serializer.py:340
-msgid "Knowledge base name duplicate!"
-msgstr "知识库名称重复！"
-
-#: apps/knowledge/serializers/knowledge.py:341
-#: apps/xpack/serializers/dataset_lark_serializer.py:359
-#, python-brace-format
-msgid "Unknown application id {knowledge_id}, cannot be associated"
-msgstr "未知智能体 ID {knowledge_id}，无法关联"
-
-#: apps/knowledge/serializers/knowledge.py:449
-#: apps/shared/serializers/shared_knowledge.py:62
-#: apps/shared/serializers/shared_knowledge.py:110
-#: apps/shared/serializers/shared_tool.py:46
-#: apps/shared/serializers/shared_tool.py:87 apps/tools/serializers/tool.py:456
-#: apps/xpack/serializers/dataset_lark_serializer.py:47
-msgid "scope"
-msgstr "范围"
-
-#: apps/knowledge/serializers/knowledge.py:460
-msgid ""
-"The community version supports up to 50 knowledge bases. If you need more "
-"knowledge bases, please contact us (https://fit2cloud.com/)."
-msgstr ""
-"社区版支持最多50个知识库，如需更多知识库，请联系我们 (https://"
-"fit2cloud.com/)."
-
-#: apps/knowledge/serializers/knowledge.py:560
-msgid "sync type"
-msgstr "同步类型"
-
-#: apps/knowledge/serializers/knowledge.py:562
-msgid "The synchronization type only supports:replace|complete"
-msgstr "同步类型仅支持:replace|complete"
-
-#: apps/knowledge/serializers/knowledge.py:568
-#: apps/knowledge/serializers/knowledge.py:649
-msgid "id does not exist"
-msgstr "知识库 ID 不存在"
-
-#: apps/knowledge/serializers/knowledge.py:636 apps/users/api/user.py:76
-msgid "id"
-msgstr "ID"
-
-#: apps/knowledge/serializers/paragraph.py:39
-#: apps/knowledge/serializers/problem.py:27
-#: apps/knowledge/serializers/problem.py:31
-#: apps/knowledge/serializers/problem.py:206
-msgid "content"
-msgstr "内容"
-
-#: apps/knowledge/serializers/paragraph.py:41
-#: apps/knowledge/serializers/paragraph.py:48
-#: apps/knowledge/serializers/paragraph.py:51
-#: apps/knowledge/serializers/paragraph.py:65
-#: apps/knowledge/serializers/paragraph.py:67
-#: apps/knowledge/serializers/paragraph.py:323
-msgid "section title"
-msgstr "章节标题"
-
-#: apps/knowledge/serializers/paragraph.py:44
-#: apps/tools/serializers/tool.py:152 apps/tools/serializers/tool.py:164
-#: apps/xpack/serializers/system_api_key.py:11
-msgid "Is active"
-msgstr "是否启用"
-
-#: apps/knowledge/serializers/paragraph.py:56
-#: apps/knowledge/serializers/paragraph.py:443
-msgid "paragraph id list"
-msgstr "段落 ID 列表"
-
-#: apps/knowledge/serializers/paragraph.py:57
-#: apps/knowledge/serializers/paragraph.py:72
-#: apps/knowledge/serializers/paragraph.py:136
-#: apps/knowledge/serializers/paragraph.py:350
-#: apps/knowledge/serializers/paragraph.py:444
-#: apps/knowledge/serializers/paragraph.py:561
-#: apps/knowledge/serializers/problem.py:35
-#: apps/knowledge/serializers/problem.py:50
-msgid "paragraph id"
-msgstr "段落 ID"
-
-#: apps/knowledge/serializers/paragraph.py:77
-#: apps/knowledge/serializers/paragraph.py:145
-msgid "Paragraph id does not exist"
-msgstr "段落 ID 不存在"
-
-#: apps/knowledge/serializers/paragraph.py:108
-msgid "Already associated, please do not associate again"
-msgstr "已关联，请勿再次关联"
-
-#: apps/knowledge/serializers/paragraph.py:181
-msgid "Problem id does not exist"
-msgstr "问题 ID 不存在"
-
-#: apps/knowledge/serializers/paragraph.py:348
-#: apps/knowledge/serializers/problem.py:26
-#: apps/knowledge/serializers/problem.py:46
-#: apps/knowledge/serializers/problem.py:56
-#: apps/knowledge/serializers/problem.py:127
-msgid "problem id"
-msgstr "问题 ID"
-
-#: apps/knowledge/serializers/paragraph.py:358
-msgid "Paragraph does not exist"
-msgstr "段落不存在"
-
-#: apps/knowledge/serializers/paragraph.py:360
-msgid "Problem does not exist"
-msgstr "问题不存在"
-
-#: apps/knowledge/serializers/paragraph.py:435
-msgid "The task is being executed, please do not send it again."
-msgstr "任务正在执行，请勿重复发送。"
-
-#: apps/knowledge/serializers/paragraph.py:442
-msgid "target document id"
-msgstr "目标文档 ID"
-
-#: apps/knowledge/serializers/paragraph.py:453
-msgid "The document to be migrated is consistent with the target document"
-msgstr "迁移的文档与目标文档一致"
-
-#: apps/knowledge/serializers/paragraph.py:455
-msgid "The document id does not exist [{document_id}]"
-msgstr "以下文档ID不存在: {error_id_list}"
-
-#: apps/knowledge/serializers/paragraph.py:459
-msgid "The target document id does not exist [{document_id}]"
-msgstr "以下目标文档ID不存在: {error_id_list}"
-
-#: apps/knowledge/serializers/paragraph.py:573
-msgid "new_position must be an integer"
-msgstr "new_position 必须是整数"
-
-#: apps/knowledge/serializers/problem.py:45
-#: apps/knowledge/serializers/problem.py:55
-msgid "problem id list"
-msgstr "问题 ID 列表"
-
-#: apps/knowledge/task/embedding.py:24 apps/knowledge/task/embedding.py:74
-#, python-brace-format
-msgid "Failed to obtain vector model: {error} {traceback}"
-msgstr "向量模型获取失败: {error} {traceback}"
-
-#: apps/knowledge/task/embedding.py:103
-#, python-brace-format
-msgid "Start--->Vectorized knowledge: {knowledge_id}"
-msgstr "开始--->向量知识库: {knowledge_id}"
-
-#: apps/knowledge/task/embedding.py:107
-#, python-brace-format
-msgid "Knowledge documentation: {document_names}"
-msgstr "知识库文档: {document_names}"
-
-#: apps/knowledge/task/embedding.py:120
-#, python-brace-format
-msgid "End--->Vectorized knowledge: {knowledge_id}"
-msgstr "结束--->向量知识库: {knowledge_id}"
-
-#: apps/knowledge/task/generate.py:106
-#, python-brace-format
-msgid ""
-"Generate issue based on document: {document_id} error {error}{traceback}"
-msgstr "生成问题基于文档: {document_id} 错误 {error}{traceback}"
-
-#: apps/knowledge/task/generate.py:110
-#, python-brace-format
-msgid "End--->Generate problem: {document_id}"
-msgstr "结束--->生成问题: {document_id}"
-
-#: apps/knowledge/task/handler.py:121
-#, python-brace-format
-msgid "Association problem failed {error}"
-msgstr "关联问题失败 {error}"
-
-#: apps/knowledge/task/sync.py:30 apps/knowledge/task/sync.py:47
-#, python-brace-format
-msgid "Start--->Start synchronization web knowledge base:{knowledge_id}"
-msgstr "开始--->开始同步 web 知识库:{knowledge_id}"
-
-#: apps/knowledge/task/sync.py:35 apps/knowledge/task/sync.py:51
-#, python-brace-format
-msgid "End--->End synchronization web knowledge base:{knowledge_id}"
-msgstr "结束--->结束同步 web 知识库:{knowledge_id}"
-
-#: apps/knowledge/task/sync.py:37 apps/knowledge/task/sync.py:53
-#, python-brace-format
-msgid "Synchronize web knowledge base:{knowledge_id} error{error}{traceback}"
-msgstr "同步 web 知识库:{knowledge_id} 错误{error}{traceback}"
-
-#: apps/knowledge/views/document.py:28 apps/knowledge/views/document.py:29
-#: apps/knowledge/views/document.py:30
-msgid "Create document"
-msgstr "创建文档"
-
-#: apps/knowledge/views/document.py:34 apps/knowledge/views/document.py:57
-#: apps/knowledge/views/document.py:84 apps/knowledge/views/document.py:104
-#: apps/knowledge/views/document.py:128 apps/knowledge/views/document.py:160
-#: apps/knowledge/views/document.py:191 apps/knowledge/views/document.py:209
-#: apps/knowledge/views/document.py:238 apps/knowledge/views/document.py:267
-#: apps/knowledge/views/document.py:295 apps/knowledge/views/document.py:323
-#: apps/knowledge/views/document.py:352 apps/knowledge/views/document.py:382
-#: apps/knowledge/views/document.py:412 apps/knowledge/views/document.py:441
-#: apps/knowledge/views/document.py:472 apps/knowledge/views/document.py:501
-#: apps/knowledge/views/document.py:527 apps/knowledge/views/document.py:553
-#: apps/knowledge/views/document.py:579 apps/knowledge/views/document.py:599
-#: apps/knowledge/views/document.py:633 apps/knowledge/views/document.py:664
-#: apps/knowledge/views/document.py:695 apps/knowledge/views/document.py:723
-#: apps/knowledge/views/document.py:737
-#: apps/xpack/views/dataset_lark_views.py:72
-#: apps/xpack/views/dataset_lark_views.py:91
-#: apps/xpack/views/dataset_lark_views.py:111
-#: apps/xpack/views/dataset_lark_views.py:132
-msgid "Knowledge Base/Documentation"
-msgstr "知识库/文档"
-
-#: apps/knowledge/views/document.py:52 apps/knowledge/views/document.py:53
-#: apps/knowledge/views/document.py:54
-msgid "Get document"
-msgstr "获取文档"
-
-#: apps/knowledge/views/document.py:79 apps/knowledge/views/document.py:80
-#: apps/knowledge/views/document.py:81
-msgid "Get document details"
-msgstr "文档文档详情"
-
-#: apps/knowledge/views/document.py:98 apps/knowledge/views/document.py:99
-#: apps/knowledge/views/document.py:100
-msgid "Modify document"
-msgstr "修改文档"
-
-#: apps/knowledge/views/document.py:123 apps/knowledge/views/document.py:124
-#: apps/knowledge/views/document.py:125
-msgid "Delete document"
-msgstr "删除文档"
-
-#: apps/knowledge/views/document.py:154 apps/knowledge/views/document.py:155
-#: apps/knowledge/views/document.py:156
-msgid "Segmented document"
-msgstr "分段文档"
-
-#: apps/knowledge/views/document.py:186 apps/knowledge/views/document.py:187
-#: apps/knowledge/views/document.py:188
-msgid "Get a list of segment IDs"
-msgstr "获取分段列表"
-
-#: apps/knowledge/views/document.py:203 apps/knowledge/views/document.py:204
-#: apps/knowledge/views/document.py:205
-msgid "Modify document hit processing methods in batches"
-msgstr "批量修改文档命中处理方法"
-
-#: apps/knowledge/views/document.py:232 apps/knowledge/views/document.py:233
-#: apps/knowledge/views/document.py:234
-msgid "Synchronize web site types"
-msgstr "同步网站类型"
-
-#: apps/knowledge/views/document.py:261 apps/knowledge/views/document.py:262
-#: apps/knowledge/views/document.py:263
-msgid "Refresh document vector library"
-msgstr "刷新文档向量库"
-
-#: apps/knowledge/views/document.py:289 apps/knowledge/views/document.py:290
-#: apps/knowledge/views/document.py:291
-msgid "Cancel task"
-msgstr "取消任务"
-
-#: apps/knowledge/views/document.py:317 apps/knowledge/views/document.py:318
-#: apps/knowledge/views/document.py:319
-msgid "Cancel tasks in batches"
-msgstr "批量取消任务"
-
-#: apps/knowledge/views/document.py:346 apps/knowledge/views/document.py:347
-#: apps/knowledge/views/document.py:348
-msgid "Create documents in batches"
-msgstr "批量创建文档"
-
-#: apps/knowledge/views/document.py:376 apps/knowledge/views/document.py:377
-#: apps/knowledge/views/document.py:378
-msgid "Batch sync documents"
-msgstr "批量同步文档"
-
-#: apps/knowledge/views/document.py:406 apps/knowledge/views/document.py:407
-#: apps/knowledge/views/document.py:408
-msgid "Delete documents in batches"
-msgstr "批量删除文档"
-
-#: apps/knowledge/views/document.py:436 apps/knowledge/views/document.py:437
-msgid "Batch refresh document vector library"
-msgstr "批量刷新文档向量库"
-
-#: apps/knowledge/views/document.py:466 apps/knowledge/views/document.py:467
-#: apps/knowledge/views/document.py:468
-msgid "Batch generate related problems"
-msgstr "批量生成相关问题"
-
-#: apps/knowledge/views/document.py:496 apps/knowledge/views/document.py:497
-#: apps/knowledge/views/document.py:498
-msgid "Get document by pagination"
-msgstr "分页获取文档"
-
-#: apps/knowledge/views/document.py:523 apps/knowledge/views/document.py:524
-msgid "Export document"
-msgstr "导出文档"
-
-#: apps/knowledge/views/document.py:549 apps/knowledge/views/document.py:550
-msgid "Export Zip document"
-msgstr "导出 Zip 文档"
-
-#: apps/knowledge/views/document.py:575 apps/knowledge/views/document.py:576
-msgid "Download source file"
-msgstr "下载源文件"
-
-#: apps/knowledge/views/document.py:594 apps/knowledge/views/document.py:595
-msgid "Migrate documents in batches"
-msgstr "批量迁移文档"
-
-#: apps/knowledge/views/document.py:627 apps/knowledge/views/document.py:628
-#: apps/knowledge/views/document.py:629
-#: apps/shared/views/shared_document.py:570
-msgid "Create Web site documents"
-msgstr "创建网站文档"
-
-#: apps/knowledge/views/document.py:658 apps/knowledge/views/document.py:659
-#: apps/knowledge/views/document.py:660
-msgid "Import QA and create documentation"
-msgstr "导入问答并创建文档"
-
-#: apps/knowledge/views/document.py:689 apps/knowledge/views/document.py:690
-#: apps/knowledge/views/document.py:691
-msgid "Import tables and create documents"
-msgstr "导入表格并创建文档"
-
-#: apps/knowledge/views/document.py:719 apps/knowledge/views/document.py:720
-msgid "Get QA template"
-msgstr "获取问答模板"
-
-#: apps/knowledge/views/document.py:733 apps/knowledge/views/document.py:734
-msgid "Get form template"
-msgstr "获取表格模板"
-
-#: apps/knowledge/views/knowledge.py:25 apps/knowledge/views/knowledge.py:26
-#: apps/knowledge/views/knowledge.py:27
-msgid "Get knowledge by folder"
-msgstr "根据文件夹获取知识库"
-
-#: apps/knowledge/views/knowledge.py:30 apps/knowledge/views/knowledge.py:59
-#: apps/knowledge/views/knowledge.py:83 apps/knowledge/views/knowledge.py:106
-#: apps/knowledge/views/knowledge.py:127 apps/knowledge/views/knowledge.py:156
-#: apps/knowledge/views/knowledge.py:188 apps/knowledge/views/knowledge.py:218
-#: apps/knowledge/views/knowledge.py:242 apps/knowledge/views/knowledge.py:266
-#: apps/knowledge/views/knowledge.py:293 apps/knowledge/views/knowledge.py:319
-#: apps/knowledge/views/knowledge.py:343 apps/knowledge/views/knowledge.py:369
-#: apps/knowledge/views/knowledge.py:397
-#: apps/xpack/views/dataset_lark_views.py:29
-#: apps/xpack/views/dataset_lark_views.py:50
-msgid "Knowledge Base"
-msgstr "知识库"
-
-#: apps/knowledge/views/knowledge.py:53 apps/knowledge/views/knowledge.py:54
-#: apps/knowledge/views/knowledge.py:55
-msgid "Edit knowledge"
-msgstr "修改知识库"
-
-#: apps/knowledge/views/knowledge.py:77 apps/knowledge/views/knowledge.py:78
-#: apps/knowledge/views/knowledge.py:79
-msgid "Delete knowledge"
-msgstr "删除知识库"
-
-#: apps/knowledge/views/knowledge.py:101 apps/knowledge/views/knowledge.py:102
-#: apps/knowledge/views/knowledge.py:103
-msgid "Get knowledge"
-msgstr "获取知识库"
-
-#: apps/knowledge/views/knowledge.py:122 apps/knowledge/views/knowledge.py:123
-#: apps/knowledge/views/knowledge.py:124
-msgid "Get the knowledge base paginated list"
-msgstr "获取知识库分页列表"
-
-#: apps/knowledge/views/knowledge.py:150 apps/knowledge/views/knowledge.py:151
-#: apps/knowledge/views/knowledge.py:152
-msgid "Synchronize the knowledge base of the website"
-msgstr "同步网站知识库"
-
-#: apps/knowledge/views/knowledge.py:182 apps/knowledge/views/knowledge.py:183
-#: apps/knowledge/views/knowledge.py:184
-msgid "Hit test list"
-msgstr "命中测试列表"
-
-#: apps/knowledge/views/knowledge.py:212 apps/knowledge/views/knowledge.py:213
-#: apps/knowledge/views/knowledge.py:214
-msgid "Re-vectorize"
-msgstr "重新向量化"
-
-#: apps/knowledge/views/knowledge.py:238 apps/knowledge/views/knowledge.py:239
-msgid "Export knowledge base"
-msgstr "导出知识库"
-
-#: apps/knowledge/views/knowledge.py:262 apps/knowledge/views/knowledge.py:263
-msgid "Export knowledge base containing images"
-msgstr "导出包含图片的知识库"
-
-#: apps/knowledge/views/knowledge.py:287 apps/knowledge/views/knowledge.py:288
-#: apps/knowledge/views/knowledge.py:289
-msgid "Generate related"
-msgstr "生成相关"
-
-#: apps/knowledge/views/knowledge.py:314 apps/knowledge/views/knowledge.py:315
-#: apps/knowledge/views/knowledge.py:316
-msgid "Get model for knowledge base"
-msgstr "获取知识库模型"
-
-#: apps/knowledge/views/knowledge.py:338 apps/knowledge/views/knowledge.py:339
-#: apps/knowledge/views/knowledge.py:340
-msgid "Get embedding model for knowledge base"
-msgstr "获取知识库向量模型"
-
-#: apps/knowledge/views/knowledge.py:363 apps/knowledge/views/knowledge.py:364
-#: apps/knowledge/views/knowledge.py:365
-msgid "Create base knowledge"
-msgstr "创建知识库"
-
-#: apps/knowledge/views/knowledge.py:391 apps/knowledge/views/knowledge.py:392
-#: apps/knowledge/views/knowledge.py:393
-msgid "Create web knowledge"
-msgstr "创建 web 知识库"
-
-#: apps/knowledge/views/paragraph.py:24 apps/knowledge/views/paragraph.py:25
-#: apps/knowledge/views/paragraph.py:26
-msgid "Paragraph list"
-msgstr "段落列表"
-
-#: apps/knowledge/views/paragraph.py:29 apps/knowledge/views/paragraph.py:53
-#: apps/knowledge/views/paragraph.py:82 apps/knowledge/views/paragraph.py:102
-#: apps/knowledge/views/paragraph.py:138 apps/knowledge/views/paragraph.py:167
-#: apps/knowledge/views/paragraph.py:199 apps/knowledge/views/paragraph.py:224
-#: apps/knowledge/views/paragraph.py:259 apps/knowledge/views/paragraph.py:289
-#: apps/knowledge/views/paragraph.py:316 apps/knowledge/views/paragraph.py:351
-#: apps/knowledge/views/paragraph.py:385 apps/knowledge/views/paragraph.py:415
-msgid "Knowledge Base/Documentation/Paragraph"
-msgstr "知识库/文档/段落"
-
-#: apps/knowledge/views/paragraph.py:48 apps/knowledge/views/paragraph.py:49
-msgid "Create Paragraph"
-msgstr "创建段落"
-
-#: apps/knowledge/views/paragraph.py:76 apps/knowledge/views/paragraph.py:77
-#: apps/knowledge/views/paragraph.py:78
-msgid "Batch Paragraph"
-msgstr "批量段落"
-
-#: apps/knowledge/views/paragraph.py:97 apps/knowledge/views/paragraph.py:98
-msgid "Migrate paragraphs in batches"
-msgstr "批量迁移段落"
-
-#: apps/knowledge/views/paragraph.py:132 apps/knowledge/views/paragraph.py:133
-#: apps/knowledge/views/paragraph.py:134
-msgid "Batch Generate Related"
-msgstr "批量生成相关"
-
-#: apps/knowledge/views/paragraph.py:161 apps/knowledge/views/paragraph.py:162
-#: apps/knowledge/views/paragraph.py:163
-msgid "Modify paragraph data"
-msgstr "修改段落数据"
-
-#: apps/knowledge/views/paragraph.py:194 apps/knowledge/views/paragraph.py:195
-#: apps/knowledge/views/paragraph.py:196
-msgid "Get paragraph details"
-msgstr "获取段落详情"
-
-#: apps/knowledge/views/paragraph.py:219 apps/knowledge/views/paragraph.py:220
-#: apps/knowledge/views/paragraph.py:221
-msgid "Delete paragraph"
-msgstr "删除段落"
-
-#: apps/knowledge/views/paragraph.py:253 apps/knowledge/views/paragraph.py:254
-#: apps/knowledge/views/paragraph.py:255
-msgid "Add associated questions"
-msgstr "添加关联问题"
-
-#: apps/knowledge/views/paragraph.py:284 apps/knowledge/views/paragraph.py:285
-#: apps/knowledge/views/paragraph.py:286
-msgid "Get a list of paragraph questions"
-msgstr "获取段落问题列表"
-
-#: apps/knowledge/views/paragraph.py:310 apps/knowledge/views/paragraph.py:311
-#: apps/knowledge/views/paragraph.py:312
-msgid "Disassociation issue"
-msgstr "取消关联问题"
-
-#: apps/knowledge/views/paragraph.py:345 apps/knowledge/views/paragraph.py:346
-#: apps/knowledge/views/paragraph.py:347
-msgid "Related questions"
-msgstr "关联问题"
-
-#: apps/knowledge/views/paragraph.py:380 apps/knowledge/views/paragraph.py:381
-#: apps/knowledge/views/paragraph.py:382
-msgid "Get paragraph list by pagination"
-msgstr "获取段落列表"
-
-#: apps/knowledge/views/paragraph.py:409 apps/knowledge/views/paragraph.py:410
-#: apps/knowledge/views/paragraph.py:411
-#: apps/resource_manage/views/paragraph.py:364
-#: apps/resource_manage/views/paragraph.py:365
-#: apps/resource_manage/views/paragraph.py:366
-#: apps/shared/views/shared_paragraph.py:365
-#: apps/shared/views/shared_paragraph.py:366
-#: apps/shared/views/shared_paragraph.py:367
-msgid "Adjust paragraph position"
-msgstr "调整段落位置"
-
-#: apps/knowledge/views/problem.py:23 apps/knowledge/views/problem.py:24
-#: apps/knowledge/views/problem.py:25
-msgid "Question list"
-msgstr "问题列表"
-
-#: apps/knowledge/views/problem.py:28 apps/knowledge/views/problem.py:53
-#: apps/knowledge/views/problem.py:78 apps/knowledge/views/problem.py:104
-#: apps/knowledge/views/problem.py:131 apps/knowledge/views/problem.py:157
-#: apps/knowledge/views/problem.py:186 apps/knowledge/views/problem.py:216
-msgid "Knowledge Base/Documentation/Paragraph/Question"
-msgstr "知识库/文档/段落/问题"
-
-#: apps/knowledge/views/problem.py:47 apps/knowledge/views/problem.py:48
-#: apps/knowledge/views/problem.py:49
-msgid "Create question"
-msgstr "创建问题"
-
-#: apps/knowledge/views/problem.py:73 apps/knowledge/views/problem.py:74
-#: apps/knowledge/views/problem.py:75
-msgid "Get a list of associated paragraphs"
-msgstr "获取关联段落列表"
-
-#: apps/knowledge/views/problem.py:98 apps/knowledge/views/problem.py:99
-#: apps/knowledge/views/problem.py:100
-msgid "Batch associated paragraphs"
-msgstr "批量关联段落"
-
-#: apps/knowledge/views/problem.py:125 apps/knowledge/views/problem.py:126
-#: apps/knowledge/views/problem.py:127
-msgid "Batch deletion issues"
-msgstr "批量删除问题"
-
-#: apps/knowledge/views/problem.py:152 apps/knowledge/views/problem.py:153
-#: apps/knowledge/views/problem.py:154
-msgid "Delete question"
-msgstr "删除问题"
-
-#: apps/knowledge/views/problem.py:180 apps/knowledge/views/problem.py:181
-#: apps/knowledge/views/problem.py:182
-msgid "Modify question"
-msgstr "修改问题"
-
-#: apps/knowledge/views/problem.py:211 apps/knowledge/views/problem.py:212
-#: apps/knowledge/views/problem.py:213
-msgid "Get the list of questions by page"
-msgstr "分页获取问题列表"
-
-#: apps/maxkb/settings/base.py:101
-msgid "Intelligent customer service platform"
-msgstr "强大易用的企业级智能体平台"
-
-#: apps/models_provider/api/model.py:37 apps/models_provider/api/provide.py:17
-#: apps/models_provider/api/provide.py:23
-#: apps/models_provider/api/provide.py:28
-#: apps/models_provider/api/provide.py:30
-#: apps/models_provider/api/provide.py:82
-#: apps/models_provider/serializers/model_serializer.py:40
-#: apps/models_provider/serializers/model_serializer.py:215
-#: apps/models_provider/serializers/model_serializer.py:253
-#: apps/models_provider/serializers/model_serializer.py:318
-#: apps/models_provider/serializers/model_serializer.py:393
-#: apps/shared/api/shared_model.py:18
-#: apps/shared/serializers/shared_model.py:111
-msgid "model name"
-msgstr "模型名称"
-
-#: apps/models_provider/api/model.py:44 apps/models_provider/api/provide.py:29
-#: apps/models_provider/api/provide.py:70
-#: apps/models_provider/api/provide.py:98
-#: apps/models_provider/serializers/model_serializer.py:42
-#: apps/models_provider/serializers/model_serializer.py:217
-#: apps/models_provider/serializers/model_serializer.py:255
-#: apps/models_provider/serializers/model_serializer.py:319
-#: apps/models_provider/serializers/model_serializer.py:394
-#: apps/shared/api/shared_model.py:25
-#: apps/shared/serializers/shared_model.py:112
-msgid "model type"
-msgstr "模型类型"
-
-#: apps/models_provider/api/model.py:51
-#: apps/models_provider/serializers/model_serializer.py:43
-#: apps/models_provider/serializers/model_serializer.py:219
-#: apps/models_provider/serializers/model_serializer.py:256
-#: apps/models_provider/serializers/model_serializer.py:320
-#: apps/models_provider/serializers/model_serializer.py:395
-#: apps/shared/api/shared_model.py:32
-#: apps/shared/serializers/shared_model.py:113
-msgid "base model"
-msgstr "基础模型"
-
-#: apps/models_provider/api/model.py:58 apps/models_provider/api/provide.py:18
-#: apps/models_provider/api/provide.py:38
-#: apps/models_provider/api/provide.py:76
-#: apps/models_provider/api/provide.py:104
-#: apps/models_provider/api/provide.py:126
-#: apps/models_provider/serializers/model_serializer.py:41
-#: apps/models_provider/serializers/model_serializer.py:254
-#: apps/models_provider/serializers/model_serializer.py:321
-#: apps/models_provider/serializers/model_serializer.py:396
-#: apps/shared/api/shared_model.py:39
-#: apps/shared/serializers/shared_model.py:114
-msgid "provider"
-msgstr "供应商"
-
-#: apps/models_provider/api/model.py:65
-#: apps/models_provider/serializers/model_serializer.py:322
-#: apps/models_provider/serializers/model_serializer.py:397
-#: apps/shared/api/shared_model.py:46
-#: apps/shared/serializers/shared_model.py:115
-msgid "create user"
-msgstr "创建用户"
-
-#: apps/models_provider/api/provide.py:19
-#: apps/xpack/serializers/application_setting_serializer.py:41
-#: apps/xpack/serializers/system_params.py:21
-msgid "icon"
-msgstr "图标"
-
-#: apps/models_provider/api/provide.py:34 apps/tools/serializers/tool.py:134
-msgid "input type"
-msgstr "输入类型"
-
-#: apps/models_provider/api/provide.py:35
-msgid "label"
-msgstr "标签"
-
-#: apps/models_provider/api/provide.py:36
-msgid "text field"
-msgstr "文本字段"
-
-#: apps/models_provider/api/provide.py:37
-msgid "value field"
-msgstr "值"
-
-#: apps/models_provider/api/provide.py:39
-msgid "method"
-msgstr "方法"
-
-#: apps/models_provider/api/provide.py:40 apps/tools/serializers/tool.py:119
-#: apps/tools/serializers/tool.py:133
-msgid "required"
-msgstr "必填"
-
-#: apps/models_provider/api/provide.py:41
-msgid "default value"
-msgstr "默认值"
-
-#: apps/models_provider/api/provide.py:42
-msgid "relation show field dict"
-msgstr "关系显示字段"
-
-#: apps/models_provider/api/provide.py:43
-msgid "relation trigger field dict"
-msgstr "关系触发字段"
-
-#: apps/models_provider/api/provide.py:44
-msgid "trigger type"
-msgstr "触发类型"
-
-#: apps/models_provider/api/provide.py:45
-msgid "attrs"
-msgstr "属性"
-
-#: apps/models_provider/api/provide.py:46
-msgid "props info"
-msgstr "props 信息"
-
-#: apps/models_provider/base_model_provider.py:60
-msgid "Model type cannot be empty"
-msgstr "模型类型不能为空"
-
-#: apps/models_provider/base_model_provider.py:85
-msgid "The current platform does not support downloading models"
-msgstr "当前平台不支持下载模型"
-
-#: apps/models_provider/base_model_provider.py:143
-msgid "LLM"
-msgstr "大语言模型"
-
-#: apps/models_provider/base_model_provider.py:144
-msgid "Embedding Model"
-msgstr "向量模型"
-
-#: apps/models_provider/base_model_provider.py:145
-msgid "Speech2Text"
-msgstr "语音识别"
-
-#: apps/models_provider/base_model_provider.py:146
-msgid "TTS"
-msgstr "语音合成"
-
-#: apps/models_provider/base_model_provider.py:147
-msgid "Vision Model"
-msgstr "视觉模型"
-
-#: apps/models_provider/base_model_provider.py:148
-msgid "Image Generation"
-msgstr "图片生成"
-
-#: apps/models_provider/base_model_provider.py:149
-msgid "Rerank"
-msgstr "重排模型"
-
-#: apps/models_provider/base_model_provider.py:223
-msgid "The model does not support"
-msgstr "模型不支持"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:42
-msgid ""
-"With the GTE-Rerank text sorting series model developed by Alibaba Tongyi "
-"Lab, developers can integrate high-quality text retrieval and sorting "
-"through the LlamaIndex framework."
-msgstr ""
-"阿里巴巴通义实验室开发的GTE-Rerank文本排序系列模型，开发者可以通过LlamaIndex"
-"框架进行集成高质量文本检索、排序。"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:45
-msgid ""
-"Chinese (including various dialects such as Cantonese), English, Japanese, "
-"and Korean support free switching between multiple languages."
-msgstr "中文（含粤语等各种方言）、英文、日语、韩语支持多个语种自由切换"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:48
-msgid ""
-"CosyVoice is based on a new generation of large generative speech models, "
-"which can predict emotions, intonation, rhythm, etc. based on context, and "
-"has better anthropomorphic effects."
-msgstr ""
-"CosyVoice基于新一代生成式语音大模型，能根据上下文预测情绪、语调、韵律等，具有"
-"更好的拟人效果"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:51
-msgid ""
-"Universal text vector is Tongyi Lab's multi-language text unified vector "
-"model based on the LLM base. It provides high-level vector services for "
-"multiple mainstream languages around the world and helps developers quickly "
-"convert text data into high-quality vector data."
-msgstr ""
-"通用文本向量，是通义实验室基于LLM底座的多语言文本统一向量模型，面向全球多个主"
-"流语种，提供高水准的向量服务，帮助开发者将文本数据快速转换为高质量的向量数"
-"据。"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:69
-msgid ""
-"Tongyi Wanxiang - a large image model for text generation, supports "
-"bilingual input in Chinese and English, and supports the input of reference "
-"pictures for reference content or reference style migration. Key styles "
-"include but are not limited to watercolor, oil painting, Chinese painting, "
-"sketch, flat illustration, two-dimensional, and 3D. Cartoon."
-msgstr ""
-"通义万相-文本生成图像大模型，支持中英文双语输入，支持输入参考图片进行参考内容"
-"或者参考风格迁移，重点风格包括但不限于水彩、油画、中国画、素描、扁平插画、二"
-"次元、3D卡通。"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:95
-msgid "Alibaba Cloud Bailian"
-msgstr "阿里云百炼"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:53
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:50
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:74
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:77
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:61
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tti.py:43
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py:37
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:33
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:34
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:53
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:37
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:40
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:69
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:32
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/gemini_model_provider/model/stt.py:43
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:37
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:37
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:44
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:35
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:35
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:58
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:37
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:58
-#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:23
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:37
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:51
-#: apps/models_provider/impl/tencent_model_provider/model/tti.py:54
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:50
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:32
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/volcanic_engine_model_provider/model/tts.py:77
-#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:60
-#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:76
-#: apps/models_provider/impl/xf_model_provider/model/tts.py:101
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:32
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:50
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:34
-#: apps/models_provider/impl/xinference_model_provider/model/tts.py:44
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:31
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:56
-#: apps/models_provider/impl/zhipu_model_provider/model/tti.py:49
-msgid "Hello"
-msgstr "你好"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:36
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:46
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt.py:44
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:96
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:89
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:23
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:21
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:40
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:30
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/azure_model_provider/credential/stt.py:23
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:58
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:41
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:22
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:21
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:28
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/ollama_model_provider/credential/image.py:19
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:44
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:27
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:31
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:25
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:48
-#: apps/models_provider/impl/openai_model_provider/credential/stt.py:22
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:61
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:40
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:25
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:28
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:22
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:61
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:22
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:19
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:28
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:78
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/vllm_model_provider/credential/image.py:22
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:39
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:22
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:25
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:41
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:51
-#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:46
-#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:29
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/xf_model_provider/credential/stt.py:24
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:47
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:19
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:22
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:39
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:25
-#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:21
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:59
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:39
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:21
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:40
-#, python-brace-format
-msgid "{model_type} Model type is not supported"
-msgstr "{model_type} 模型类型不支持"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:44
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:67
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:55
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt.py:53
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:105
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:98
-#, python-brace-format
-msgid "{key} is required"
-msgstr "{key} 是必填项"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:60
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:85
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:69
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt.py:67
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:121
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:113
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:43
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:65
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:42
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:61
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:50
-#: apps/models_provider/impl/azure_model_provider/credential/stt.py:40
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:77
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:58
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:65
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:42
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:38
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:64
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:44
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:45
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:51
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:45
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:67
-#: apps/models_provider/impl/openai_model_provider/credential/stt.py:39
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:80
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:58
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:45
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:44
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:39
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:80
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:40
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:30
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:47
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:104
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/vllm_model_provider/credential/image.py:42
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:55
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:42
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:42
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:58
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:68
-#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:38
-#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:38
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:50
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:84
-#: apps/models_provider/impl/xf_model_provider/credential/stt.py:41
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:65
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:41
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:40
-#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:37
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:77
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:56
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:41
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:64
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:59
-#, python-brace-format
-msgid ""
-"Verification failed, please check whether the parameters are correct: {error}"
-msgstr "认证失败，请检查参数是否正确：{error}"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:17
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:14
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:20
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:14
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:41
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:22
-msgid "Temperature"
-msgstr "温度"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:18
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:21
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:16
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:42
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:16
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:23
-msgid ""
-"Higher values make the output more random, while lower values make it more "
-"focused and deterministic"
-msgstr "较高的数值会使输出更加随机，而较低的数值会使其更加集中和确定"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:30
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:43
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:29
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:50
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:31
-msgid "Output the maximum Tokens"
-msgstr "输出最大Token数"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:31
-msgid "Specify the maximum number of tokens that the model can generate."
-msgstr "指定模型可以生成的最大 tokens 数"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:43
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:15
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:74
-msgid "API URL"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:14
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:15
-msgid "Image size"
-msgstr "图片尺寸"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:15
-msgid "Specify the size of the generated image, such as: 1024x1024"
-msgstr "指定生成图片的尺寸, 如: 1024x1024"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:34
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:40
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:43
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:43
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:41
-msgid "Number of pictures"
-msgstr "图片数量"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:34
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:40
-msgid "Specify the number of generated images"
-msgstr "指定生成图片的数量"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:44
-msgid "Style"
-msgstr "风格"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:44
-msgid "Specify the style of generated images"
-msgstr "指定生成图片的风格"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:48
-msgid "Default value, the image style is randomly output by the model"
-msgstr "默认值，图片风格由模型随机输出"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:49
-msgid "photography"
-msgstr "摄影"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:50
-msgid "Portraits"
-msgstr "人像写真"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:51
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:52
 msgid "3D cartoon"
 msgstr "3D卡通"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:52
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:102
+msgid "7B dense converter for rapid deployment and easy customization. Small in size yet powerful in a variety of use cases. Supports English and code, as well as 32k context windows."
+msgstr "7B 密集型转换器，可快速部署，易于定制。体积虽小，但功能强大，适用于各种用例。支持英语和代码，以及 32k 的上下文窗口。"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:47
+msgid "A better routing strategy is adopted to simultaneously alleviate the problems of load balancing and expert convergence. For long articles, the needle-in-a-haystack index reaches 99.9%"
+msgstr "采用更优的路由策略，同时缓解了负载均衡和专家趋同的问题。长文方面，大海捞针指标达到99.9%"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:76
+msgid "A faster, more affordable but still very powerful model that can handle a range of tasks including casual conversation, text analysis, summarization and document question answering."
+msgstr "一种更快速、更实惠但仍然非常强大的模型，它可以处理一系列任务，包括随意对话、文本分析、摘要和文档问题回答。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:162
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:197
+msgid "A high-performance open embedding model with a large token context window."
+msgstr "一个具有大 tokens上下文窗口的高性能开放嵌入模型。"
+
+#: apps/common/constants/permission_constants.py:1291
+msgid "About"
+msgstr "关于"
+
+#: apps/chat/serializers/chat_record.py:122
+msgid "Abstract"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:24
+msgid "accent"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:24
+msgid "Access Key ID"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:374
+msgid "Access restrictions"
+msgstr "访问限制"
+
+#: apps/oss/serializers/file.py:198
+msgid "Access to internal IP addresses is blocked"
+msgstr ""
+
+#: apps/chat/api/chat_authentication_api.py:45
+#: apps/chat/serializers/chat_authentication.py:27
+#: apps/chat/serializers/chat_authentication.py:53
+msgid "access_token"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:172
+msgid "accurate"
+msgstr "内容准确"
+
+#: apps/application/serializers/application.py:207
+msgid "Acquaintance"
+msgstr "相似度"
+
+#: apps/trigger/views/trigger.py:201
+#: apps/trigger/views/trigger.py:202
+#: apps/trigger/views/trigger.py:203
+msgid "Activate trigger in batches"
+msgstr "批量启用/禁用触发器"
+
+#: apps/homepage/api/home_page_api.py:385
+msgid "Active model count"
+msgstr "启用模型数量"
+
+#: apps/homepage/api/home_page_api.py:348
+msgid "Active tool count"
+msgstr "启用工具数量"
+
+#: apps/homepage/serializers/homepage.py:492
+#: apps/homepage/serializers/homepage.py:629
+msgid "active users"
+msgstr "活跃用户数"
+
+#: no source
+msgid "Add ApiKey"
+msgstr "添加 API KEY"
+
+#: apps/tools/views/tool.py:547
+#: apps/tools/views/tool.py:548
+#: apps/tools/views/tool.py:549
+msgid "Add Appstore tool"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:276
+#: apps/knowledge/views/paragraph.py:277
+#: apps/knowledge/views/paragraph.py:278
+msgid "Add associated questions"
+msgstr "添加关联问题"
+
+#: apps/knowledge/views/document.py:1039
+#: apps/knowledge/views/document.py:1040
+#: apps/knowledge/views/document.py:1041
+msgid "Add document tags"
+msgstr ""
+
+#: apps/tools/views/tool.py:500
+#: apps/tools/views/tool.py:501
+#: apps/tools/views/tool.py:502
+msgid "Add internal tool"
+msgstr "添加内置工具"
+
+#: apps/common/constants/permission_constants.py:365
+msgid "Add Member"
+msgstr "添加成员"
+
+#: no source
+msgid "Add member to chat user group"
+msgstr "添加成员到对话用户组"
+
+#: no source
+msgid "Add member to system role"
+msgstr "系统角色添加成员"
+
+#: no source
+msgid "Add member to system workspace"
+msgstr "系统工作空间添加成员"
+
+#: no source
+msgid "Add member to user group"
+msgstr "添加成员到用户组"
+
+#: no source
+msgid "Add member to workspace"
+msgstr "工作空间添加成员"
+
+#: no source
+msgid "Add member to workspace role"
+msgstr "工作空间角色添加成员"
+
+#: no source
+msgid "Add or modify authentication configuration"
+msgstr "添加或修改认证配置"
+
+#: no source
+msgid "Add or modify Chat/Authentication Configuration"
+msgstr "添加或修改对话/认证配置"
+
+#: no source
+msgid "Add personal system API_KEY"
+msgstr "添加个人系统API KEY"
+
+#: no source
+msgid "Add shared associated questions"
+msgstr "添加关联问题"
+
+#: no source
+msgid "Add system associated questions"
+msgstr "添加关联问题"
+
+#: apps/application/views/application_chat_record.py:116
+#: apps/application/views/application_chat_record.py:117
+#: apps/application/views/application_chat_record.py:118
+#: apps/common/constants/permission_constants.py:382
+msgid "Add to Knowledge Base"
+msgstr "添加到知识库"
+
+#: no source
+msgid "Add user"
+msgstr "添加用户"
+
+#: apps/knowledge/views/paragraph.py:446
+#: apps/knowledge/views/paragraph.py:447
+#: apps/knowledge/views/paragraph.py:448
+msgid "Adjust paragraph position"
+msgstr "调整段落位置"
+
+#: no source
+msgid "ADMIN"
+msgstr "系统管理员"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:108
+msgid "Advanced Mistral AI large-scale language model capable of handling any language task, including complex multilingual reasoning, text understanding, transformation, and code generation."
+msgstr "先进的 Mistral AI 大型语言模型，能够处理任何语言任务，包括复杂的多语言推理、文本理解、转换和代码生成。"
+
+#: apps/application/serializers/application.py:468
+#: apps/application/serializers/application.py:468
+msgid "Affiliation user"
+msgstr "关联用户"
+
+#: no source
+msgid "Agent ID is required"
+msgstr "Agent ID 是必填项"
+
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:417
+#: apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py:386
+msgid "Agent Key is required for agent tool 【{name}】"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:411
+#: apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py:380
+msgid "Agent 【{name}】 access token authentication is not supported for agent tool"
+msgstr ""
+
+#: no source
+msgid "AI reply: "
+msgstr "AI 回复: "
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:240
+msgid "Alibaba Cloud Bailian"
+msgstr "阿里云百炼"
+
+#: no source
+msgid "Allow cross domain"
+msgstr "允许跨域"
+
+#: apps/knowledge/serializers/paragraph.py:167
+msgid "Already associated, please do not associate again"
+msgstr "已关联，请勿再次关联"
+
+#: apps/chat/serializers/chat_record.py:94
+msgid "Already voted, please cancel first and then vote again"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:96
+msgid "Amazon Titan Text Express has context lengths of up to 8,000 tokens, making it ideal for a variety of high-level general language tasks, such as open-ended text generation and conversational chat, as well as support in retrieval-augmented generation (RAG). At launch, the model is optimized for English, but other languages are supported."
+msgstr "Amazon Titan Text Express 的上下文长度长达 8000 个 tokens，因而非常适合各种高级常规语言任务，例如开放式文本生成和对话式聊天，以及检索增强生成（RAG）中的支持。在发布时，该模型针对英语进行了优化，但也支持其他语言。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:90
+msgid "Amazon Titan Text Lite is a lightweight, efficient model ideal for fine-tuning English-language tasks, including summarization and copywriting, where customers require smaller, more cost-effective, and highly customizable models."
+msgstr "Amazon Titan Text Lite 是一种轻量级的高效模型，非常适合英语任务的微调，包括摘要和文案写作等，在这种场景下，客户需要更小、更经济高效且高度可定制的模型"
+
+#: no source
+msgid "An error occurred while processing the GET request {e}"
+msgstr "get 请求处理时发生错误 {e}"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:41
+msgid "An update to Claude 2 that doubles the context window and improves reliability, hallucination rates, and evidence-based accuracy in long documents and RAG contexts."
+msgstr "Claude 2 的更新，采用双倍的上下文窗口，并在长文档和 RAG 上下文中提高可靠性、幻觉率和循证准确性。"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:53
 msgid "animation"
 msgstr "动画"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:53
-msgid "painting"
-msgstr "油画"
+#: no source
+msgid "Animation 1.3.0-Vincent Picture"
+msgstr "动漫1.3.0-文生图"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:54
-msgid "watercolor"
-msgstr "水彩"
+#: no source
+msgid "Animation 1.3.1-Vincent Picture"
+msgstr "动漫1.3.1-文生图"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:55
-msgid "sketch"
-msgstr "素描"
+#: apps/application/serializers/application_chat.py:220
+#: apps/application/views/application_chat_record.py:165
+#: apps/application/views/application_chat_record.py:166
+#: apps/application/views/application_chat_record.py:167
+#: apps/common/constants/permission_constants.py:370
+msgid "Annotation"
+msgstr "标注"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:56
-msgid "Chinese painting"
-msgstr "中国画"
+#: apps/application/serializers/application_chat.py:216
+msgid "answer"
+msgstr "回答"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:57
-msgid "flat illustration"
-msgstr "扁平插画"
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:48
+msgid "Anthropic is a powerful model that can handle a variety of tasks, from complex dialogue and creative content generation to detailed command obedience."
+msgstr "Anthropic 功能强大的模型，可处理各种任务，从复杂的对话和创意内容生成到详细的指令服从。"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:20
-msgid "Timbre"
-msgstr "音色"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:20
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:15
-msgid "Chinese sounds can support mixed scenes of Chinese and English"
-msgstr "中文音色支持中英文混合场景"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:26
-msgid "Long Xiaochun"
-msgstr "龙小淳"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:27
-msgid "Long Xiaoxia"
-msgstr "龙小夏"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:28
-msgid "Long Xiaochen"
-msgstr "龙小诚"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:29
-msgid "Long Xiaobai"
-msgstr "龙小白"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:30
-msgid "Long Laotie"
-msgstr "龙老铁"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:31
-msgid "Long Shu"
-msgstr "龙书"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:32
-msgid "Long Shuo"
-msgstr "龙硕"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:33
-msgid "Long Jing"
-msgstr "龙婧"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:34
-msgid "Long Miao"
-msgstr "龙妙"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:35
-msgid "Long Yue"
-msgstr "龙悦"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:36
-msgid "Long Yuan"
-msgstr "龙媛"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:37
-msgid "Long Fei"
-msgstr "龙飞"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:38
-msgid "Long Jielidou"
-msgstr "龙杰力豆"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:39
-msgid "Long Tong"
-msgstr "龙彤"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:40
-msgid "Long Xiang"
-msgstr "龙祥"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:47
-msgid "Speaking speed"
-msgstr "语速"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:47
-msgid "[0.5, 2], the default is 1, usually one decimal place is enough"
-msgstr "[0.5,2]，默认为1，通常一位小数就足够了"
-
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:28
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:32
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:35
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:64
-#: apps/models_provider/impl/azure_model_provider/credential/stt.py:28
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:63
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:46
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:27
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:26
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:32
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:46
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:62
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:63
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:30
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:53
-#: apps/models_provider/impl/openai_model_provider/credential/stt.py:27
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:66
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:45
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:30
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:32
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:27
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:66
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:27
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:32
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/vllm_model_provider/credential/image.py:27
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:65
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:27
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:30
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:46
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:56
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:55
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:72
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:34
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:71
-#: apps/models_provider/impl/xf_model_provider/credential/stt.py:29
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:52
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:40
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:27
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:29
-#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:26
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:64
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:44
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:26
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:51
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:45
-#, python-brace-format
-msgid "{key}  is required"
-msgstr "{key} 是必填项"
-
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:33
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:44
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:30
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:33
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:25
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:51
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:25
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:32
-msgid "Specify the maximum number of tokens that the model can generate"
-msgstr "指定模型可以生成的最大 tokens 数"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:36
-msgid ""
-"An update to Claude 2 that doubles the context window and improves "
-"reliability, hallucination rates, and evidence-based accuracy in long "
-"documents and RAG contexts."
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:21
+msgid "API"
 msgstr ""
-"Claude 2 的更新，采用双倍的上下文窗口，并在长文档和 RAG 上下文中提高可靠性、"
-"幻觉率和循证准确性。"
 
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:43
-msgid ""
-"Anthropic is a powerful model that can handle a variety of tasks, from "
-"complex dialogue and creative content generation to detailed command "
-"obedience."
-msgstr ""
-"Anthropic 功能强大的模型，可处理各种任务，从复杂的对话和创意内容生成到详细的"
-"指令服从。"
+#: apps/application/serializers/application_chat.py:289
+msgid "API Call"
+msgstr "API 调用"
 
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:50
-msgid ""
-"The Claude 3 Haiku is Anthropic's fastest and most compact model, with near-"
-"instant responsiveness. The model can answer simple queries and requests "
-"quickly. Customers will be able to build seamless AI experiences that mimic "
-"human interactions. Claude 3 Haiku can process images and return text "
-"output, and provides 200K context windows."
-msgstr ""
-"Claude 3 Haiku 是 Anthropic 最快速、最紧凑的模型，具有近乎即时的响应能力。该"
-"模型可以快速回答简单的查询和请求。客户将能够构建模仿人类交互的无缝人工智能体"
-"验。 Claude 3 Haiku 可以处理图像和返回文本输出，并且提供 200K 上下文窗口。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:57
-msgid ""
-"The Claude 3 Sonnet model from Anthropic strikes the ideal balance between "
-"intelligence and speed, especially when it comes to handling enterprise "
-"workloads. This model offers maximum utility while being priced lower than "
-"competing products, and it's been engineered to be a solid choice for "
-"deploying AI at scale."
-msgstr ""
-"Anthropic 推出的 Claude 3 Sonnet 模型在智能和速度之间取得理想的平衡，尤其是在"
-"处理企业工作负载方面。该模型提供最大的效用，同时价格低于竞争产品，并且其经过"
-"精心设计，是大规模部署人工智能的可靠选择。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:64
-msgid ""
-"The Claude 3.5 Sonnet raises the industry standard for intelligence, "
-"outperforming competing models and the Claude 3 Opus in extensive "
-"evaluations, with the speed and cost-effectiveness of our mid-range models."
-msgstr ""
-"Claude 3.5 Sonnet提高了智能的行业标准，在广泛的评估中超越了竞争对手的型号和"
-"Claude 3 Opus，具有我们中端型号的速度和成本效益。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:71
-msgid ""
-"A faster, more affordable but still very powerful model that can handle a "
-"range of tasks including casual conversation, text analysis, summarization "
-"and document question answering."
-msgstr ""
-"一种更快速、更实惠但仍然非常强大的模型，它可以处理一系列任务，包括随意对话、"
-"文本分析、摘要和文档问题回答。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:78
-msgid ""
-"Titan Text Premier is the most powerful and advanced model in the Titan Text "
-"series, designed to deliver exceptional performance for a variety of "
-"enterprise applications. With its cutting-edge features, it delivers greater "
-"accuracy and outstanding results, making it an excellent choice for "
-"organizations looking for a top-notch text processing solution."
-msgstr ""
-"Titan Text Premier 是 Titan Text 系列中功能强大且先进的型号，旨在为各种企业应"
-"用程序提供卓越的性能。凭借其尖端功能，它提供了更高的准确性和出色的结果，使其"
-"成为寻求一流文本处理解决方案的组织的绝佳选择。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:85
-msgid ""
-"Amazon Titan Text Lite is a lightweight, efficient model ideal for fine-"
-"tuning English-language tasks, including summarization and copywriting, "
-"where customers require smaller, more cost-effective, and highly "
-"customizable models."
-msgstr ""
-"Amazon Titan Text Lite 是一种轻量级的高效模型，非常适合英语任务的微调，包括摘"
-"要和文案写作等，在这种场景下，客户需要更小、更经济高效且高度可定制的模型"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:91
-msgid ""
-"Amazon Titan Text Express has context lengths of up to 8,000 tokens, making "
-"it ideal for a variety of high-level general language tasks, such as open-"
-"ended text generation and conversational chat, as well as support in "
-"retrieval-augmented generation (RAG). At launch, the model is optimized for "
-"English, but other languages are supported."
-msgstr ""
-"Amazon Titan Text Express 的上下文长度长达 8000 个 tokens，因而非常适合各种高"
-"级常规语言任务，例如开放式文本生成和对话式聊天，以及检索增强生成（RAG）中的支"
-"持。在发布时，该模型针对英语进行了优化，但也支持其他语言。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:97
-msgid ""
-"7B dense converter for rapid deployment and easy customization. Small in "
-"size yet powerful in a variety of use cases. Supports English and code, as "
-"well as 32k context windows."
-msgstr ""
-"7B 密集型转换器，可快速部署，易于定制。体积虽小，但功能强大，适用于各种用例。"
-"支持英语和代码，以及 32k 的上下文窗口。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:103
-msgid ""
-"Advanced Mistral AI large-scale language model capable of handling any "
-"language task, including complex multilingual reasoning, text understanding, "
-"transformation, and code generation."
-msgstr ""
-"先进的 Mistral AI 大型语言模型，能够处理任何语言任务，包括复杂的多语言推理、"
-"文本理解、转换和代码生成。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:109
-msgid ""
-"Ideal for content creation, conversational AI, language understanding, R&D, "
-"and enterprise applications"
-msgstr "非常适合内容创作、对话式人工智能、语言理解、研发和企业智能体"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:115
-msgid ""
-"Ideal for limited computing power and resources, edge devices, and faster "
-"training times."
-msgstr "非常适合有限的计算能力和资源、边缘设备和更快的训练时间。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:123
-msgid ""
-"Titan Embed Text is the largest embedding model in the Amazon Titan Embed "
-"series and can handle various text embedding tasks, such as text "
-"classification, text similarity calculation, etc."
-msgstr ""
-"Titan Embed Text 是 Amazon Titan Embed 系列中最大的嵌入模型，可以处理各种文本"
-"嵌入任务，如文本分类、文本相似度计算等。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:28
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:47
-#, python-brace-format
-msgid "The following fields are required: {keys}"
-msgstr "以下字段是必填项: {keys}"
-
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:44
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:76
-msgid "Verification failed, please check whether the parameters are correct"
-msgstr "认证失败，请检查参数是否正确"
-
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:28
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:29
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:29
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:28
-msgid "Picture quality"
-msgstr "图片质量"
-
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:17
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:17
-msgid ""
-"Try out the different sounds (Alloy, Echo, Fable, Onyx, Nova, and Sparkle) "
-"to find one that suits your desired tone and audience. The current voiceover "
-"is optimized for English."
-msgstr ""
-"尝试不同的声音（合金、回声、寓言、缟玛瑙、新星和闪光），找到一种适合您所需的"
-"音调和听众的声音。当前的语音针对英语进行了优化。"
-
-#: apps/models_provider/impl/deepseek_model_provider/deepseek_model_provider.py:24
-msgid "Good at common conversational tasks, supports 32K contexts"
-msgstr "擅长通用对话任务，支持 32K 上下文"
-
-#: apps/models_provider/impl/deepseek_model_provider/deepseek_model_provider.py:29
-msgid "Good at handling programming tasks, supports 16K contexts"
-msgstr "擅长处理编程任务，支持 16K 上下文"
-
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:32
-msgid "Latest Gemini 1.0 Pro model, updated with Google update"
-msgstr "最新的 Gemini 1.0 Pro 模型，更新了 Google 更新"
-
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:36
-msgid "Latest Gemini 1.0 Pro Vision model, updated with Google update"
-msgstr "最新的Gemini 1.0 Pro Vision模型，随Google更新而更新"
-
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:43
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:47
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:54
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:58
-msgid "Latest Gemini 1.5 Flash model, updated with Google updates"
-msgstr "最新的Gemini 1.5 Flash模型，随Google更新而更新"
-
-#: apps/models_provider/impl/gemini_model_provider/model/stt.py:53
-msgid "convert audio to text"
-msgstr "将音频转换为文本"
-
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:53
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:54
-msgid "Model catalog"
-msgstr "模型目录"
-
-#: apps/models_provider/impl/local_model_provider/local_model_provider.py:39
-msgid "local model"
-msgstr "本地模型"
+#: no source
+msgid "API Details"
+msgstr "API详情"
 
 #: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:30
-#: apps/models_provider/impl/ollama_model_provider/credential/image.py:23
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:43
 #: apps/models_provider/impl/ollama_model_provider/credential/llm.py:48
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:35
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:43
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:45
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:42
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:43
 #: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:24
 #: apps/models_provider/impl/xinference_model_provider/credential/llm.py:44
 msgid "API domain name is invalid"
 msgstr "API 域名无效"
 
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:35
-#: apps/models_provider/impl/ollama_model_provider/credential/image.py:28
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:53
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:40
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:30
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:48
-msgid "The model does not exist, please download the model first"
-msgstr "模型不存在，请先下载模型"
+#: apps/application/flow/step_node/application_node/i_application_node.py:18
+msgid "API Input Fields"
+msgstr "API 输入字段"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:56
-msgid ""
-"Llama 2 is a set of pretrained and fine-tuned generative text models ranging "
-"in size from 7 billion to 70 billion. This is a repository of 7B pretrained "
-"models. Links to other models can be found in the index at the bottom."
+#: apps/common/constants/permission_constants.py:376
+msgid "API KEY"
 msgstr ""
-"Llama 2 是一组经过预训练和微调的生成文本模型，其规模从 70 亿到 700 亿个不等。"
-"这是 7B 预训练模型的存储库。其他模型的链接可以在底部的索引中找到。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:60
-msgid ""
-"Llama 2 is a set of pretrained and fine-tuned generative text models ranging "
-"in size from 7 billion to 70 billion. This is a repository of 13B pretrained "
-"models. Links to other models can be found in the index at the bottom."
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:43
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:14
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:31
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:21
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:35
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:74
+msgid "API Key"
 msgstr ""
-"Llama 2 是一组经过预训练和微调的生成文本模型，其规模从 70 亿到 700 亿个不等。"
-"这是 13B 预训练模型的存储库。其他模型的链接可以在底部的索引中找到。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:64
-msgid ""
-"Llama 2 is a set of pretrained and fine-tuned generative text models ranging "
-"in size from 7 billion to 70 billion. This is a repository of 70B pretrained "
-"models. Links to other models can be found in the index at the bottom."
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:95
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:87
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:44
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:42
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:31
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:13
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:30
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:20
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:70
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:83
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:47
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:34
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:73
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:74
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:52
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:29
+msgid "API URL"
 msgstr ""
-"Llama 2 是一组经过预训练和微调的生成文本模型，其规模从 70 亿到 700 亿个不等。"
-"这是 70B 预训练模型的存储库。其他模型的链接可以在底部的索引中找到。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:68
-msgid ""
-"Since the Chinese alignment of Llama2 itself is weak, we use the Chinese "
-"instruction set to fine-tune meta-llama/Llama-2-13b-chat-hf with LoRA so "
-"that it has strong Chinese conversation capabilities."
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:20
+msgid "API Version"
 msgstr ""
-"由于Llama2本身的中文对齐较弱，我们采用中文指令集，对meta-llama/Llama-2-13b-"
-"chat-hf进行LoRA微调，使其具备较强的中文对话能力。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:72
-msgid ""
-"Meta Llama 3: The most capable public product LLM to date. 8 billion "
-"parameters."
-msgstr "Meta Llama 3：迄今为止最有能力的公开产品LLM。80亿参数。"
+#: apps/application/serializers/application_api_key.py:106
+msgid "APIKey does not exist"
+msgstr "APIKey 不存在"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:76
-msgid ""
-"Meta Llama 3: The most capable public product LLM to date. 70 billion "
-"parameters."
-msgstr "Meta Llama 3：迄今为止最有能力的公开产品LLM。700亿参数。"
+#: apps/application/serializers/application_api_key.py:76
+msgid "ApiKeyId"
+msgstr "ApiKey ID"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:80
-msgid ""
-"Compared with previous versions, qwen 1.5 0.5b has significantly enhanced "
-"the model's alignment with human preferences and its multi-language "
-"processing capabilities. Models of all sizes support a context length of "
-"32768 tokens. 500 million parameters."
+#: no source
+msgid "App ID is required"
+msgstr "App ID 是必填项"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:47
+msgid "App IDs"
 msgstr ""
-"qwen 1.5 0.5b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有"
-"显著增强。所有规模的模型都支持32768个tokens的上下文长度。5亿参数。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:84
-msgid ""
-"Compared with previous versions, qwen 1.5 1.8b has significantly enhanced "
-"the model's alignment with human preferences and its multi-language "
-"processing capabilities. Models of all sizes support a context length of "
-"32768 tokens. 1.8 billion parameters."
+#: no source
+msgid "App Key is required"
+msgstr "App Key 是必填项"
+
+#: no source
+msgid "App Secret is required"
+msgstr "App Secret 是必填项"
+
+#: apps/common/constants/permission_constants.py:404
+msgid "Appearance Settings"
+msgstr "外观设置"
+
+#: apps/application/views/application.py:61
+#: apps/application/views/application.py:80
+#: apps/application/views/application.py:99
+#: apps/application/views/application.py:121
+#: apps/application/views/application.py:148
+#: apps/application/views/application.py:175
+#: apps/application/views/application.py:201
+#: apps/application/views/application.py:227
+#: apps/application/views/application.py:251
+#: apps/application/views/application.py:278
+#: apps/application/views/application.py:303
+#: apps/application/views/application.py:322
+#: apps/application/views/application.py:359
+#: apps/application/views/application.py:398
+#: apps/application/views/application.py:441
+#: apps/application/views/application.py:467
+#: apps/application/views/application.py:493
+#: apps/application/views/application.py:520
+#: apps/application/views/application_access_token.py:43
+#: apps/application/views/application_access_token.py:65
+#: apps/application/views/application_chat.py:126
+#: apps/application/views/application_chat.py:152
+#: apps/application/views/application_chat.py:168
+#: apps/application/views/application_stats.py:33
+#: apps/application/views/application_stats.py:61
+#: apps/application/views/application_stats.py:88
+#: apps/chat/serializers/chat.py:157
+#: apps/chat/views/chat.py:264
+#: apps/common/constants/permission_constants.py:340
+#: apps/common/constants/permission_constants.py:353
+#: apps/common/constants/permission_constants.py:434
+#: apps/common/constants/permission_constants.py:438
+msgid "Application"
+msgstr "智能体"
+
+#: apps/common/constants/permission_constants.py:396
+#: apps/common/constants/permission_constants.py:440
+msgid "Application Access"
+msgstr "智能体接入"
+
+#: apps/chat/views/chat.py:101
+#: apps/chat/views/chat.py:102
+#: apps/chat/views/chat.py:103
+msgid "Application Anonymous Certification"
+msgstr "智能体匿名认证"
+
+#: apps/application/views/application_api_key.py:37
+#: apps/application/views/application_api_key.py:64
+#: apps/application/views/application_api_key.py:89
+#: apps/application/views/application_api_key.py:115
+msgid "Application Api Key"
+msgstr "智能体 API 密钥"
+
+#: apps/application/serializers/application_chat_record.py:61
+msgid "Application authentication information does not exist"
+msgstr "智能体认证信息不存在"
+
+#: apps/homepage/views/homepage.py:259
+#: apps/homepage/views/homepage.py:260
+msgid "Application data aggregation"
+msgstr "应用数据聚合"
+
+#: apps/application/serializers/application.py:345
+msgid "application describe"
+msgstr "智能体描述"
+
+#: apps/application/api/application_api.py:82
+#: apps/application/serializers/application.py:296
+#: apps/application/serializers/application.py:449
+#: apps/application/serializers/application.py:463
+#: apps/application/serializers/application.py:463
+#: apps/application/serializers/application.py:593
+msgid "Application Description"
+msgstr "智能体描述"
+
+#: apps/application/serializers/application.py:1736
+#: apps/chat/serializers/chat.py:487
+#: apps/chat/serializers/chat.py:548
+#: apps/oss/serializers/file.py:222
+msgid "Application does not exist"
+msgstr "智能体不存在"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:15
+#: apps/application/serializers/application.py:993
+#: apps/application/serializers/application_access_token.py:47
+#: apps/application/serializers/application_chat.py:40
+#: apps/application/serializers/application_chat.py:58
+#: apps/application/serializers/application_chat_link.py:57
+#: apps/application/serializers/application_chat_record.py:47
+#: apps/application/serializers/application_chat_record.py:92
+#: apps/application/serializers/application_chat_record.py:201
+#: apps/application/serializers/application_chat_record.py:249
+#: apps/application/serializers/application_stats.py:39
+#: apps/application/serializers/application_version.py:21
+#: apps/application/serializers/application_version.py:69
+#: apps/chat/serializers/chat.py:218
+#: apps/chat/serializers/chat.py:290
+#: apps/chat/serializers/chat.py:604
+#: apps/chat/serializers/chat.py:616
+#: apps/chat/serializers/chat_authentication.py:93
+#: apps/chat/serializers/chat_record.py:102
+#: apps/chat/serializers/chat_record.py:126
+#: apps/chat/serializers/chat_record.py:154
+#: apps/chat/serializers/chat_record.py:166
+#: apps/homepage/api/home_page_api.py:163
+#: apps/homepage/api/home_page_api.py:193
+#: apps/homepage/serializers/homepage.py:656
+msgid "Application ID"
+msgstr "智能体 ID"
+
+#: apps/application/serializers/application_api_key.py:38
+#: apps/application/serializers/application_api_key.py:75
+#: apps/knowledge/serializers/knowledge.py:134
+msgid "application id"
+msgstr "智能体 ID"
+
+#: apps/application/serializers/application_chat_record.py:379
+msgid "Application id"
 msgstr ""
-"qwen 1.5 1.8b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有"
-"显著增强。所有规模的模型都支持32768个tokens的上下文长度。18亿参数。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:88
-msgid ""
-"Compared with previous versions, qwen 1.5 4b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"4 billion parameters."
+#: apps/application/serializers/application.py:1004
+#: apps/application/serializers/application_access_token.py:57
+#: apps/application/serializers/application_api_key.py:48
+#: apps/application/serializers/application_api_key.py:85
+#: apps/application/serializers/application_chat.py:75
+#: apps/application/serializers/application_chat_record.py:57
+#: apps/application/serializers/application_chat_record.py:103
+#: apps/application/serializers/application_chat_record.py:215
+#: apps/application/serializers/application_chat_record.py:262
+#: apps/application/serializers/application_chat_record.py:390
+#: apps/application/serializers/application_stats.py:50
+#: apps/application/serializers/application_version.py:80
+#: apps/chat/serializers/chat.py:167
+msgid "Application id does not exist"
+msgstr "智能体 ID 不存在"
+
+#: apps/knowledge/serializers/knowledge.py:135
+msgid "application id list"
+msgstr "智能体 ID 列表"
+
+#: apps/application/api/application_api.py:75
+#: apps/application/serializers/application.py:289
+#: apps/application/serializers/application.py:448
+#: apps/application/serializers/application.py:461
+#: apps/application/serializers/application.py:461
+#: apps/application/serializers/application.py:586
+#: apps/homepage/serializers/homepage.py:389
+#: apps/homepage/serializers/homepage.py:489
+#: apps/homepage/serializers/homepage.py:516
+#: apps/homepage/serializers/homepage.py:625
+msgid "Application Name"
+msgstr "智能体名称"
+
+#: apps/application/serializers/application.py:338
+msgid "application name"
+msgstr "智能体名称"
+
+#: apps/homepage/api/home_page_api.py:164
+#: apps/homepage/api/home_page_api.py:194
+msgid "Application name"
+msgstr "应用名称"
+
+#: no source
+msgid "Application Password Certification"
+msgstr "智能体密码认证"
+
+#: apps/homepage/api/home_page_api.py:189
+msgid "Application question ranking list"
+msgstr "应用提问次数排行榜列表"
+
+#: apps/application/views/application_stats.py:56
+#: apps/application/views/application_stats.py:57
+#: apps/application/views/application_stats.py:58
+msgid "Application token usage statistics"
+msgstr "智能体令牌使用统计"
+
+#: apps/homepage/api/home_page_api.py:159
+msgid "Application tokens ranking list"
+msgstr "应用 tokens 消耗排行榜列表"
+
+#: apps/application/views/application_stats.py:83
+#: apps/application/views/application_stats.py:84
+#: apps/application/views/application_stats.py:85
+msgid "Application top question statistics"
+msgstr "智能体提问次数统计"
+
+#: apps/application/serializers/application.py:373
+msgid "Application Type"
+msgstr "智能体类型"
+
+#: apps/application/serializers/application.py:466
+#: apps/application/serializers/application.py:466
+msgid "Application type"
+msgstr "智能体类型"
+
+#: apps/application/serializers/application.py:377
+msgid "Application type only supports SIMPLE|WORK_FLOW"
+msgstr "智能体类型仅支持 SIMPLE|WORK_FLOW"
+
+#: apps/application/serializers/application_version.py:71
+msgid "Application version ID"
 msgstr ""
-"qwen 1.5 4b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显"
-"著增强。所有规模的模型都支持32768个tokens的上下文长度。40亿参数。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:93
-msgid ""
-"Compared with previous versions, qwen 1.5 7b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"7 billion parameters."
+#: no source
+msgid "Application/application access"
+msgstr "智能体/智能体访问"
+
+#: apps/application/views/application_chat.py:50
+#: apps/application/views/application_chat.py:75
+#: apps/application/views/application_chat.py:101
+#: apps/application/views/application_chat_record.py:37
+#: apps/application/views/application_chat_record.py:63
+#: apps/application/views/application_chat_record.py:92
+#: apps/application/views/application_chat_record.py:122
+#: apps/application/views/application_chat_record.py:146
+#: apps/application/views/application_chat_record.py:171
+#: apps/application/views/application_chat_record.py:202
+msgid "Application/Conversation Log"
+msgstr "智能体/对话日志"
+
+#: no source
+msgid "Application/Get platform status"
+msgstr "智能体/获取平台状态"
+
+#: apps/application/views/application_version.py:35
+#: apps/application/views/application_version.py:59
+#: apps/application/views/application_version.py:84
+#: apps/application/views/application_version.py:106
+msgid "Application/Version"
+msgstr "智能体/ 版本"
+
+#: no source
+msgid "Applications Resource"
+msgstr "智能体资源"
+
+#: no source
+msgid "app_id is required"
+msgstr "app_id 是必填项"
+
+#: no source
+msgid "app_secret is required"
+msgstr "app_secret 是必填项"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:32
+msgid "Arabic"
+msgstr "阿拉伯语"
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:22
+msgid "array"
 msgstr ""
-"qwen 1.5 7b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显"
-"著增强。所有规模的模型都支持32768个tokens的上下文长度。70亿参数。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:97
-msgid ""
-"Compared with previous versions, qwen 1.5 14b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"14 billion parameters."
+#: apps/homepage/api/home_page_api.py:226
+msgid "Asker user information"
+msgstr "提问用户信息"
+
+#: apps/knowledge/task/handler.py:134
+msgid "Association problem failed {error}"
+msgstr "关联问题失败 {error}"
+
+#: apps/models_provider/api/provide.py:45
+msgid "attrs"
+msgstr "属性"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:23
+#: apps/chat/serializers/chat.py:94
+msgid "Audio"
+msgstr "音频"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:23
+msgid "Audio file recognition - Tongyi Qwen"
+msgstr "录音文件识别-通义千问"
+
+#: no source
+msgid "Auth Type"
+msgstr "认证类型"
+
+#: no source
+msgid "Authentication Configuration"
+msgstr "认证配置"
+
+#: apps/models_provider/impl/xf_model_provider/model/tts/super_humanoid_tts.py:114
+msgid "Authentication failed (HTTP 401). Please check: 1) API URL is correct for TTS service; 2) APP ID, API Key, and API Secret are correct; 3) Your iFlytek account has TTS service enabled."
 msgstr ""
-"qwen 1.5 14b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显"
-"著增强。所有规模的模型都支持32768个tokens的上下文长度。140亿参数。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:101
-msgid ""
-"Compared with previous versions, qwen 1.5 32b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"32 billion parameters."
+#: no source
+msgid "Authentication failed. Please verify that the parameters are correct"
+msgstr "认证失败，请检查参数是否正确"
+
+#: apps/chat/serializers/chat.py:67
+#: apps/chat/serializers/chat.py:69
+#: apps/chat/serializers/chat.py:71
+msgid "Authentication failed. Please verify that the parameters are correct."
 msgstr ""
-"qwen 1.5 32b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显"
-"著增强。所有规模的模型都支持32768个tokens的上下文长度。320亿参数。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:105
-msgid ""
-"Compared with previous versions, qwen 1.5 72b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"72 billion parameters."
-msgstr ""
-"qwen 1.5 72b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显"
-"著增强。所有规模的模型都支持32768个tokens的上下文长度。720亿参数。"
+#: apps/common/auth/handle/impl/application_key.py:34
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:40
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:42
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:44
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:48
+#: apps/common/auth/handle/impl/user_token.py:317
+#: apps/trigger/handler/impl/trigger/event_trigger.py:120
+#: apps/trigger/handler/impl/trigger/event_trigger.py:123
+msgid "Authentication information is incorrect"
+msgstr "身份验证信息不正确"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:109
-msgid ""
-"Compared with previous versions, qwen 1.5 110b has significantly enhanced "
-"the model's alignment with human preferences and its multi-language "
-"processing capabilities. Models of all sizes support a context length of "
-"32768 tokens. 110 billion parameters."
-msgstr ""
-"qwen 1.5 110b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有"
-"显著增强。所有规模的模型都支持32768个tokens的上下文长度。1100亿参数。"
+#: apps/common/auth/authenticate.py:84
+#: apps/common/auth/authenticate.py:91
+#: apps/common/auth/authenticate.py:97
+#: apps/common/auth/authenticate.py:110
+#: apps/common/auth/authenticate.py:117
+#: apps/common/auth/authenticate.py:123
+#: apps/common/auth/authenticate.py:136
+#: apps/common/auth/authenticate.py:143
+#: apps/common/auth/authenticate.py:149
+msgid "Authentication information is incorrect! illegal user"
+msgstr "身份验证信息不正确！非法用户"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:153
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:193
-msgid ""
-"Phi-3 Mini is Microsoft's 3.8B parameter, lightweight, state-of-the-art open "
-"model."
-msgstr "Phi-3 Mini是Microsoft的3.8B参数，轻量级，最先进的开放模型。"
+#: no source
+msgid "authentication type"
+msgstr "认证类型"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:162
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:197
-msgid ""
-"A high-performance open embedding model with a large token context window."
-msgstr "一个具有大 tokens上下文窗口的高性能开放嵌入模型。"
+#: no source
+msgid "Authorization address cannot be empty"
+msgstr "认证地址不能为空"
 
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:16
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:16
-msgid ""
-"The image generation endpoint allows you to create raw images based on text "
-"prompts. When using the DALL·E 3, the image size can be 1024x1024, 1024x1792 "
-"or 1792x1024 pixels."
-msgstr ""
-"图像生成端点允许您根据文本提示创建原始图像。使用 DALL·E 3 时，图像的尺寸可以"
-"为 1024x1024、1024x1792 或 1792x1024 像素。"
+#: no source
+msgid "Authorization knowledge workspace"
+msgstr "授权知识工作空间"
 
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:29
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:29
-msgid ""
-"\n"
-"By default, images are produced in standard quality, but with DALL·E 3 you "
-"can set quality: \"hd\" to enhance detail. Square, standard quality images "
-"are generated fastest.\n"
-"        "
-msgstr ""
-"默认情况下，图像以标准质量生成，但使用 DALL·E 3 时，您可以设置质量：“hd”以增"
-"强细节。方形、标准质量的图像生成速度最快。"
+#: no source
+msgid "Authorization knowledge workspace "
+msgstr "授权知识工作空间"
 
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:44
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:44
-msgid ""
-"You can use DALL·E 3 to request 1 image at a time (requesting more images by "
-"issuing parallel requests), or use DALL·E 2 with the n parameter to request "
-"up to 10 images at a time."
-msgstr ""
-"您可以使用 DALL·E 3 一次请求 1 个图像（通过发出并行请求来请求更多图像），或者"
-"使用带有 n 参数的 DALL·E 2 一次最多请求 10 个图像。"
+#: no source
+msgid "Authorization model workspace"
+msgstr "授权模型工作空间"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:35
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:119
-#: apps/models_provider/impl/siliconCloud_model_provider/siliconCloud_model_provider.py:118
-msgid "The latest gpt-3.5-turbo, updated with OpenAI adjustments"
-msgstr "最新的gpt-3.5-turbo，随OpenAI调整而更新"
+#: no source
+msgid "Authorization model workspace "
+msgstr "授权模型工作空间"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:38
-msgid "Latest gpt-4, updated with OpenAI adjustments"
-msgstr "最新的gpt-4，随OpenAI调整而更新"
+#: no source
+msgid "Authorization tool workspace"
+msgstr "授权工作空间工具"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:40
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:99
-msgid ""
-"The latest GPT-4o, cheaper and faster than gpt-4-turbo, updated with OpenAI "
-"adjustments"
-msgstr "最新的GPT-4o，比gpt-4-turbo更便宜、更快，随OpenAI调整而更新"
+#: no source
+msgid "Authorization tool workspace "
+msgstr "授权工作空间工具"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:43
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:102
-msgid ""
-"The latest gpt-4o-mini, cheaper and faster than gpt-4o, updated with OpenAI "
-"adjustments"
-msgstr "最新的gpt-4o-mini，比gpt-4o更便宜、更快，随OpenAI调整而更新"
+#: no source
+msgid "Authorized pagination list for obtaining resources"
+msgstr "获取资源的关系分页列表"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:46
-msgid "The latest gpt-4-turbo, updated with OpenAI adjustments"
-msgstr "最新的gpt-4-turbo，随OpenAI调整而更新"
+#: apps/knowledge/serializers/document.py:202
+msgid "Auto Clean"
+msgstr "自动清理"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:49
-msgid "The latest gpt-4-turbo-preview, updated with OpenAI adjustments"
-msgstr "最新的gpt-4-turbo-preview，随OpenAI调整而更新"
+#: apps/application/serializers/application_api_key.py:23
+msgid "Availability"
+msgstr "可用"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:53
-msgid ""
-"gpt-3.5-turbo snapshot on January 25, 2024, supporting context length 16,385 "
-"tokens"
-msgstr "2024年1月25日的gpt-3.5-turbo快照，支持上下文长度16,385 tokens"
+#: no source
+msgid "avatar"
+msgstr "头像"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:57
-msgid ""
-"gpt-3.5-turbo snapshot on November 6, 2023, supporting context length 16,385 "
-"tokens"
-msgstr "2023年11月6日的gpt-3.5-turbo快照，支持上下文长度16,385 tokens"
+#: no source
+msgid "avatar url"
+msgstr "头像地址"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:61
-msgid ""
-"[Legacy] gpt-3.5-turbo snapshot on June 13, 2023, will be deprecated on June "
-"13, 2024"
-msgstr "[Legacy] 2023年6月13日的gpt-3.5-turbo快照，将于2024年6月13日弃用"
+#: apps/homepage/serializers/homepage.py:493
+msgid "Average Number of Conversation Turns per Person"
+msgstr "人均对话轮次"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:65
-msgid ""
-"gpt-4o snapshot on May 13, 2024, supporting context length 128,000 tokens"
-msgstr "2024年5月13日的gpt-4o快照，支持上下文长度128,000 tokens"
+#: apps/homepage/serializers/homepage.py:306
+#: apps/homepage/serializers/homepage.py:630
+msgid "Average tokens per request"
+msgstr "单次请求平均Token数"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:69
-msgid ""
-"gpt-4-turbo snapshot on April 9, 2024, supporting context length 128,000 "
-"tokens"
-msgstr "2024年4月9日的gpt-4-turbo快照，支持上下文长度128,000 tokens"
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:72
-msgid ""
-"gpt-4-turbo snapshot on January 25, 2024, supporting context length 128,000 "
-"tokens"
-msgstr "2024年1月25日的gpt-4-turbo快照，支持上下文长度128,000 tokens"
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:75
-msgid ""
-"gpt-4-turbo snapshot on November 6, 2023, supporting context length 128,000 "
-"tokens"
-msgstr "2023年11月6日的gpt-4-turbo快照，支持上下文长度128,000 tokens"
-
-#: apps/models_provider/impl/tencent_cloud_model_provider/tencent_cloud_model_provider.py:58
-msgid "Tencent Cloud"
-msgstr "腾讯云"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:41
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:88
-#, python-brace-format
-msgid "{keys} is required"
-msgstr "{keys} 是必填项"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:14
-msgid "painting style"
-msgstr "绘画风格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:14
-msgid "If not passed, the default value is 201 (Japanese anime style)"
-msgstr "如果未传递，则默认值为201（日本动漫风格）"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:18
-msgid "Not limited to style"
-msgstr "不限于风格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:19
-msgid "ink painting"
-msgstr "水墨画"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:20
-msgid "concept art"
-msgstr "概念艺术"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:21
-msgid "Oil painting 1"
-msgstr "油画1"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:22
-msgid "Oil Painting 2 (Van Gogh)"
-msgstr "油画2（梵高）"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:23
-msgid "watercolor painting"
-msgstr "水彩画"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:24
-msgid "pixel art"
-msgstr "像素画"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:25
-msgid "impasto style"
-msgstr "厚涂风格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:26
-msgid "illustration"
-msgstr "插图"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:27
-msgid "paper cut style"
-msgstr "剪纸风格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:28
-msgid "Impressionism 1 (Monet)"
-msgstr "印象派1（莫奈）"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:29
-msgid "Impressionism 2"
-msgstr "印象派2"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:31
-msgid "classical portraiture"
-msgstr "古典肖像画"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:32
-msgid "black and white sketch"
-msgstr "黑白素描画"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:33
-msgid "cyberpunk"
-msgstr "赛博朋克"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:34
-msgid "science fiction style"
-msgstr "科幻风格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:35
-msgid "dark style"
-msgstr "暗黑风格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:37
-msgid "vaporwave"
-msgstr "蒸汽波"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:38
-msgid "Japanese animation"
-msgstr "日系动漫"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:39
-msgid "monster style"
-msgstr "怪兽风格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:40
-msgid "Beautiful ancient style"
-msgstr "唯美古风"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:41
-msgid "retro anime"
-msgstr "复古动漫"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:42
-msgid "Game cartoon hand drawing"
-msgstr "游戏卡通手绘"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:43
-msgid "Universal realistic style"
-msgstr "通用写实风格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:50
-msgid "Generate image resolution"
-msgstr "生成图像分辨率"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:50
-msgid "If not transmitted, the default value is 768:768."
-msgstr "不传默认使用768:768。"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:38
-msgid ""
-"The most effective version of the current hybrid model, the trillion-level "
-"parameter scale MOE-32K long article model. Reaching the absolute leading "
-"level on various benchmarks, with complex instructions and reasoning, "
-"complex mathematical capabilities, support for function call, and "
-"application focus optimization in fields such as multi-language translation, "
-"finance, law, and medical care"
-msgstr ""
-"当前混元模型中效果最优版本，万亿级参数规模 MOE-32K 长文模型。在各种 "
-"benchmark 上达到绝对领先的水平，复杂指令和推理，具备复杂数学能力，支持 "
-"functioncall，在多语言翻译、金融法律医疗等领域智能体重点优化"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:45
-msgid ""
-"A better routing strategy is adopted to simultaneously alleviate the "
-"problems of load balancing and expert convergence. For long articles, the "
-"needle-in-a-haystack index reaches 99.9%"
-msgstr ""
-"采用更优的路由策略，同时缓解了负载均衡和专家趋同的问题。长文方面，大海捞针指"
-"标达到99.9%"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:51
-msgid ""
-"Upgraded to MOE structure, the context window is 256k, leading many open "
-"source models in multiple evaluation sets such as NLP, code, mathematics, "
-"industry, etc."
-msgstr ""
-"升级为 MOE 结构，上下文窗口为 256k ，在 NLP，代码，数学，行业等多项评测集上领"
-"先众多开源模型"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:57
-msgid ""
-"Hunyuan's latest version of the role-playing model, a role-playing model "
-"launched by Hunyuan's official fine-tuning training, is based on the Hunyuan "
-"model combined with the role-playing scene data set for additional training, "
-"and has better basic effects in role-playing scenes."
-msgstr ""
-"混元最新版角色扮演模型，混元官方精调训练推出的角色扮演模型，基于混元模型结合"
-"角色扮演场景数据集进行增训，在角色扮演场景具有更好的基础效果"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:63
-msgid ""
-"Hunyuan's latest MOE architecture FunctionCall model has been trained with "
-"high-quality FunctionCall data and has a context window of 32K, leading in "
-"multiple dimensions of evaluation indicators."
-msgstr ""
-"混元最新 MOE 架构 FunctionCall 模型，经过高质量的 FunctionCall 数据训练，上下"
-"文窗口达 32K，在多个维度的评测指标上处于领先。"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:69
-msgid ""
-"Hunyuan's latest code generation model, after training the base model with "
-"200B high-quality code data, and iterating on high-quality SFT data for half "
-"a year, the context long window length has been increased to 8K, and it "
-"ranks among the top in the automatic evaluation indicators of code "
-"generation in the five major languages; the five major languages In the "
-"manual high-quality evaluation of 10 comprehensive code tasks that consider "
-"all aspects, the performance is in the first echelon."
-msgstr ""
-"混元最新代码生成模型，经过 200B 高质量代码数据增训基座模型，迭代半年高质量 "
-"SFT 数据训练，上下文长窗口长度增大到 8K，五大语言代码生成自动评测指标上位居前"
-"列；五大语言10项考量各方面综合代码任务人工高质量评测上，性能处于第一梯队"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:77
-msgid ""
-"Tencent's Hunyuan Embedding interface can convert text into high-quality "
-"vector data. The vector dimension is 1024 dimensions."
-msgstr ""
-"腾讯混元 Embedding 接口，可以将文本转化为高质量的向量数据。向量维度为1024维。"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:87
-msgid "Mixed element visual model"
-msgstr "混元视觉模型"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:94
-msgid "Hunyuan graph model"
-msgstr "混元生图模型"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:125
-msgid "Tencent Hunyuan"
-msgstr "腾讯混元"
-
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:24
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:42
-msgid "Facebook’s 125M parameter model"
-msgstr "Facebook的125M参数模型"
-
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:25
-msgid "BAAI’s 7B parameter model"
-msgstr "BAAI的7B参数模型"
-
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:26
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:35
 msgid "BAAI’s 13B parameter mode"
 msgstr "BAAI的13B参数模型"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:16
-msgid ""
-"If the gap between width, height and 512 is too large, the picture rendering "
-"effect will be poor and the probability of excessive delay will increase "
-"significantly. Recommended ratio and corresponding width and height before "
-"super score: width*height"
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:33
+msgid "BAAI’s 7B parameter model"
+msgstr "BAAI的7B参数模型"
+
+#: no source
+msgid "Base DN cannot be empty"
+msgstr "Base DN不能为空"
+
+#: apps/models_provider/api/model.py:51
+#: apps/models_provider/serializers/model_serializer.py:66
+#: apps/models_provider/serializers/model_serializer.py:252
+#: apps/models_provider/serializers/model_serializer.py:288
+#: apps/models_provider/serializers/model_serializer.py:361
+#: apps/models_provider/serializers/model_serializer.py:544
+msgid "base model"
+msgstr "基础模型"
+
+#: apps/models_provider/serializers/model_serializer.py:264
+#: apps/models_provider/serializers/model_serializer.py:301
+msgid "base model【{model_name}】already exists"
+msgstr "模型【{model_name}】已存在"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:27
+msgid "Base URL"
 msgstr ""
-"宽、高与512差距过大，则出图效果不佳、延迟过长概率显著增加。超分前建议比例及对"
-"应宽高：width*height"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:15
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:15
-msgid "timbre"
-msgstr "音色"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:28
-msgid "speaking speed"
-msgstr "语速"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:31
-msgid "[0.2,3], the default is 1, usually one decimal place is enough"
-msgstr "[0.2,3]，默认为1，通常保留一位小数即可"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:39
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:44
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:88
-msgid ""
-"The user goes to the model inference page of Volcano Ark to create an "
-"inference access point. Here, you need to enter ep-xxxxxxxxxx-yyyy to call "
-"it."
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:21
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:21
+msgid "Base Url"
 msgstr ""
-"用户前往火山方舟的模型推理页面创建推理接入点，这里需要输入ep-xxxxxxxxxx-yyyy"
-"进行调用"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:59
-msgid "Universal 2.0-Vincent Diagram"
-msgstr "通用2.0-文生图"
+#: apps/application/flow/common.py:282
+msgid "Basic information node is required"
+msgstr "基本信息节点是必需的"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:64
-msgid "Universal 2.0Pro-Vincent Chart"
-msgstr "通用2.0Pro-文生图"
+#: no source
+msgid "Batch add chat user to group"
+msgstr "批量添加对话用户到用户组"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:69
-msgid "Universal 1.4-Vincent Chart"
-msgstr "通用1.4-文生图"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:74
-msgid "Animation 1.3.0-Vincent Picture"
-msgstr "动漫1.3.0-文生图"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:79
-msgid "Animation 1.3.1-Vincent Picture"
-msgstr "动漫1.3.1-文生图"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:113
-msgid "volcano engine"
-msgstr "火山引擎"
-
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:51
-#, python-brace-format
-msgid "{model_name} The model does not support"
-msgstr "{model_name} 模型不支持"
-
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:24
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:53
-msgid ""
-"ERNIE-Bot-4 is a large language model independently developed by Baidu. It "
-"covers massive Chinese data and has stronger capabilities in dialogue Q&A, "
-"content creation and generation."
+#: apps/knowledge/views/document.py:711
+#: apps/knowledge/views/document.py:712
+msgid "Batch add tags to documents"
 msgstr ""
-"ERNIE-Bot-4是百度自行研发的大语言模型，覆盖海量中文数据，具有更强的对话问答、"
-"内容创作生成等能力。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:27
-msgid ""
-"ERNIE-Bot is a large language model independently developed by Baidu. It "
-"covers massive Chinese data and has stronger capabilities in dialogue Q&A, "
-"content creation and generation."
+#: no source
+msgid "Batch add user to group"
+msgstr "批量添加用户到组"
+
+#: apps/knowledge/views/problem.py:107
+#: apps/knowledge/views/problem.py:108
+#: apps/knowledge/views/problem.py:109
+msgid "Batch associated paragraphs"
+msgstr "批量关联段落"
+
+#: no source
+msgid "Batch associated shared paragraphs"
+msgstr "批量关联段落"
+
+#: no source
+msgid "Batch associated system paragraphs"
+msgstr "批量关联段落"
+
+#: apps/common/constants/permission_constants.py:392
+msgid "Batch delete"
+msgstr "批量删除"
+
+#: apps/knowledge/views/tag.py:128
+msgid "Batch Delete a knowledge tag"
 msgstr ""
-"ERNIE-Bot是百度自行研发的大语言模型，覆盖海量中文数据，具有更强的对话问答、内"
-"容创作生成等能力。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:30
-msgid ""
-"ERNIE-Bot-turbo is a large language model independently developed by Baidu. "
-"It covers massive Chinese data, has stronger capabilities in dialogue Q&A, "
-"content creation and generation, and has a faster response speed."
+#: apps/application/views/application.py:316
+#: apps/application/views/application.py:317
+#: apps/application/views/application.py:318
+msgid "Batch delete applications"
+msgstr "批量删除应用"
+
+#: no source
+msgid "Batch delete chat user"
+msgstr "批量删除对话用户"
+
+#: apps/knowledge/views/document.py:1114
+#: apps/knowledge/views/document.py:1115
+msgid "Batch Delete Documents Tag"
 msgstr ""
-"ERNIE-Bot-turbo是百度自行研发的大语言模型，覆盖海量中文数据，具有更强的对话问"
-"答、内容创作生成等能力，响应速度更快。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:33
-msgid ""
-"BLOOMZ-7B is a well-known large language model in the industry. It was "
-"developed and open sourced by BigScience and can output text in 46 languages "
-"and 13 programming languages."
+#: apps/chat/views/chat_record.py:107
+#: apps/chat/views/chat_record.py:108
+#: apps/chat/views/chat_record.py:109
+msgid "Batch delete history conversation"
 msgstr ""
-"BLOOMZ-7B是业内知名的大语言模型，由BigScience研发并开源，能够以46种语言和13种"
-"编程语言输出文本。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:39
-msgid ""
-"Llama-2-13b-chat was developed by Meta AI and is open source. It performs "
-"well in scenarios such as coding, reasoning and knowledge application. "
-"Llama-2-13b-chat is a native open source version with balanced performance "
-"and effect, suitable for conversation scenarios."
+#: apps/knowledge/views/knowledge.py:143
+#: apps/knowledge/views/knowledge.py:144
+#: apps/knowledge/views/knowledge.py:145
+msgid "Batch delete knowledge"
+msgstr "批量删除知识库"
+
+#: apps/knowledge/views/tag.py:127
+msgid "Batch Delete Knowledge Tag"
 msgstr ""
-"Llama-2-13b-chat由Meta AI研发并开源，在编码、推理及知识智能体等场景表现优秀，"
-"Llama-2-13b-chat是性能与效果均衡的原生开源版本，适用于对话场景。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:42
-msgid ""
-"Llama-2-70b-chat was developed by Meta AI and is open source. It performs "
-"well in scenarios such as coding, reasoning, and knowledge application. "
-"Llama-2-70b-chat is a native open source version with high-precision effects."
+#: apps/tools/views/tool.py:205
+#: apps/tools/views/tool.py:206
+#: apps/tools/views/tool.py:207
+msgid "Batch delete tools"
+msgstr "批量删除工具"
+
+#: apps/users/views/user.py:249
+#: apps/users/views/user.py:250
+#: apps/users/views/user.py:251
+msgid "Batch delete user"
+msgstr "批量删除用户"
+
+#: apps/knowledge/views/problem.py:137
+#: apps/knowledge/views/problem.py:138
+#: apps/knowledge/views/problem.py:139
+#: apps/knowledge/views/termbase.py:93
+#: apps/knowledge/views/termbase.py:94
+#: apps/knowledge/views/termbase.py:95
+msgid "Batch deletion issues"
+msgstr "批量删除问题"
+
+#: no source
+msgid "Batch deletion shared issues"
+msgstr "批量删除问题"
+
+#: no source
+msgid "Batch deletion system issues"
+msgstr "批量删除问题"
+
+#: apps/knowledge/views/termbase.py:128
+#: apps/knowledge/views/termbase.py:129
+#: apps/knowledge/views/termbase.py:130
+msgid "Batch export termbase"
 msgstr ""
-"Llama-2-70b-chat由Meta AI研发并开源，在编码、推理及知识智能体等场景表现优秀，"
-"Llama-2-70b-chat是高精度效果的原生开源版本。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:45
-msgid ""
-"The Chinese enhanced version developed by the Qianfan team based on "
-"Llama-2-7b has performed well on Chinese knowledge bases such as CMMLU and C-"
-"EVAL."
+#: apps/knowledge/views/paragraph.py:143
+#: apps/knowledge/views/paragraph.py:144
+#: apps/knowledge/views/paragraph.py:145
+msgid "Batch Generate Related"
+msgstr "批量生成相关"
+
+#: no source
+msgid "Batch generate related"
+msgstr "批量生成相关"
+
+#: apps/knowledge/views/document.py:748
+#: apps/knowledge/views/document.py:749
+#: apps/knowledge/views/document.py:750
+msgid "Batch generate related problems"
+msgstr "批量生成相关问题"
+
+#: no source
+msgid "Batch generate related shared problems"
+msgstr "批量生成相关问题"
+
+#: no source
+msgid "Batch generate related system problems"
+msgstr "批量生成相关问题"
+
+#: no source
+msgid "Batch generate shared related"
+msgstr "批量生成相关"
+
+#: no source
+msgid "Batch generate system related"
+msgstr "批量生成相关"
+
+#: apps/common/constants/permission_constants.py:393
+msgid "Batch move"
+msgstr "批量移动"
+
+#: apps/application/views/application.py:353
+#: apps/application/views/application.py:354
+#: apps/application/views/application.py:355
+msgid "Batch move applications"
+msgstr "批量移动应用"
+
+#: apps/knowledge/views/knowledge.py:181
+#: apps/knowledge/views/knowledge.py:182
+#: apps/knowledge/views/knowledge.py:183
+msgid "Batch move knowledge"
+msgstr "批量移动知识库"
+
+#: apps/tools/views/tool.py:243
+#: apps/tools/views/tool.py:244
+#: apps/tools/views/tool.py:245
+msgid "Batch move tools"
+msgstr "批量移动工具"
+
+#: apps/knowledge/views/paragraph.py:81
+#: apps/knowledge/views/paragraph.py:82
+#: apps/knowledge/views/paragraph.py:83
+msgid "Batch Paragraph"
+msgstr "批量段落"
+
+#: apps/knowledge/views/document.py:633
+#: apps/knowledge/views/document.py:634
+msgid "Batch refresh document vector library"
+msgstr "批量刷新文档向量库"
+
+#: no source
+msgid "Batch refresh shared document vector library"
+msgstr "批量刷新共享文档向量库"
+
+#: no source
+msgid "Batch refresh system document vector library"
+msgstr "批量刷新文档向量库"
+
+#: no source
+msgid "Batch Remove Documents from Tag"
+msgstr "批量删除标签下的文档"
+
+#: no source
+msgid "Batch set user roles"
+msgstr "批量设置用户角色"
+
+#: no source
+msgid "Batch shared paragraph"
+msgstr "批量关联段落"
+
+#: apps/knowledge/views/document.py:553
+#: apps/knowledge/views/document.py:554
+#: apps/knowledge/views/document.py:555
+msgid "Batch sync documents"
+msgstr "批量同步文档"
+
+#: no source
+msgid "Batch sync shared documents"
+msgstr "批量同步共享文档"
+
+#: no source
+msgid "Batch sync system knowledges"
+msgstr "批量同步知识库"
+
+#: no source
+msgid "Batch synchronize lark document"
+msgstr "批量同步飞书文档"
+
+#: no source
+msgid "Batch system paragraph"
+msgstr "批量关联段落"
+
+#: apps/knowledge/views/document.py:672
+#: apps/knowledge/views/document.py:673
+msgid "Batch tokenize document library"
 msgstr ""
-"千帆团队在Llama-2-7b基础上的中文增强版本，在CMMLU、C-EVAL等中文知识库上表现优"
-"异。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:49
-msgid ""
-"Embedding-V1 is a text representation model based on Baidu Wenxin large "
-"model technology. It can convert text into a vector form represented by "
-"numerical values and can be used in text retrieval, information "
-"recommendation, knowledge mining and other scenarios. Embedding-V1 provides "
-"the Embeddings interface, which can generate corresponding vector "
-"representations based on input content. You can call this interface to input "
-"text into the model and obtain the corresponding vector representation for "
-"subsequent text processing and analysis."
+#: apps/application/views/application.py:392
+#: apps/application/views/application.py:393
+#: apps/application/views/application.py:394
+msgid "Batch update application chat log clear policy"
 msgstr ""
-"Embedding-V1是一个基于百度文心大模型技术的文本表示模型，可以将文本转化为用数"
-"值表示的向量形式，用于文本检索、信息推荐、知识挖掘等场景。 Embedding-V1提供了"
-"Embeddings接口，可以根据输入内容生成对应的向量表示。您可以通过调用该接口，将"
-"文本输入到模型中，获取到对应的向量表示，从而进行后续的文本处理和分析。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:66
-msgid "Thousand sails large model"
-msgstr "千帆大模型"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:39
+msgid "Beautiful ancient style"
+msgstr "唯美古风"
 
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:42
-msgid "Please outline this picture"
-msgstr "请描述这张图片"
-
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:15
-msgid "Speaker"
-msgstr "发音人"
-
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:16
-msgid ""
-"Speaker, optional value: Please go to the console to add a trial or purchase "
-"speaker. After adding, the speaker parameter value will be displayed."
+#: apps/chat/serializers/chat_record.py:27
+msgid "Bidding Status"
 msgstr ""
-"发音人，可选值：请到控制台添加试用或购买发音人，添加后即显示发音人参数值"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:21
-msgid "iFlytek Xiaoyan"
-msgstr "讯飞小燕"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:31
+msgid "black and white sketch"
+msgstr "黑白素描画"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:22
-msgid "iFlytek Xujiu"
-msgstr "讯飞许久"
+#: apps/knowledge/serializers/document.py:1310
+msgid "blank line"
+msgstr "空行"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:23
-msgid "iFlytek Xiaoping"
-msgstr "讯飞小萍"
+#: apps/oss/serializers/file.py:247
+msgid "Blocked unsafe redirect to internal host"
+msgstr "阻止不安全的重定向到内部主机"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:24
-msgid "iFlytek Xiaojing"
-msgstr "讯飞小婧"
+#: no source
+msgid "BLOOMZ-7B is a well-known large language model in the industry. It was developed and open sourced by BigScience and can output text in 46 languages and 13 programming languages."
+msgstr "BLOOMZ-7B是业内知名的大语言模型，由BigScience研发并开源，能够以46种语言和13种编程语言输出文本。"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:25
-msgid "iFlytek Xuxiaobao"
-msgstr "讯飞许小宝"
+#: apps/trigger/serializers/trigger.py:244
+msgid "body must be an array"
+msgstr "body 必须是数组类型"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:28
-msgid "Speech speed, optional value: [0-100], default is 50"
-msgstr "语速，可选值：[0-100]，默认为50"
+#: no source
+msgid "Bot User Token is required"
+msgstr "机器人用户令牌是必填项"
 
-#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:39
-#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:50
-msgid "Chinese and English recognition"
-msgstr "中英文识别"
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:25
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:13
+msgid "Branch id"
+msgstr "分支 ID"
 
-#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:66
-msgid "iFlytek Spark"
-msgstr "讯飞星火"
-
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:15
-msgid ""
-"The image generation endpoint allows you to create raw images based on text "
-"prompts. The dimensions of the image can be 1024x1024, 1024x1792, or "
-"1792x1024 pixels."
-msgstr ""
-"图像生成端点允许您根据文本提示创建原始图像。图像的尺寸可以为 1024x1024、"
-"1024x1792 或 1792x1024 像素。"
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:26
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:15
+msgid "Branch Type"
+msgstr "分支类型"
 
 #: apps/models_provider/impl/xinference_model_provider/credential/tti.py:29
-msgid ""
-"By default, images are generated in standard quality, you can set quality: "
-"\"hd\" to enhance detail. Square, standard quality images are generated "
-"fastest."
-msgstr ""
-"默认情况下，图像以标准质量生成，您可以设置质量：“hd”以增强细节。方形、标准质"
-"量的图像生成速度最快。"
+msgid "By default, images are generated in standard quality, you can set quality: \"hd\" to enhance detail. Square, standard quality images are generated fastest."
+msgstr "默认情况下，图像以标准质量生成，您可以设置质量：“hd”以增强细节。方形、标准质量的图像生成速度最快。"
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:42
-msgid ""
-"You can request 1 image at a time (requesting more images by making parallel "
-"requests), or up to 10 images at a time using the n parameter."
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:28
+msgid "\nBy default, images are produced in standard quality, but with DALL·E 3 you can set quality: \"hd\" to enhance detail. Square, standard quality images are generated fastest.\n        "
+msgstr "默认情况下，图像以标准质量生成，但使用 DALL·E 3 时，您可以设置质量：“hd”以增强细节。方形、标准质量的图像生成速度最快。"
+
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:28
+msgid "       \nBy default, images are produced in standard quality.\n        "
 msgstr ""
-"您可以一次请求 1 个图像（通过发出并行请求来请求更多图像），或者使用 n 参数一"
-"次最多请求 10 个图像。"
+
+#: no source
+msgid "Callback URL is required"
+msgstr "Callback URL 是必填项"
+
+#: no source
+msgid "callback_url is required"
+msgstr "callback_url 是必填项"
+
+#: apps/knowledge/views/knowledge_workflow.py:199
+#: apps/knowledge/views/knowledge_workflow.py:200
+#: apps/knowledge/views/knowledge_workflow.py:201
+msgid "Cancel knowledge workflow action"
+msgstr ""
+
+#: no source
+msgid "Cancel shared task"
+msgstr "取消任务"
+
+#: no source
+msgid "Cancel shared tasks in batches"
+msgstr "批量取消任务"
+
+#: no source
+msgid "Cancel system task"
+msgstr "取消任务"
+
+#: no source
+msgid "Cancel system tasks in batches"
+msgstr "批量取消任务"
+
+#: apps/knowledge/views/document.py:438
+#: apps/knowledge/views/document.py:439
+#: apps/knowledge/views/document.py:440
+msgid "Cancel task"
+msgstr "取消任务"
+
+#: apps/knowledge/views/document.py:475
+#: apps/knowledge/views/document.py:476
+#: apps/knowledge/views/document.py:477
+msgid "Cancel tasks in batches"
+msgstr "批量取消任务"
+
+#: apps/users/serializers/user.py:671
+#: apps/users/serializers/user.py:674
+#: apps/users/serializers/user.py:685
+msgid "Cannot delete built-in role"
+msgstr "无法删除内置角色"
+
+#: apps/folders/serializers/folder.py:247
+msgid "Cannot delete root folder"
+msgstr "无法删除根文件夹"
+
+#: apps/users/serializers/user.py:504
+msgid "Cannot modify administrator status"
+msgstr "不能修改管理员状态"
+
+#: no source
+msgid "Cannot modify built-in role"
+msgstr "不能修改内置角色"
+
+#: no source
+msgid "Cannot remove member from built-in role"
+msgstr "不能从内置角色中移除成员"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:22
+msgid "Cantonese"
+msgstr "粤语"
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:23
+msgid "Cantonese female"
+msgstr "粤语女"
+
+#: apps/users/serializers/login.py:35
+#: apps/users/serializers/login.py:268
+msgid "captcha"
+msgstr "验证码"
+
+#: apps/users/serializers/login.py:207
+msgid "Captcha code error or expiration"
+msgstr "验证码错误或过期"
+
+#: apps/users/serializers/login.py:200
+msgid "Captcha is required"
+msgstr "验证码是必填项"
+
+#: no source
+msgid "CAS authentication failed"
+msgstr "CAS 认证失败"
+
+#: no source
+msgid "CAS Log in"
+msgstr "CAS 登录"
+
+#: apps/models_provider/serializers/model_serializer.py:68
+#: apps/models_provider/serializers/model_serializer.py:254
+#: apps/models_provider/serializers/model_serializer.py:290
+msgid "certification information"
+msgstr "认证信息"
+
+#: no source
+msgid "Change chat user password"
+msgstr "修改对话用户密码"
+
+#: apps/common/constants/permission_constants.py:1306
+msgid "Change Password"
+msgstr "修改密码"
+
+#: apps/users/serializers/user.py:1146
+#: apps/users/views/user.py:265
+#: apps/users/views/user.py:266
+#: apps/users/views/user.py:267
+#: apps/users/views/user.py:300
+#: apps/users/views/user.py:301
+#: apps/users/views/user.py:302
+msgid "Change password"
+msgstr "修改密码"
+
+#: apps/chat/views/chat.py:79
+#: apps/chat/views/chat.py:106
+#: apps/chat/views/chat.py:128
+#: apps/chat/views/chat.py:145
+#: apps/chat/views/chat.py:163
+#: apps/chat/views/chat.py:189
+#: apps/chat/views/chat.py:207
+#: apps/chat/views/chat.py:225
+#: apps/chat/views/chat.py:244
+#: apps/chat/views/chat_embed.py:27
+#: apps/chat/views/chat_record.py:35
+#: apps/chat/views/chat_record.py:54
+#: apps/chat/views/chat_record.py:74
+#: apps/chat/views/chat_record.py:92
+#: apps/chat/views/chat_record.py:112
+#: apps/chat/views/chat_record.py:130
+#: apps/chat/views/chat_record.py:150
+#: apps/chat/views/chat_record.py:170
+#: apps/chat/views/chat_record.py:191
+#: apps/oss/views/file.py:80
+msgid "Chat"
+msgstr "对话"
+
+#: no source
+msgid "chat background"
+msgstr "聊天背景"
+
+#: no source
+msgid "chat background url"
+msgstr "聊天背景地址"
+
+#: apps/chat/serializers/chat.py:55
+msgid "Chat context"
+msgstr "聊天上下文"
+
+#: apps/application/serializers/application_chat_link.py:131
+msgid "Chat has been deleted"
+msgstr "聊天记录已被删除"
+
+#: apps/application/api/application_chat_link.py:38
+#: apps/application/api/application_chat_record.py:46
+#: apps/application/api/application_chat_record.py:115
+#: apps/application/serializers/application_chat.py:49
+#: apps/application/serializers/application_chat_record.py:93
+#: apps/chat/api/vote_api.py:27
+#: apps/chat/serializers/chat_record.py:128
+#: apps/chat/serializers/chat_record.py:167
+msgid "Chat ID"
+msgstr "对话 ID"
+
+#: apps/application/serializers/application_chat.py:35
+msgid "chat id"
+msgstr "对话 ID"
+
+#: apps/application/serializers/application_chat_link.py:67
+msgid "Chat id does not exist"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:48
+msgid "Chat ID List"
+msgstr "对话 ID 列表"
+
+#: apps/chat/serializers/chat_record.py:135
+msgid "Chat is not exist"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:34
+msgid "Chat record aggregation"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:33
+msgid "Chat record data aggregation"
+msgstr ""
+
+#: apps/application/api/application_chat_record.py:122
+#: apps/chat/api/vote_api.py:34
+msgid "Chat Record ID"
+msgstr "对话记录 ID"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:72
+msgid "Chat record id"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:46
+msgid "Chat record IDs"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:52
+msgid "Chat record ids can not be empty"
+msgstr ""
+
+#: apps/application/views/application_chat_link.py:30
+#: apps/application/views/application_chat_link.py:50
+msgid "Chat record link"
+msgstr "聊天记录链接"
+
+#: apps/common/constants/permission_constants.py:405
+#: apps/common/constants/permission_constants.py:431
+msgid "Chat User"
+msgstr "对话用户"
+
+#: no source
+msgid "Chat user"
+msgstr "对话用户"
+
+#: apps/common/constants/permission_constants.py:407
+msgid "Chat User Auth"
+msgstr "对话用户认证"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:71
+msgid "Chat user id"
+msgstr "对话用户 ID"
+
+#: apps/application/serializers/application_chat.py:37
+#: apps/chat/serializers/chat_record.py:103
+#: apps/chat/serializers/chat_record.py:127
+#: apps/chat/serializers/chat_record.py:155
+#: apps/chat/serializers/chat_record.py:168
+msgid "Chat User ID"
+msgstr "对话用户 ID"
+
+#: apps/homepage/api/home_page_api.py:217
+msgid "Chat user ID"
+msgstr "对话用户 ID"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:74
+msgid "Chat user Type"
+msgstr "对话用户类型"
+
+#: apps/application/serializers/application_chat.py:38
+msgid "Chat User Type"
+msgstr "对话用户类型"
+
+#: apps/homepage/api/home_page_api.py:219
+msgid "Chat user type"
+msgstr "对话用户类型"
+
+#: no source
+msgid "Chat User/Authentication Configuration"
+msgstr "对话用户/认证配置"
+
+#: no source
+msgid "Chat User/login"
+msgstr "对话用户/登录"
+
+#: no source
+msgid "Chat User/login authentication"
+msgstr "对话用户/登录认证"
+
+#: no source
+msgid "Chat User/logout"
+msgstr "对话用户/登出"
+
+#: no source
+msgid "Chat User/Three-party login"
+msgstr "对话用户/三方登录"
+
+#: apps/tools/views/tool.py:403
+#: apps/tools/views/tool.py:404
+#: apps/tools/views/tool.py:405
+msgid "Check code"
+msgstr "检查代码"
+
+#: no source
+msgid "Check if the fields are correct"
+msgstr "检查字段是否正确"
+
+#: apps/system_manage/serializers/valid_serializers.py:41
+msgid "check quantity"
+msgstr ""
+
+#: no source
+msgid "Check shared code"
+msgstr "检查代码"
+
+#: no source
+msgid "Check system code"
+msgstr "检查代码"
+
+#: apps/users/views/user.py:339
+#: apps/users/views/user.py:340
+#: apps/users/views/user.py:341
+msgid "Check whether the verification code is correct"
+msgstr "检查验证码是否正确"
+
+#: no source
+msgid "Check workspace can it be deleted"
+msgstr "检查工作空间是否可以被删除"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:26
+#: apps/chat/serializers/chat.py:97
+msgid "Child Nodes"
+msgstr "子节点"
+
+#: no source
+msgid "Children"
+msgstr "子级"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:80
+msgid "Chinese (including various dialects such as Cantonese), English, Japanese, and Korean support free switching between multiple languages."
+msgstr "中文（含粤语等各种方言）、英文、日语、韩语支持多个语种自由切换"
+
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:50
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:52
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:67
+msgid "Chinese and English recognition"
+msgstr "中英文识别"
 
 #: apps/models_provider/impl/xinference_model_provider/credential/tts.py:20
 msgid "Chinese female"
@@ -4869,13 +1441,1368 @@ msgstr "中文女"
 msgid "Chinese male"
 msgstr "中文男"
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:22
-msgid "Japanese male"
-msgstr "日语男"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:20
+msgid "Chinese medical"
+msgstr "中文医疗"
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:23
-msgid "Cantonese female"
-msgstr "粤语女"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:57
+msgid "Chinese painting"
+msgstr "中国画"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:21
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:14
+msgid "Chinese sounds can support mixed scenes of Chinese and English"
+msgstr "中文音色支持中英文混合场景"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:16
+msgid "Chinese telephone universal"
+msgstr "中文电话通用"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:19
+msgid "Chinese, English, and Guangdong"
+msgstr "中文、英文和广东话"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:45
+msgid "chunk size"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:50
+msgid "chunk size reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:47
+msgid "chunk size type"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:30
+msgid "classical portraiture"
+msgstr "古典肖像画"
+
+#: apps/application/serializers/application.py:1746
+msgid "Clean time"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:371
+msgid "Clear Policy"
+msgstr "清除策略"
+
+#: apps/chat/serializers/chat.py:219
+#: apps/chat/serializers/chat.py:287
+#: apps/chat/serializers/chat.py:534
+msgid "Client id"
+msgstr "客户端 ID"
+
+#: no source
+msgid "Client ID cannot be empty"
+msgstr "客户端 ID 不能为空"
+
+#: no source
+msgid "Client ID is required"
+msgstr "Client ID 是必填项"
+
+#: no source
+msgid "Client secret cannot be empty"
+msgstr "客户端密钥不能为空"
+
+#: no source
+msgid "Client Secret is required"
+msgstr "客户端密钥是必填项"
+
+#: apps/chat/serializers/chat.py:220
+#: apps/chat/serializers/chat.py:288
+#: apps/chat/serializers/chat.py:535
+msgid "Client Type"
+msgstr "客户端类型"
+
+#: apps/users/serializers/user.py:974
+msgid "Code"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:44
+msgid "\nCode Llama Instruct is a fine-tuned version of Code Llama's instructions, designed to perform specific tasks.\n        "
+msgstr "Code Llama Instruct 是 Code Llama 的指令微调版本，专为执行特定任务而设计。"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:37
+msgid "Code Llama is a language model specifically designed for code generation."
+msgstr "Code Llama 是一个专门用于代码生成的语言模型。"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:53
+msgid "Code Llama Python is a language model specifically designed for Python code generation."
+msgstr "Code Llama Python 是一个专门用于 Python 代码生成的语言模型。"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:67
+msgid "CodeQwen 1.5 Chat is a chat model version of CodeQwen 1.5."
+msgstr "CodeQwen 1.5 Chat 是一个聊天模型版本的 CodeQwen 1.5。"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:60
+msgid "CodeQwen 1.5 is a language model for code generation with high performance."
+msgstr "CodeQwen 1.5 是一个用于代码生成的语言模型，具有较高的性能。"
+
+#: apps/knowledge/serializers/document.py:1307
+msgid "comma"
+msgstr "逗号"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:18
+msgid "Commonly used in Chinese"
+msgstr "中文常用"
+
+#: apps/application/api/application_chat.py:88
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:19
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:20
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:19
+#: apps/application/serializers/application_chat.py:63
+msgid "Comparator"
+msgstr "比较器"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:80
+msgid "Compared with previous versions, qwen 1.5 0.5b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 500 million parameters."
+msgstr "qwen 1.5 0.5b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显著增强。所有规模的模型都支持32768个tokens的上下文长度。5亿参数。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:84
+msgid "Compared with previous versions, qwen 1.5 1.8b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 1.8 billion parameters."
+msgstr "qwen 1.5 1.8b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显著增强。所有规模的模型都支持32768个tokens的上下文长度。18亿参数。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:109
+msgid "Compared with previous versions, qwen 1.5 110b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 110 billion parameters."
+msgstr "qwen 1.5 110b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显著增强。所有规模的模型都支持32768个tokens的上下文长度。1100亿参数。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:97
+msgid "Compared with previous versions, qwen 1.5 14b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 14 billion parameters."
+msgstr "qwen 1.5 14b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显著增强。所有规模的模型都支持32768个tokens的上下文长度。140亿参数。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:101
+msgid "Compared with previous versions, qwen 1.5 32b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 32 billion parameters."
+msgstr "qwen 1.5 32b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显著增强。所有规模的模型都支持32768个tokens的上下文长度。320亿参数。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:88
+msgid "Compared with previous versions, qwen 1.5 4b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 4 billion parameters."
+msgstr "qwen 1.5 4b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显著增强。所有规模的模型都支持32768个tokens的上下文长度。40亿参数。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:105
+msgid "Compared with previous versions, qwen 1.5 72b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 72 billion parameters."
+msgstr "qwen 1.5 72b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显著增强。所有规模的模型都支持32768个tokens的上下文长度。720亿参数。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:93
+msgid "Compared with previous versions, qwen 1.5 7b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 7 billion parameters."
+msgstr "qwen 1.5 7b 相较于以往版本，模型与人类偏好的对齐程度以及多语言处理能力上有显著增强。所有规模的模型都支持32768个tokens的上下文长度。70亿参数。"
+
+#: apps/application/serializers/application_chat.py:172
+msgid "complete"
+msgstr "内容完善"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:44
+msgid "Completion problem"
+msgstr "完成问题"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:68
+msgid "Completion Question"
+msgstr "完成问题"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:19
+msgid "concept art"
+msgstr "概念艺术"
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:27
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:26
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:25
+msgid "Condition or|and"
+msgstr "条件 或|与"
+
+#: no source
+msgid "Config"
+msgstr "配置"
+
+#: no source
+msgid "Configuration information is wrong and failed to save"
+msgstr "配置信息错误，保存失败"
+
+#: no source
+msgid "Confirm Password"
+msgstr "确认密码"
+
+#: no source
+msgid "Connection failed"
+msgstr "连接失败"
+
+#: apps/application/serializers/application_chat.py:220
+msgid "Consuming tokens"
+msgstr "消耗的令牌"
+
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:14
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:38
+#: apps/chat/serializers/chat.py:206
+#: apps/knowledge/serializers/paragraph.py:70
+#: apps/knowledge/serializers/problem.py:28
+#: apps/knowledge/serializers/problem.py:32
+#: apps/knowledge/serializers/problem.py:236
+#: apps/knowledge/serializers/termbase.py:22
+#: apps/knowledge/serializers/termbase.py:29
+#: apps/knowledge/serializers/termbase.py:141
+msgid "content"
+msgstr "内容"
+
+#: apps/chat/serializers/chat.py:50
+msgid "Content"
+msgstr ""
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:37
+msgid "Content cannot be empty"
+msgstr "内容不能为空"
+
+#: no source
+msgid "Content generated by AI"
+msgstr "AI 生成的内容"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:37
+msgid "Context Type"
+msgstr "上下文类型"
+
+#: apps/application/serializers/application_chat_record.py:78
+#: apps/chat/serializers/chat.py:301
+#: apps/chat/serializers/chat.py:484
+msgid "Conversation does not exist"
+msgstr "对话不存在"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:60
+#: apps/application/serializers/application_chat.py:214
+#: apps/application/serializers/application_chat.py:263
+#: apps/application/serializers/application_chat_link.py:56
+#: apps/application/serializers/application_chat_record.py:45
+#: apps/application/serializers/application_chat_record.py:203
+#: apps/application/serializers/application_chat_record.py:253
+#: apps/application/serializers/application_chat_record.py:371
+#: apps/application/serializers/application_chat_record.py:471
+#: apps/chat/serializers/chat.py:136
+#: apps/chat/serializers/chat.py:212
+#: apps/chat/serializers/chat.py:286
+#: apps/chat/serializers/chat_record.py:45
+msgid "Conversation ID"
+msgstr "对话 ID"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:55
+msgid "Conversation list"
+msgstr "对话列表"
+
+#: apps/common/constants/permission_constants.py:398
+#: apps/common/constants/permission_constants.py:442
+msgid "Conversation log"
+msgstr "对话日志"
+
+#: apps/application/serializers/application_chat_record.py:224
+#: apps/application/serializers/application_chat_record.py:436
+#: apps/application/serializers/application_chat_record.py:514
+#: apps/chat/serializers/chat.py:388
+msgid "Conversation record does not exist"
+msgstr "对话记录不存在"
+
+#: apps/application/serializers/application_chat_record.py:48
+#: apps/application/serializers/application_chat_record.py:206
+#: apps/application/serializers/application_chat_record.py:374
+#: apps/application/serializers/application_chat_record.py:474
+#: apps/chat/serializers/chat.py:80
+#: apps/chat/serializers/chat_record.py:48
+msgid "Conversation record id"
+msgstr "对话记录 ID"
+
+#: apps/application/serializers/application_chat_record.py:302
+msgid "Conversation records that do not exist"
+msgstr "对话记录不存在"
+
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:26
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:27
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:24
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:26
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:23
+msgid "Conversation storage type"
+msgstr "对话存储类型"
+
+#: no source
+msgid "convert audio to text"
+msgstr "将音频转换为文本"
+
+#: apps/common/constants/permission_constants.py:348
+msgid "Copy"
+msgstr "复制"
+
+#: no source
+msgid "Corp ID is required"
+msgstr "Corp ID 是必填项"
+
+#: no source
+msgid "corporation"
+msgstr "公司"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:89
+msgid "CosyVoice is based on a new generation of large generative speech models, which can predict emotions, intonation, rhythm, etc. based on context, and has better anthropomorphic effects."
+msgstr "CosyVoice基于新一代生成式语音大模型，能根据上下文预测情绪、语调、韵律等，具有更好的拟人效果"
+
+#: no source
+msgid "count"
+msgstr "数量"
+
+#: apps/common/constants/permission_constants.py:350
+msgid "Create"
+msgstr "创建"
+
+#: no source
+msgid "Create a lark knowledge base"
+msgstr "创建知识库"
+
+#: apps/knowledge/views/tag.py:21
+msgid "Create a new knowledge tag"
+msgstr ""
+
+#: no source
+msgid "Create a web site knowledge base"
+msgstr "创建一个web知识库"
+
+#: apps/application/views/application.py:55
+#: apps/application/views/application.py:56
+#: apps/application/views/application.py:57
+msgid "Create an application"
+msgstr "创建一个智能体程序"
+
+#: apps/application/views/application_api_key.py:31
+#: apps/application/views/application_api_key.py:32
+#: apps/application/views/application_api_key.py:33
+msgid "Create application ApiKey"
+msgstr "创建智能体 API 密钥"
+
+#: apps/application/views/application_api_key.py:60
+#: apps/application/views/application_api_key.py:61
+msgid "Create application ApiKey List"
+msgstr "创建智能体 API 密钥列表"
+
+#: apps/knowledge/views/knowledge.py:594
+#: apps/knowledge/views/knowledge.py:595
+#: apps/knowledge/views/knowledge.py:596
+msgid "Create base knowledge"
+msgstr "创建知识库"
+
+#: no source
+msgid "Create chat user"
+msgstr "创建对话用户"
+
+#: apps/knowledge/views/document.py:53
+#: apps/knowledge/views/document.py:54
+#: apps/knowledge/views/document.py:55
+msgid "Create document"
+msgstr "创建文档"
+
+#: apps/knowledge/views/document.py:513
+#: apps/knowledge/views/document.py:514
+#: apps/knowledge/views/document.py:515
+msgid "Create documents in batches"
+msgstr "批量创建文档"
+
+#: apps/folders/views/folder.py:32
+#: apps/folders/views/folder.py:33
+#: apps/folders/views/folder.py:34
+msgid "Create folder"
+msgstr "创建文件夹"
+
+#: apps/knowledge/views/tag.py:20
+msgid "Create Knowledge Tag"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:229
+#: apps/knowledge/views/knowledge_workflow.py:230
+#: apps/knowledge/views/knowledge_workflow.py:231
+msgid "Create knowledge workflow"
+msgstr ""
+
+#: apps/models_provider/views/model.py:61
+#: apps/models_provider/views/model.py:62
+#: apps/models_provider/views/model.py:63
+msgid "Create model"
+msgstr "创建模型"
+
+#: no source
+msgid "Create or update Chat User Group"
+msgstr "创建或更新对话用户组"
+
+#: apps/system_manage/views/email_setting.py:50
+#: apps/system_manage/views/email_setting.py:51
+#: apps/system_manage/views/email_setting.py:52
+msgid "Create or update email settings"
+msgstr "创建或更新邮件设置"
+
+#: no source
+msgid "Create or update role"
+msgstr "创建或更新角色"
+
+#: no source
+msgid "Create or update role permission"
+msgstr "创建或更新角色权限"
+
+#: no source
+msgid "Create or update user group"
+msgstr "创建或更新用户组"
+
+#: no source
+msgid "Create or update workspace"
+msgstr "创建或更新工作空间"
+
+#: apps/knowledge/views/paragraph.py:50
+#: apps/knowledge/views/paragraph.py:51
+msgid "Create Paragraph"
+msgstr "创建段落"
+
+#: apps/knowledge/views/problem.py:50
+#: apps/knowledge/views/problem.py:51
+#: apps/knowledge/views/problem.py:52
+msgid "Create question"
+msgstr "创建问题"
+
+#: no source
+msgid "Create shared base knowledge"
+msgstr "创建共享知识库"
+
+#: no source
+msgid "Create shared document"
+msgstr "创建共享文档"
+
+#: no source
+msgid "Create shared documents in batches"
+msgstr "批量创建共享文档"
+
+#: no source
+msgid "Create shared paragraph"
+msgstr "创建段落"
+
+#: no source
+msgid "Create shared question"
+msgstr "创建问题"
+
+#: no source
+msgid "Create shared tool"
+msgstr "创建共享工具"
+
+#: no source
+msgid "Create shared web knowledge"
+msgstr "创建 web 知识库"
+
+#: no source
+msgid "Create system knowledge"
+msgstr "创建系统知识库"
+
+#: no source
+msgid "Create system knowledges in batches"
+msgstr "批量创建知识库"
+
+#: no source
+msgid "Create system paragraph"
+msgstr "创建段落"
+
+#: no source
+msgid "Create system question"
+msgstr "创建问题"
+
+#: no source
+msgid "Create SystemAPIKey"
+msgstr "创建系统 API 密钥"
+
+#: apps/knowledge/views/termbase.py:58
+#: apps/knowledge/views/termbase.py:59
+#: apps/knowledge/views/termbase.py:60
+msgid "Create termbase"
+msgstr ""
+
+#: apps/tools/views/tool.py:44
+#: apps/tools/views/tool.py:45
+#: apps/tools/views/tool.py:46
+msgid "Create tool"
+msgstr "创建工具"
+
+#: apps/common/constants/permission_constants.py:388
+msgid "Create Trigger"
+msgstr "创建触发器"
+
+#: apps/trigger/views/trigger.py:57
+#: apps/trigger/views/trigger.py:58
+#: apps/trigger/views/trigger.py:59
+msgid "Create trigger"
+msgstr "创建触发器"
+
+#: apps/trigger/views/trigger.py:254
+#: apps/trigger/views/trigger.py:255
+#: apps/trigger/views/trigger.py:256
+msgid "Create trigger in source"
+msgstr "资源端创建触发器"
+
+#: apps/application/serializers/application.py:456
+#: apps/knowledge/serializers/knowledge.py:190
+#: apps/models_provider/api/model.py:65
+#: apps/models_provider/serializers/model_serializer.py:363
+#: apps/models_provider/serializers/model_serializer.py:546
+#: apps/tools/serializers/tool.py:347
+#: apps/tools/serializers/tool.py:1695
+msgid "create user"
+msgstr "创建用户"
+
+#: apps/trigger/serializers/trigger.py:643
+#: apps/users/views/user.py:175
+#: apps/users/views/user.py:176
+#: apps/users/views/user.py:177
+msgid "Create user"
+msgstr "创建用户"
+
+#: apps/knowledge/views/knowledge.py:622
+#: apps/knowledge/views/knowledge.py:623
+#: apps/knowledge/views/knowledge.py:624
+msgid "Create web knowledge"
+msgstr "创建 web 知识库"
+
+#: apps/knowledge/views/document.py:1197
+#: apps/knowledge/views/document.py:1198
+#: apps/knowledge/views/document.py:1199
+msgid "Create Web site documents"
+msgstr "创建网站文档"
+
+#: no source
+msgid "Create Web site shared documents"
+msgstr "创建网站文档"
+
+#: apps/application/serializers/application.py:469
+#: apps/application/serializers/application.py:469
+msgid "Creation time"
+msgstr "创建时间"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:32
+#: apps/system_manage/serializers/resource_mapping_serializers.py:114
+msgid "creator"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:230
+msgid "cron type requires cron_expression field"
+msgstr "cron 类型需要 cron_expression 字段"
+
+#: no source
+msgid "Cross domain list"
+msgstr "跨域列表"
+
+#: apps/application/serializers/application_api_key.py:30
+msgid "Cross-domain address"
+msgstr "跨域地址"
+
+#: apps/application/serializers/application_api_key.py:31
+msgid "Cross-domain list"
+msgstr "跨域列表"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:13
+msgid "CueWord"
+msgstr "提示词"
+
+#: apps/application/api/application_api.py:54
+#: apps/application/api/application_chat.py:110
+#: apps/application/api/application_chat_record.py:74
+#: apps/homepage/api/home_page_api.py:96
+#: apps/system_manage/api/resource_mapping.py:56
+#: apps/system_manage/api/user_resource_permission.py:207
+#: apps/system_manage/api/user_resource_permission.py:273
+#: apps/trigger/api/trigger.py:93
+#: apps/trigger/api/trigger_task.py:102
+msgid "Current page"
+msgstr "当前页"
+
+#: apps/common/result/api.py:44
+msgid "current page"
+msgstr "当前页"
+
+#: no source
+msgid "Currently only text messages are supported"
+msgstr "目前仅支持文本消息"
+
+#: no source
+msgid "Custom role"
+msgstr "自定义角色"
+
+#: no source
+msgid "Custom theme field type error"
+msgstr "自定义主题字段类型错误"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:32
+msgid "cyberpunk"
+msgstr "赛博朋克"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:34
+msgid "dark style"
+msgstr "暗黑风格"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:83
+msgid "data source web node:{node_id} error{error}{traceback}"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:30
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:39
+msgid "Dataset id list"
+msgstr "知识库 ID 列表"
+
+#: apps/application/serializers/application.py:606
+msgid "Dataset settings"
+msgstr "知识库设置"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:88
+msgid "datasource data"
+msgstr ""
+
+#: apps/application/serializers/application_stats.py:31
+msgid "date"
+msgstr "日期"
+
+#: apps/chat/serializers/chat.py:291
+#: apps/chat/serializers/chat.py:536
+msgid "Debug"
+msgstr "调试"
+
+#: no source
+msgid "Debug shared Tool"
+msgstr "调试共享工具"
+
+#: no source
+msgid "Debug system tool"
+msgstr "调试工具"
+
+#: apps/tools/views/tool.py:99
+#: apps/tools/views/tool.py:100
+#: apps/tools/views/tool.py:101
+msgid "Debug Tool"
+msgstr "调试工具"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:74
+msgid "Deepseek is a large-scale language model with 13 billion parameters."
+msgstr "Deepseek Chat 是一个聊天模型版本的 Deepseek。"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:216
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:72
+msgid "default"
+msgstr ""
+
+#: no source
+msgid "Default user group cannot be deleted"
+msgstr "默认用户组不能被删除"
+
+#: apps/models_provider/api/provide.py:41
+msgid "default value"
+msgstr "默认值"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:49
+msgid "Default value, the image style is randomly output by the model"
+msgstr "默认值，图片风格由模型随机输出"
+
+#: no source
+msgid "Default workspace cannot be deleted"
+msgstr "默认工作空间不能被删除"
+
+#: apps/users/serializers/user.py:71
+msgid "defaultPermission"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:351
+msgid "Delete"
+msgstr "删除"
+
+#: apps/application/views/application_chat_record.py:196
+#: apps/application/views/application_chat_record.py:197
+#: apps/application/views/application_chat_record.py:198
+msgid "Delete a Annotation"
+msgstr "删除注释"
+
+#: apps/knowledge/views/tag.py:101
+msgid "Delete a knowledge tag"
+msgstr ""
+
+#: apps/application/views/application_api_key.py:109
+#: apps/application/views/application_api_key.py:110
+#: apps/application/views/application_api_key.py:111
+msgid "Delete Application API_KEY"
+msgstr "删除智能体 API 密钥"
+
+#: no source
+msgid "Delete application API_KEY"
+msgstr "删除智能体 API KEY"
+
+#: no source
+msgid "Delete chat user"
+msgstr "删除对话用户"
+
+#: no source
+msgid "Delete chat user group"
+msgstr "删除对话用户组"
+
+#: apps/knowledge/views/document.py:186
+#: apps/knowledge/views/document.py:187
+#: apps/knowledge/views/document.py:188
+msgid "Delete document"
+msgstr "删除文档"
+
+#: apps/knowledge/views/document.py:1072
+#: apps/knowledge/views/document.py:1073
+#: apps/knowledge/views/document.py:1074
+msgid "Delete document tags"
+msgstr ""
+
+#: apps/knowledge/views/document.py:593
+#: apps/knowledge/views/document.py:594
+#: apps/knowledge/views/document.py:595
+msgid "Delete documents in batches"
+msgstr "批量删除文档"
+
+#: apps/oss/views/file.py:59
+#: apps/oss/views/file.py:60
+#: apps/oss/views/file.py:61
+msgid "Delete file"
+msgstr "删除文件"
+
+#: apps/folders/views/folder.py:146
+#: apps/folders/views/folder.py:147
+#: apps/folders/views/folder.py:148
+msgid "Delete folder"
+msgstr "删除文件夹"
+
+#: apps/chat/views/chat_record.py:87
+#: apps/chat/views/chat_record.py:88
+#: apps/chat/views/chat_record.py:89
+msgid "Delete history conversation"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:92
+#: apps/knowledge/views/knowledge.py:93
+#: apps/knowledge/views/knowledge.py:94
+msgid "Delete knowledge"
+msgstr "删除知识库"
+
+#: no source
+msgid "Delete knowledge base"
+msgstr "删除知识库"
+
+#: apps/knowledge/views/tag.py:100
+msgid "Delete Knowledge Tag"
+msgstr ""
+
+#: apps/models_provider/views/model.py:138
+#: apps/models_provider/views/model.py:139
+#: apps/models_provider/views/model.py:140
+msgid "Delete model"
+msgstr "删除模型"
+
+#: apps/knowledge/views/paragraph.py:239
+#: apps/knowledge/views/paragraph.py:240
+#: apps/knowledge/views/paragraph.py:241
+msgid "Delete paragraph"
+msgstr "删除段落"
+
+#: no source
+msgid "Delete personal system API_KEY"
+msgstr "删除个人系统API KEY"
+
+#: apps/knowledge/views/problem.py:167
+#: apps/knowledge/views/problem.py:168
+#: apps/knowledge/views/problem.py:169
+msgid "Delete question"
+msgstr "删除问题"
+
+#: no source
+msgid "Delete role"
+msgstr "删除角色"
+
+#: no source
+msgid "Delete shared document"
+msgstr "删除共享文档"
+
+#: no source
+msgid "Delete shared documents in batches"
+msgstr "批量删除共享文档"
+
+#: no source
+msgid "Delete shared knowledge"
+msgstr "删除共享知识库"
+
+#: no source
+msgid "Delete shared paragraph"
+msgstr "删除段落"
+
+#: no source
+msgid "Delete shared question"
+msgstr "删除问题"
+
+#: no source
+msgid "Delete shared tool"
+msgstr "删除共享工具"
+
+#: no source
+msgid "Delete system document"
+msgstr "删除文档"
+
+#: no source
+msgid "Delete system document in batches"
+msgstr "批量删除文档"
+
+#: no source
+msgid "Delete system knowledge"
+msgstr "删除知识库"
+
+#: no source
+msgid "Delete system knowledge in batches"
+msgstr "批量删除知识库"
+
+#: no source
+msgid "Delete system paragraph"
+msgstr "删除段落"
+
+#: no source
+msgid "Delete system question"
+msgstr "删除问题"
+
+#: no source
+msgid "Delete system tool"
+msgstr "删除工具"
+
+#: no source
+msgid "Delete SystemAPIKey"
+msgstr "删除系统 API 密钥"
+
+#: apps/knowledge/views/termbase.py:163
+#: apps/knowledge/views/termbase.py:164
+#: apps/knowledge/views/termbase.py:165
+msgid "Delete termbase"
+msgstr ""
+
+#: no source
+msgid "Delete the System task source trigger"
+msgstr "删除系统任务来源触发器"
+
+#: apps/trigger/views/trigger.py:375
+#: apps/trigger/views/trigger.py:376
+#: apps/trigger/views/trigger.py:377
+msgid "Delete the task source trigger"
+msgstr "删除资源端触发器"
+
+#: apps/trigger/views/trigger.py:150
+#: apps/trigger/views/trigger.py:151
+#: apps/trigger/views/trigger.py:152
+msgid "Delete the trigger"
+msgstr "删除触发器"
+
+#: apps/tools/views/tool.py:175
+#: apps/tools/views/tool.py:176
+#: apps/tools/views/tool.py:177
+msgid "Delete tool"
+msgstr "删除工具"
+
+#: apps/common/constants/permission_constants.py:390
+msgid "Delete Trigger"
+msgstr "删除触发器"
+
+#: apps/trigger/views/trigger.py:175
+#: apps/trigger/views/trigger.py:176
+#: apps/trigger/views/trigger.py:177
+msgid "Delete trigger in batches"
+msgstr "批量删除触发器"
+
+#: apps/users/views/user.py:206
+#: apps/users/views/user.py:207
+#: apps/users/views/user.py:208
+msgid "Delete user"
+msgstr "删除用户"
+
+#: no source
+msgid "Delete user group"
+msgstr "删除用户组"
+
+#: no source
+msgid "Delete workspace"
+msgstr "删除工作空间"
+
+#: apps/application/views/application.py:170
+#: apps/application/views/application.py:171
+#: apps/application/views/application.py:172
+msgid "Deleting application"
+msgstr "删除智能体"
+
+#: apps/application/views/application_chat.py:146
+#: apps/application/views/application_chat.py:147
+#: apps/application/views/application_chat.py:148
+#: apps/chat/views/chat.py:157
+#: apps/chat/views/chat.py:158
+#: apps/chat/views/chat.py:159
+msgid "dialogue"
+msgstr "对话"
+
+#: no source
+msgid "Dialogue log"
+msgstr "对话日志"
+
+#: apps/common/constants/permission_constants.py:397
+#: apps/common/constants/permission_constants.py:399
+#: apps/common/constants/permission_constants.py:419
+#: apps/common/constants/permission_constants.py:429
+#: apps/common/constants/permission_constants.py:441
+msgid "Dialogue users"
+msgstr "对话用户"
+
+#: apps/application/views/application_stats.py:28
+#: apps/application/views/application_stats.py:29
+#: apps/application/views/application_stats.py:30
+#: apps/homepage/views/homepage.py:232
+#: apps/homepage/views/homepage.py:233
+msgid "Dialogue-related statistical trends"
+msgstr "与对话有关的统计趋势"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:24
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:22
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:22
+msgid "Dimensions"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:380
+msgid "Dingding"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:293
+msgid "DingTalk"
+msgstr "钉钉应用"
+
+#: no source
+msgid "dingtalk"
+msgstr "钉钉"
+
+#: no source
+msgid "DingTalk application: {user}"
+msgstr "钉钉智能体: {user}"
+
+#: no source
+msgid "DingTalk callback"
+msgstr "钉钉回调"
+
+#: no source
+msgid "DingTalk OAuth2 callback"
+msgstr "钉钉 OAuth2 回调"
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:24
+msgid "Direct answer content"
+msgstr "直接回答内容"
+
+#: apps/knowledge/serializers/document.py:174
+#: apps/knowledge/serializers/document.py:250
+msgid "directly return similarity"
+msgstr "直接返回相似度"
+
+#: apps/knowledge/serializers/knowledge.py:771
+msgid "Directly return similarity"
+msgstr "直接返回相似度"
+
+#: apps/knowledge/views/paragraph.py:339
+#: apps/knowledge/views/paragraph.py:340
+#: apps/knowledge/views/paragraph.py:341
+msgid "Disassociation issue"
+msgstr "取消关联问题"
+
+#: no source
+msgid "Disassociation shared issue"
+msgstr "取消关联问题"
+
+#: no source
+msgid "Disassociation system issue"
+msgstr "取消关联问题"
+
+#: no source
+msgid "disclaimer"
+msgstr "免责申明"
+
+#: no source
+msgid "disclaimer value"
+msgstr "免责申明内容"
+
+#: apps/application/serializers/application_access_token.py:38
+msgid "Display execution details"
+msgstr "是否显示执行详情"
+
+#: apps/common/constants/permission_constants.py:375
+#: apps/common/constants/permission_constants.py:402
+msgid "Display Settings"
+msgstr "显示设置"
+
+#: no source
+msgid "Display settings"
+msgstr "显示设置"
+
+#: no source
+msgid "Displaying knowledge sources is not enabled"
+msgstr "知识库来源展示未开启"
+
+#: apps/users/serializers/user.py:1104
+msgid "Do not send emails again within {seconds} seconds"
+msgstr "不要在 {seconds} 秒内再次发送邮件"
+
+#: apps/chat/serializers/chat.py:78
+msgid "Do you want to reply again"
+msgstr "是否重新回复"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:22
+#: apps/application/flow/step_node/document_extract_node/i_document_extract_node.py:13
+#: apps/chat/serializers/chat.py:93
+msgid "document"
+msgstr "文档"
+
+#: apps/common/constants/permission_constants.py:355
+#: apps/common/constants/permission_constants.py:413
+#: apps/common/constants/permission_constants.py:423
+msgid "Document"
+msgstr "文档"
+
+#: no source
+msgid "Document does not belong to current knowledge"
+msgstr "文档不属于当前知识库"
+
+#: apps/application/api/application_chat_record.py:136
+msgid "Document ID"
+msgstr "文档 ID"
+
+#: apps/application/serializers/application_chat_record.py:251
+#: apps/application/serializers/application_chat_record.py:378
+#: apps/application/serializers/application_chat_record.py:478
+msgid "Document id"
+msgstr "文档 ID"
+
+#: apps/knowledge/serializers/document.py:358
+#: apps/knowledge/serializers/document.py:588
+#: apps/knowledge/serializers/document.py:685
+#: apps/knowledge/serializers/document.py:1002
+#: apps/knowledge/serializers/document.py:1699
+#: apps/knowledge/serializers/document.py:1774
+#: apps/knowledge/serializers/document.py:1815
+#: apps/knowledge/serializers/document.py:1880
+#: apps/knowledge/serializers/paragraph.py:97
+#: apps/knowledge/serializers/paragraph.py:109
+#: apps/knowledge/serializers/paragraph.py:206
+#: apps/knowledge/serializers/paragraph.py:340
+#: apps/knowledge/serializers/paragraph.py:438
+#: apps/knowledge/serializers/paragraph.py:475
+#: apps/knowledge/serializers/paragraph.py:554
+#: apps/knowledge/serializers/paragraph.py:603
+#: apps/knowledge/serializers/paragraph.py:780
+#: apps/knowledge/serializers/problem.py:37
+#: apps/knowledge/serializers/problem.py:52
+msgid "document id"
+msgstr "文档 ID"
+
+#: apps/knowledge/serializers/document.py:1871
+msgid "Document id does not belong to current knowledge"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1715
+#: apps/knowledge/serializers/document.py:1792
+#: apps/knowledge/serializers/document.py:1833
+#: apps/knowledge/serializers/document.py:1896
+msgid "Document id does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:236
+#: apps/knowledge/serializers/document.py:243
+msgid "document id list"
+msgstr "文档 ID 列表"
+
+#: apps/knowledge/serializers/document.py:601
+#: apps/knowledge/serializers/document.py:699
+msgid "document id not exist"
+msgstr "文档 ID 不存在"
+
+#: apps/knowledge/serializers/document.py:177
+#: apps/knowledge/serializers/document.py:480
+msgid "document is active"
+msgstr "文档已激活"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:13
+#: apps/application/flow/step_node/knowledge_write_node/i_knowledge_write_node.py:20
+#: apps/knowledge/serializers/document.py:358
+msgid "document list"
+msgstr "文档列表"
+
+#: apps/knowledge/serializers/knowledge.py:775
+msgid "Document meta"
+msgstr "文档元数据"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:53
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:54
+#: apps/knowledge/serializers/document.py:138
+#: apps/knowledge/serializers/document.py:138
+#: apps/knowledge/serializers/document.py:159
+#: apps/knowledge/serializers/document.py:159
+#: apps/knowledge/serializers/document.py:475
+msgid "document name"
+msgstr "文档名称"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:32
+msgid "document name relate problem"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:35
+msgid "document name relate problem reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:28
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:39
+msgid "document name relate problem type"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:774
+msgid "Document type"
+msgstr "文档类型"
+
+#: apps/knowledge/serializers/document.py:208
+#: apps/knowledge/serializers/document.py:209
+msgid "document url list"
+msgstr "文档 URL 列表"
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:19
+msgid "domain"
+msgstr ""
+
+#: no source
+msgid "Download"
+msgstr "下载"
+
+#: apps/tools/serializers/tool.py:1378
+msgid "download callback url"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:372
+msgid "Download Original Document"
+msgstr "下载原文档"
+
+#: no source
+msgid "Download shared source file"
+msgstr "下载共享源文件"
+
+#: apps/knowledge/views/document.py:952
+#: apps/knowledge/views/document.py:953
+msgid "Download source file"
+msgstr "下载源文件"
+
+#: no source
+msgid "Download system source file"
+msgstr "下载系统源文件"
+
+#: apps/tools/serializers/tool.py:1377
+msgid "download url"
+msgstr ""
+
+#: no source
+msgid "draggable"
+msgstr "是否可拖动"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:43
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:43
+msgid "Duration"
+msgstr "时长"
+
+#: apps/common/constants/permission_constants.py:347
+msgid "Edit"
+msgstr "编辑"
+
+#: no source
+msgid "Edit folder"
+msgstr "编辑文件夹"
+
+#: apps/knowledge/views/knowledge.py:65
+#: apps/knowledge/views/knowledge.py:66
+#: apps/knowledge/views/knowledge.py:67
+msgid "Edit knowledge"
+msgstr "修改知识库"
+
+#: apps/knowledge/views/knowledge_workflow.py:366
+#: apps/knowledge/views/knowledge_workflow.py:367
+#: apps/knowledge/views/knowledge_workflow.py:368
+msgid "Edit knowledge workflow"
+msgstr ""
+
+#: no source
+msgid "Edit Resource chat user group List"
+msgstr "编辑资源对话用户组列表"
+
+#: no source
+msgid "Edit Resource chat user List"
+msgstr "编辑资源对话用户列表"
+
+#: no source
+msgid "Edit shared tool icon"
+msgstr "修改共享工具图标"
+
+#: no source
+msgid "Edit system tool icon"
+msgstr "修改工具图标"
+
+#: apps/tools/views/tool.py:428
+#: apps/tools/views/tool.py:429
+#: apps/tools/views/tool.py:430
+msgid "Edit tool icon"
+msgstr "修改工具图标"
+
+#: apps/tools/views/tool_workflow.py:68
+#: apps/tools/views/tool_workflow.py:69
+#: apps/tools/views/tool_workflow.py:70
+msgid "Edit tool workflow"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:389
+msgid "Edit Trigger"
+msgstr "编辑触发器"
+
+#: apps/system_manage/views/user_resource_permission.py:142
+#: apps/system_manage/views/user_resource_permission.py:143
+#: apps/system_manage/views/user_resource_permission.py:144
+msgid "Edit user authorization status of resource"
+msgstr "修改资源对用户的授权状态"
+
+#: no source
+msgid "edition"
+msgstr "版本"
+
+#: apps/users/serializers/user.py:67
+#: apps/users/serializers/user.py:165
+#: apps/users/serializers/user.py:248
+#: apps/users/serializers/user.py:388
+#: apps/users/serializers/user.py:970
+#: apps/users/serializers/user.py:1085
+#: apps/users/serializers/user.py:1164
+msgid "Email"
+msgstr "邮箱"
+
+#: apps/common/constants/exception_code_constants.py:34
+msgid "Email format error"
+msgstr "邮箱格式错误"
+
+#: apps/users/serializers/user.py:424
+msgid "Email is already in use"
+msgstr "邮箱已被使用"
+
+#: apps/users/api/user.py:154
+msgid "Email or Username"
+msgstr "邮箱或用户名"
+
+#: no source
+msgid "Email or username"
+msgstr "邮箱或用户名"
+
+#: apps/common/constants/exception_code_constants.py:33
+#: apps/common/constants/exception_code_constants.py:45
+msgid "Email sending failed"
+msgstr "邮件发送失败"
+
+#: apps/common/constants/permission_constants.py:352
+msgid "Email Setting"
+msgstr "邮箱设置"
+
+#: apps/system_manage/views/email_setting.py:55
+#: apps/system_manage/views/email_setting.py:70
+#: apps/system_manage/views/email_setting.py:86
+msgid "Email Settings"
+msgstr "邮箱设置"
+
+#: no source
+msgid "Email settings"
+msgstr "邮箱设置"
+
+#: apps/system_manage/serializers/email_setting.py:52
+msgid "Email verification failed"
+msgstr "邮件认证失败"
+
+#: apps/common/constants/permission_constants.py:373
+msgid "Embed third party"
+msgstr "嵌入第三方"
+
+#: apps/models_provider/base_model_provider.py:148
+msgid "Embedding Model"
+msgstr "向量模型"
+
+#: no source
+msgid "embedding model"
+msgstr "向量模型"
+
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:46
+msgid "Embedding-V1 is a text representation model based on Baidu Wenxin large model technology. It can convert text into a vector form represented by numerical values and can be used in text retrieval, information recommendation, knowledge mining and other scenarios. Embedding-V1 provides the Embeddings interface, which can generate corresponding vector representations based on input content. You can call this interface to input text into the model and obtain the corresponding vector representation for subsequent text processing and analysis."
+msgstr "Embedding-V1是一个基于百度文心大模型技术的文本表示模型，可以将文本转化为用数值表示的向量形式，用于文本检索、信息推荐、知识挖掘等场景。 Embedding-V1提供了Embeddings接口，可以根据输入内容生成对应的向量表示。您可以通过调用该接口，将文本输入到模型中，获取到对应的向量表示，从而进行后续的文本处理和分析。"
+
+#: no source
+msgid "Enable"
+msgstr "启用"
+
+#: apps/users/serializers/login.py:37
+msgid "encryptedData"
+msgstr ""
+
+#: apps/common/job/clean_chat_job.py:45
+msgid "end clean chat log"
+msgstr "结束清理聊天日志"
+
+#: apps/common/job/clean_debug_file_job.py:30
+msgid "end clean debug file"
+msgstr "结束清理调试文件"
+
+#: apps/application/serializers/application.py:278
+msgid "End of thinking process marker"
+msgstr "思考过程结束标记"
+
+#: apps/common/job/client_access_num_job.py:27
+msgid "end reset access_num"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:57
+#: apps/application/serializers/application_stats.py:41
+#: apps/homepage/serializers/homepage.py:92
+#: apps/homepage/serializers/homepage.py:153
+#: apps/homepage/serializers/homepage.py:219
+#: apps/homepage/serializers/homepage.py:391
+#: apps/homepage/serializers/homepage.py:518
+#: apps/homepage/serializers/homepage.py:658
+msgid "End time"
+msgstr "结束时间"
+
+#: apps/common/event/listener_manage.py:411
+msgid "End--->Embedding document: {document_id}"
+msgstr "结束--->向量文档: {document_id}"
+
+#: apps/common/event/listener_manage.py:436
+msgid "End--->Embedding knowledge: {knowledge_id}"
+msgstr "结束--->向量知识库: {knowledge_id}"
+
+#: apps/common/event/listener_manage.py:147
+msgid "End--->Embedding paragraph: {paragraph_id_list}"
+msgstr "结束--->向量段落: {paragraph_id_list}"
+
+#: apps/common/event/listener_manage.py:197
+msgid "End--->Embedding paragraph: {paragraph_id}"
+msgstr "结束--->向量段落: {paragraph_id}"
+
+#: apps/knowledge/task/sync.py:33
+#: apps/knowledge/task/sync.py:55
+msgid "End--->End synchronization web knowledge base:{knowledge_id}"
+msgstr "结束--->结束同步 web 知识库:{knowledge_id}"
+
+#: apps/knowledge/task/generate.py:107
+msgid "End--->Generate problem: {document_id}"
+msgstr "结束--->生成问题: {document_id}"
+
+#: apps/common/event/listener_manage.py:569
+msgid "End--->Tokenize document: {document_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:250
+msgid "End--->Tokenize paragraph: {paragraph_id}"
+msgstr ""
+
+#: apps/knowledge/task/embedding.py:137
+msgid "End--->Vectorized knowledge: {knowledge_id}"
+msgstr "结束--->向量知识库: {knowledge_id}"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:12
+msgid "Engine model type"
+msgstr "引擎模型类型"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:21
+msgid "English"
+msgstr "英文"
 
 #: apps/models_provider/impl/xinference_model_provider/credential/tts.py:24
 msgid "English female"
@@ -4885,231 +2812,641 @@ msgstr "英文女"
 msgid "English male"
 msgstr "英文男"
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:26
-msgid "Korean female"
-msgstr "韩语女"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:17
+msgid "English telephone universal"
+msgstr "英文电话通用"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:37
-msgid ""
-"Code Llama is a language model specifically designed for code generation."
-msgstr "Code Llama 是一个专门用于代码生成的语言模型。"
+#: apps/knowledge/serializers/document.py:1309
+msgid "enter"
+msgstr "回车"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:44
-msgid ""
-"\n"
-"Code Llama Instruct is a fine-tuned version of Code Llama's instructions, "
-"designed to perform specific tasks.\n"
-"        "
+#: apps/application/serializers/application_chat.py:290
+msgid "Enterprise WeChat"
+msgstr "企业微信应用"
+
+#: no source
+msgid "Enterprise WeChat customer service: "
+msgstr "企业微信客服: "
+
+#: apps/application/serializers/application_chat.py:294
+msgid "Enterprise WeChat Robot"
+msgstr "企业微信机器人"
+
+#: no source
+msgid "Enterprise WeChat user: "
+msgstr "企业微信用户: "
+
+#: apps/common/constants/permission_constants.py:378
+msgid "Enterprise WeiXin"
 msgstr ""
-"Code Llama Instruct 是 Code Llama 的指令微调版本，专为执行特定任务而设计。"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:53
-msgid ""
-"Code Llama Python is a language model specifically designed for Python code "
-"generation."
-msgstr "Code Llama Python 是一个专门用于 Python 代码生成的语言模型。"
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:31
+msgid "ERNIE-Bot is a large language model independently developed by Baidu. It covers massive Chinese data and has stronger capabilities in dialogue Q&A, content creation and generation."
+msgstr "ERNIE-Bot是百度自行研发的大语言模型，覆盖海量中文数据，具有更强的对话问答、内容创作生成等能力。"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:60
-msgid ""
-"CodeQwen 1.5 is a language model for code generation with high performance."
-msgstr "CodeQwen 1.5 是一个用于代码生成的语言模型，具有较高的性能。"
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:28
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:59
+msgid "ERNIE-Bot-4 is a large language model independently developed by Baidu. It covers massive Chinese data and has stronger capabilities in dialogue Q&A, content creation and generation."
+msgstr "ERNIE-Bot-4是百度自行研发的大语言模型，覆盖海量中文数据，具有更强的对话问答、内容创作生成等能力。"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:67
-msgid "CodeQwen 1.5 Chat is a chat model version of CodeQwen 1.5."
-msgstr "CodeQwen 1.5 Chat 是一个聊天模型版本的 CodeQwen 1.5。"
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:34
+msgid "ERNIE-Bot-turbo is a large language model independently developed by Baidu. It covers massive Chinese data, has stronger capabilities in dialogue Q&A, content creation and generation, and has a faster response speed."
+msgstr "ERNIE-Bot-turbo是百度自行研发的大语言模型，覆盖海量中文数据，具有更强的对话问答、内容创作生成等能力，响应速度更快。"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:74
-msgid "Deepseek is a large-scale language model with 13 billion parameters."
-msgstr "Deepseek Chat 是一个聊天模型版本的 Deepseek。"
+#: apps/common/result/api.py:18
+#: apps/common/result/api.py:19
+#: apps/common/result/api.py:28
+#: apps/common/result/api.py:29
+msgid "error prompt"
+msgstr "错误提示"
 
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:16
-msgid ""
-"Image size, only cogview-3-plus supports this parameter. Optional range: "
-"[1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440], the "
-"default is 1024x1024."
+#: apps/trigger/serializers/trigger.py:418
+#: apps/trigger/serializers/trigger.py:442
+msgid "Error source type"
 msgstr ""
-"图片尺寸，仅 cogview-3-plus 支持该参数。可选范围："
-"[1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440]，默认是"
-"1024x1024。"
 
-#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:34
-msgid ""
-"Have strong multi-modal understanding capabilities. Able to understand up to "
-"five images simultaneously and supports video content understanding"
-msgstr "具有强大的多模态理解能力。能够同时理解多达五张图像，并支持视频内容理解"
+#: apps/trigger/serializers/trigger.py:117
+msgid "Error trigger type"
+msgstr "触发器类型错误"
+
+#: apps/trigger/handler/impl/trigger/event_trigger.py:80
+#: apps/trigger/handler/impl/trigger/event_trigger.py:81
+#: apps/trigger/handler/impl/trigger/event_trigger.py:82
+msgid "Event Trigger WebHook"
+msgstr ""
+
+#: apps/models_provider/views/provide.py:57
+#: apps/models_provider/views/provide.py:58
+#: apps/models_provider/views/provide.py:59
+msgid "Example of obtaining model list"
+msgstr "获取模型列表示例"
+
+#: apps/application/flow/step_node/loop_node/impl/base_loop_node.py:150
+msgid "Exceeding the maximum number of cycles"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:33
+msgid "Expiration time"
+msgstr ""
+
+#: no source
+msgid "expired"
+msgstr "过期时间"
+
+#: apps/common/constants/permission_constants.py:362
+msgid "Export"
+msgstr "导出"
+
+#: apps/application/views/application.py:142
+#: apps/application/views/application.py:143
+#: apps/application/views/application.py:144
+msgid "Export application"
+msgstr "导出智能体"
+
+#: no source
+msgid "Export Application"
+msgstr "导出智能体"
+
+#: apps/application/views/application_chat.py:95
+#: apps/application/views/application_chat.py:96
+#: apps/application/views/application_chat.py:97
+msgid "Export conversation"
+msgstr "导出对话"
+
+#: apps/knowledge/views/document.py:886
+#: apps/knowledge/views/document.py:887
+msgid "Export document"
+msgstr "导出文档"
+
+#: apps/knowledge/views/knowledge.py:363
+#: apps/knowledge/views/knowledge.py:364
+msgid "Export knowledge base"
+msgstr "导出知识库"
+
+#: apps/knowledge/views/knowledge.py:390
+#: apps/knowledge/views/knowledge.py:391
+msgid "Export knowledge base containing images"
+msgstr "导出包含图片的知识库"
+
+#: apps/knowledge/views/knowledge.py:417
+#: apps/knowledge/views/knowledge.py:418
+msgid "Export knowledge bundle"
+msgstr "导出知识库"
+
+#: apps/knowledge/views/knowledge_workflow.py:292
+#: apps/knowledge/views/knowledge_workflow.py:293
+#: apps/knowledge/views/knowledge_workflow.py:294
+msgid "Export knowledge workflow"
+msgstr "导出知识工作流"
+
+#: no source
+msgid "Export operate log"
+msgstr "导出操作日志"
+
+#: no source
+msgid "Export shared document"
+msgstr "导出共享文档"
+
+#: no source
+msgid "Export shared knowledge base"
+msgstr "导出共享知识库"
+
+#: no source
+msgid "Export shared knowledge base containing images"
+msgstr "导出包含图片的共享知识库"
+
+#: no source
+msgid "Export shared knowledge bundle"
+msgstr "导出共享知识库"
+
+#: no source
+msgid "Export shared tool"
+msgstr "导出共享工具"
+
+#: no source
+msgid "Export system knowledge"
+msgstr "导出知识库"
+
+#: no source
+msgid "Export system knowledge base"
+msgstr "导出系统知识库"
+
+#: no source
+msgid "Export system knowledge base containing images"
+msgstr "导出包含图片的系统知识库"
+
+#: no source
+msgid "Export system knowledge bundle"
+msgstr "导出系统知识库"
+
+#: no source
+msgid "Export system tool"
+msgstr "导出工具"
+
+#: apps/tools/views/tool.py:374
+#: apps/tools/views/tool.py:375
+#: apps/tools/views/tool.py:376
+msgid "Export tool"
+msgstr "导出工具"
+
+#: apps/knowledge/views/document.py:919
+#: apps/knowledge/views/document.py:920
+msgid "Export Zip document"
+msgstr "导出 Zip 文档"
+
+#: no source
+msgid "Export Zip shared document"
+msgstr "导出共享文档 Zip"
+
+#: no source
+msgid "Export Zip system knowledge"
+msgstr "导出Zip知识库"
+
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:31
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:64
+msgid "Facebook’s 125M parameter model"
+msgstr "Facebook的125M参数模型"
+
+#: no source
+msgid "Fail"
+msgstr "失败"
+
+#: apps/homepage/api/home_page_api.py:312
+msgid "Failed document count"
+msgstr "失败文档数量"
+
+#: apps/users/views/user.py:402
+msgid "Failed to change password"
+msgstr "修改密码失败"
+
+#: apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py:65
+#: apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py:59
+msgid "Failed to generate video"
+msgstr "生成视频失败"
+
+#: no source
+msgid "Failed to get Lark collaborators"
+msgstr "获取飞书协作者失败"
+
+#: no source
+msgid "Failed to get lark document list!"
+msgstr "获取飞书文档列表失败！"
+
+#: no source
+msgid "Failed to get Lark user details"
+msgstr "获取飞书用户详情失败"
+
+#: no source
+msgid "Failed to get WeCom access token"
+msgstr "获取企业微信访问令牌失败"
+
+#: no source
+msgid "Failed to get WeCom agent info"
+msgstr "获取企业微信代理信息失败"
+
+#: no source
+msgid "Failed to get WeCom department users"
+msgstr "获取企业微信部门用户失败"
+
+#: no source
+msgid "Failed to get WeCom user info"
+msgstr "获取企业微信用户信息失败"
+
+#: apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py:92
+msgid "Failed to obtain the image"
+msgstr "获取图片失败"
+
+#: no source
+msgid "Failed to obtain user information"
+msgstr "获取用户信息失败"
+
+#: apps/knowledge/task/embedding.py:28
+#: apps/knowledge/task/embedding.py:85
+msgid "Failed to obtain vector model: {error} {traceback}"
+msgstr "向量模型获取失败: {error} {traceback}"
+
+#: apps/oss/serializers/file.py:202
+msgid "Failed to resolve host: {error}"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:358
+#: apps/knowledge/serializers/knowledge.py:387
+msgid "Failed to send the vectorization task, please try again later!"
+msgstr "发送向量化任务失败，请稍后再试！"
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:80
+msgid "Faster, more affordable TTS model"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:216
+msgid "Feedback reason"
+msgstr "反馈理由"
+
+#: apps/common/constants/permission_constants.py:379
+msgid "Feishu"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:601
+msgid "field has no value set"
+msgstr "字段未设置值"
+
+#: apps/tools/serializers/tool.py:273
+msgid "field label"
+msgstr "标签"
+
+#: no source
+msgid "Field mapping cannot be empty"
+msgstr "字段映射不能为空"
+
+#: apps/tools/serializers/tool.py:272
+msgid "field name"
+msgstr "字段名称"
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:56
+msgid "Field: {name} No value set"
+msgstr "字段：{name} 未设置值"
+
+#: apps/tools/serializers/tool.py:613
+msgid "Field: {name} Type: {type} Value: {value} Type conversion error"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:98
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:74
+msgid "Field: {name} Type: {_type} is required"
+msgstr ""
+
+#: no source
+msgid "Field: {name} Type: {_type} Value: {value} Type conversion error"
+msgstr "字段：{name} 类型：{_type} 值：{value} 类型转换错误"
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:81
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:112
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:57
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:88
+#: apps/trigger/handler/impl/trigger/event_trigger.py:48
+msgid "Field: {name} Type: {_type} Value: {value} Type error"
+msgstr "字段：{name} 类型：{_type} 值：{value} 类型转换错误"
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:76
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:52
+#: apps/trigger/handler/impl/trigger/event_trigger.py:43
+msgid "Field: {name} Type: {_type} Value: {value} Unsupported this type"
+msgstr "字段：{name} 类型：{_type} 值：{value} 不支持该类型"
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:21
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:22
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:21
+msgid "Fields"
+msgstr "字段"
+
+#: apps/tools/serializers/tool.py:255
+msgid "fields only support string|int|dict|array|float"
+msgstr "字段仅支持字符串|整数|字典|数组|浮点数"
+
+#: apps/application/serializers/application.py:581
+#: apps/application/serializers/application.py:976
+#: apps/knowledge/serializers/document.py:216
+#: apps/knowledge/serializers/document.py:222
+#: apps/knowledge/serializers/document.py:1881
+#: apps/knowledge/serializers/knowledge.py:116
+#: apps/knowledge/serializers/knowledge_workflow.py:93
+#: apps/oss/serializers/file.py:69
+#: apps/tools/serializers/tool.py:908
+#: apps/tools/serializers/tool.py:1529
+#: apps/tools/serializers/tool_workflow.py:124
+msgid "file"
+msgstr "文件"
+
+#: apps/oss/views/file.py:23
+#: apps/oss/views/file.py:44
+#: apps/oss/views/file.py:64
+msgid "File"
+msgstr "文件"
+
+#: apps/application/serializers/application.py:1748
+msgid "File clean time"
+msgstr ""
+
+#: apps/application/serializers/application.py:1756
+msgid "File clean time cannot exceed clean time"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:138
+msgid "file count limit"
+msgstr "文件数量限制"
+
+#: apps/knowledge/serializers/document.py:197
+#: apps/knowledge/serializers/document.py:216
+#: apps/knowledge/serializers/document.py:222
+msgid "file list"
+msgstr "文件 列表"
+
+#: apps/knowledge/serializers/document.py:764
+msgid "File not exist. Only manually uploaded documents are supported"
+msgstr "文件不存在, 仅支持手动上传的文档"
+
+#: apps/oss/serializers/file.py:109
+msgid "File not found"
+msgstr "文件未找到"
+
+#: apps/oss/serializers/file.py:250
+msgid "File size exceeds limit"
+msgstr "文件大小超出限制"
+
+#: apps/knowledge/serializers/knowledge.py:137
+msgid "file size limit"
+msgstr "文件大小限制"
+
+#: apps/oss/serializers/file.py:224
+msgid "File upload is not enabled"
+msgstr "文件上传未启用"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:28
+msgid "Filipino language"
+msgstr "菲律宾语"
+
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:35
+msgid "First frame url"
+msgstr ""
+
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:53
+msgid "First frame url cannot be empty"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:58
+msgid "flat illustration"
+msgstr "扁平插画"
+
+#: no source
+msgid "float icon"
+msgstr "浮动图标"
+
+#: no source
+msgid "float icon url"
+msgstr "浮动图标地址"
+
+#: no source
+msgid "Float location field type error"
+msgstr "浮动位置字段类型错误"
+
+#: no source
+msgid "float location type"
+msgstr "浮动位置类型"
+
+#: no source
+msgid "float location value"
+msgstr "浮动位置值"
+
+#: no source
+msgid "float location x"
+msgstr "浮动位置 X"
+
+#: no source
+msgid "float location y"
+msgstr "浮动位置 Y"
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:37
-msgid ""
-"Focus on single picture understanding. Suitable for scenarios requiring "
-"efficient image analysis"
+msgid "Focus on single picture understanding. Suitable for scenarios requiring efficient image analysis"
 msgstr "专注于单图理解。适用于需要高效图像解析的场景"
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:40
-msgid ""
-"Focus on single picture understanding. Suitable for scenarios requiring "
-"efficient image analysis (free)"
+msgid "Focus on single picture understanding. Suitable for scenarios requiring efficient image analysis (free)"
 msgstr "专注于单图理解。适用于需要高效图像解析的场景(免费)"
 
-#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:46
-msgid ""
-"Quickly and accurately generate images based on user text descriptions. "
-"Resolution supports 1024x1024"
-msgstr "根据用户文字描述快速、精准生成图像。分辨率支持1024x1024"
+#: apps/common/constants/permission_constants.py:443
+#: apps/common/constants/permission_constants.py:444
+#: apps/common/constants/permission_constants.py:445
+#: apps/folders/views/folder.py:38
+#: apps/folders/views/folder.py:72
+#: apps/folders/views/folder.py:99
+#: apps/folders/views/folder.py:131
+#: apps/folders/views/folder.py:151
+msgid "Folder"
+msgstr "文件夹"
+
+#: no source
+msgid "folder"
+msgstr "文件夹"
+
+#: apps/folders/serializers/folder.py:98
+msgid "Folder depth cannot exceed 10000 levels"
+msgstr ""
+
+#: no source
+msgid "Folder depth cannot exceed 5 levels"
+msgstr "文件夹深度不能超过5级"
+
+#: apps/folders/models/folder.py:8
+#: apps/folders/models/folder.py:19
+#: apps/folders/serializers/folder.py:128
+msgid "folder description"
+msgstr "文件夹描述"
+
+#: apps/folders/serializers/folder.py:188
+#: apps/folders/serializers/folder.py:245
+msgid "Folder does not exist"
+msgstr "文件夹不存在"
+
+#: apps/application/api/application_api.py:68
+#: apps/application/serializers/application.py:302
+#: apps/application/serializers/application.py:347
+#: apps/application/serializers/application.py:447
+#: apps/folders/serializers/folder.py:126
+#: apps/folders/serializers/folder.py:176
+#: apps/knowledge/serializers/common.py:66
+#: apps/knowledge/serializers/knowledge.py:110
+#: apps/knowledge/serializers/knowledge.py:121
+#: apps/knowledge/serializers/knowledge.py:176
+#: apps/knowledge/serializers/knowledge.py:885
+#: apps/tools/serializers/tool.py:319
+#: apps/tools/serializers/tool.py:342
+#: apps/tools/serializers/tool.py:911
+#: apps/tools/serializers/tool.py:1687
+msgid "folder id"
+msgstr "文件夹 ID"
+
+#: apps/application/serializers/application.py:582
+msgid "Folder ID"
+msgstr ""
+
+#: apps/folders/models/folder.py:6
+#: apps/folders/models/folder.py:17
+#: apps/folders/serializers/folder.py:127
+msgid "folder name"
+msgstr "文件夹名称"
+
+#: apps/folders/serializers/folder.py:153
+#: apps/folders/serializers/folder.py:201
+#: apps/folders/serializers/folder.py:222
+msgid "Folder name already exists"
+msgstr "文件夹名称已存在"
+
+#: apps/knowledge/serializers/knowledge.py:261
+#: apps/knowledge/serializers/knowledge.py:292
+#: apps/tools/serializers/tool.py:1703
+msgid "Folder not found"
+msgstr "文件夹不存在"
+
+#: no source
+msgid "Folder token"
+msgstr "文件夹 Token"
+
+#: no source
+msgid "folder token"
+msgstr "文件夹令牌"
+
+#: apps/folders/serializers/folder.py:129
+msgid "folder user id"
+msgstr "文件夹用户 ID"
+
+#: apps/application/flow/step_node/form_node/i_form_node.py:20
+msgid "Form Configuration"
+msgstr "表单配置"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:27
+#: apps/application/flow/step_node/form_node/i_form_node.py:22
+msgid "Form Data"
+msgstr "表单数据"
+
+#: apps/application/flow/step_node/form_node/i_form_node.py:21
+msgid "Form output content"
+msgstr "表单输出内容"
+
+#: no source
+msgid "forum url"
+msgstr "论坛网址"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:35
+msgid "French"
+msgstr "法语"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:46
+msgid "function"
+msgstr "工具内容"
+
+#: apps/tools/serializers/tool.py:336
+msgid "function content"
+msgstr "工具内容"
+
+#: apps/tools/serializers/tool.py:1169
+msgid "Function does not exist"
+msgstr "工具不存在"
+
+#: apps/tools/serializers/tool.py:1150
+msgid "function ID"
+msgstr "工具 ID"
+
+#: no source
+msgid "Function {name} is unavailable"
+msgstr "工具 {name} 不可用"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:302
+msgid "function_name"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:41
+msgid "Game cartoon hand drawing"
+msgstr "游戏卡通手绘"
+
+#: apps/common/constants/permission_constants.py:364
+msgid "Generate"
+msgstr "生成问题"
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:49
-msgid ""
-"Generate high-quality images based on user text descriptions, supporting "
-"multiple image sizes"
+msgid "Generate high-quality images based on user text descriptions, supporting multiple image sizes"
 msgstr "根据用户文字描述生成高质量图像，支持多图片尺寸"
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:52
-msgid ""
-"Generate high-quality images based on user text descriptions, supporting "
-"multiple image sizes (free)"
+msgid "Generate high-quality images based on user text descriptions, supporting multiple image sizes (free)"
 msgstr "根据用户文字描述生成高质量图像，支持多图片尺寸(免费)"
 
-#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:75
-msgid "zhipu AI"
-msgstr "智谱 AI"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:49
+msgid "Generate image resolution"
+msgstr "生成图像分辨率"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:32
-#: apps/models_provider/serializers/model_apply_serializers.py:37
-msgid "vector text"
-msgstr "向量文本"
+#: apps/knowledge/task/generate.py:103
+msgid "Generate issue based on document: {document_id} error {error}{traceback}"
+msgstr "生成问题基于文档: {document_id} 错误 {error}{traceback}"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:33
-msgid "vector text list"
-msgstr "向量文本列表"
+#: apps/application/views/application_chat.py:162
+#: apps/application/views/application_chat.py:163
+#: apps/application/views/application_chat.py:164
+msgid "generate prompt"
+msgstr "生成提示词"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:41
-msgid "text"
-msgstr "文本"
+#: apps/knowledge/views/knowledge.py:482
+#: apps/knowledge/views/knowledge.py:483
+#: apps/knowledge/views/knowledge.py:484
+msgid "Generate related"
+msgstr "生成相关"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:42
-msgid "metadata"
-msgstr "元数据"
+#: no source
+msgid "Generate related documents"
+msgstr "生成相关文档"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:47
-msgid "query"
-msgstr "查询"
+#: apps/application/views/application_chat_link.py:24
+#: apps/application/views/application_chat_link.py:25
+#: apps/application/views/application_chat_link.py:26
+msgid "Generate share link"
+msgstr "生成分享链接"
 
-#: apps/models_provider/serializers/model_serializer.py:44
-#: apps/models_provider/serializers/model_serializer.py:257
-msgid "parameter configuration"
-msgstr "参数配置"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:36
+msgid "German"
+msgstr "德语"
 
-#: apps/models_provider/serializers/model_serializer.py:45
-#: apps/models_provider/serializers/model_serializer.py:222
-#: apps/models_provider/serializers/model_serializer.py:258
-msgid "certification information"
-msgstr "认证信息"
+#: apps/knowledge/views/problem.py:79
+#: apps/knowledge/views/problem.py:80
+#: apps/knowledge/views/problem.py:81
+msgid "Get a list of associated paragraphs"
+msgstr "获取关联段落列表"
 
-#: apps/models_provider/serializers/model_serializer.py:118
-msgid "Shared models cannot be deleted or modified"
-msgstr "共享模型不能被删除或修改"
+#: no source
+msgid "Get a list of associated shared paragraphs"
+msgstr "获取关联段落列表"
 
-#: apps/models_provider/serializers/model_serializer.py:230
-#: apps/models_provider/serializers/model_serializer.py:269
-#, python-brace-format
-msgid "base model【{model_name}】already exists"
-msgstr "模型【{model_name}】已存在"
-
-#: apps/models_provider/serializers/model_serializer.py:309
-msgid "Model saving failed"
-msgstr "模型保存失败"
-
-#: apps/models_provider/views/model.py:60
-#: apps/models_provider/views/model.py:61
-#: apps/models_provider/views/model.py:62 apps/shared/views/shared_model.py:55
-#: apps/shared/views/shared_model.py:56 apps/shared/views/shared_model.py:57
-msgid "Create model"
-msgstr "创建模型"
-
-#: apps/models_provider/views/model.py:90
-#: apps/models_provider/views/model.py:91
-#: apps/models_provider/views/model.py:92 apps/shared/views/shared_model.py:84
-#: apps/shared/views/shared_model.py:85 apps/shared/views/shared_model.py:86
-msgid "Query model list"
-msgstr "查询模型列表"
-
-#: apps/models_provider/views/model.py:107
-#: apps/models_provider/views/model.py:108
-#: apps/models_provider/views/model.py:109
-#: apps/shared/views/shared_model.py:101 apps/shared/views/shared_model.py:102
-#: apps/shared/views/shared_model.py:103
-msgid "Update model"
-msgstr "更新模型"
-
-#: apps/models_provider/views/model.py:125
-#: apps/models_provider/views/model.py:126
-#: apps/models_provider/views/model.py:127
-#: apps/shared/views/shared_model.py:119 apps/shared/views/shared_model.py:120
-#: apps/shared/views/shared_model.py:121
-msgid "Delete model"
-msgstr "删除模型"
-
-#: apps/models_provider/views/model.py:140
-#: apps/models_provider/views/model.py:141
-#: apps/models_provider/views/model.py:142
-#: apps/shared/views/shared_model.py:133 apps/shared/views/shared_model.py:134
-#: apps/shared/views/shared_model.py:135
-msgid "Query model details"
-msgstr "查询模型详情"
-
-#: apps/models_provider/views/model.py:155
-#: apps/models_provider/views/model.py:156
-#: apps/models_provider/views/model.py:157
-#: apps/shared/views/shared_model.py:148 apps/shared/views/shared_model.py:149
-#: apps/shared/views/shared_model.py:150
-msgid "Get model parameter form"
-msgstr "获取模型参数表单"
-
-#: apps/models_provider/views/model.py:167
-#: apps/models_provider/views/model.py:168
-#: apps/models_provider/views/model.py:169
-#: apps/shared/views/shared_model.py:160 apps/shared/views/shared_model.py:161
-#: apps/shared/views/shared_model.py:162
-msgid "Save model parameter form"
-msgstr "保存模型参数表单"
-
-#: apps/models_provider/views/model.py:187
-#: apps/models_provider/views/model.py:189
-#: apps/models_provider/views/model.py:191
-#: apps/shared/views/shared_model.py:179 apps/shared/views/shared_model.py:181
-#: apps/shared/views/shared_model.py:183
-msgid ""
-"Query model meta information, this interface does not carry authentication "
-"information"
-msgstr "查询模型元信息，该接口不携带认证信息"
-
-#: apps/models_provider/views/model.py:204
-#: apps/models_provider/views/model.py:205
-#: apps/models_provider/views/model.py:206
-#: apps/shared/views/shared_model.py:196 apps/shared/views/shared_model.py:197
-#: apps/shared/views/shared_model.py:198
-msgid "Pause model download"
-msgstr "下载模型暂停"
-
-#: apps/models_provider/views/model.py:222
-#: apps/models_provider/views/model.py:223
-#: apps/models_provider/views/model.py:224
-msgid "Get Share model"
-msgstr "获取共享模型"
-
-#: apps/models_provider/views/model_apply.py:25
-#: apps/models_provider/views/model_apply.py:26
-#: apps/models_provider/views/model_apply.py:27
-#: apps/models_provider/views/model_apply.py:37
-#: apps/models_provider/views/model_apply.py:38
-#: apps/models_provider/views/model_apply.py:39
-msgid "Vectorization documentation"
-msgstr "向量化文档"
-
-#: apps/models_provider/views/model_apply.py:49
-#: apps/models_provider/views/model_apply.py:50
-#: apps/models_provider/views/model_apply.py:51
-msgid "Reorder documents"
-msgstr "重新排序文档"
+#: no source
+msgid "Get a list of associated system paragraphs"
+msgstr "获取关联段落列表"
 
 #: apps/models_provider/views/provide.py:21
 #: apps/models_provider/views/provide.py:22
@@ -5123,1480 +3460,221 @@ msgstr "获取模型供应商列表"
 msgid "Get a list of model types"
 msgstr "获取模型类型列表"
 
-#: apps/models_provider/views/provide.py:57
-#: apps/models_provider/views/provide.py:58
-#: apps/models_provider/views/provide.py:59
-msgid "Example of obtaining model list"
-msgstr "获取模型列表示例"
-
-#: apps/models_provider/views/provide.py:75
-#: apps/models_provider/views/provide.py:76
-#: apps/models_provider/views/provide.py:77
-msgid "Get model default parameters"
-msgstr "获取模型默认参数"
-
-#: apps/models_provider/views/provide.py:92
-#: apps/models_provider/views/provide.py:93
-#: apps/models_provider/views/provide.py:94
-msgid "Get the model creation form"
-msgstr "获取模型创建表单"
-
-#: apps/oss/serializers/file.py:80
-msgid "File not found"
-msgstr "文件未找到"
-
-#: apps/oss/views/file.py:21 apps/oss/views/file.py:22
-#: apps/oss/views/file.py:23
-msgid "Upload file"
-msgstr "上传文件"
-
-#: apps/oss/views/file.py:27 apps/oss/views/file.py:41
-#: apps/oss/views/file.py:53
-msgid "File"
-msgstr "文件"
-
-#: apps/oss/views/file.py:36 apps/oss/views/file.py:37
-#: apps/oss/views/file.py:38
-msgid "Get file"
-msgstr "获取文件"
-
-#: apps/oss/views/file.py:48 apps/oss/views/file.py:49
-#: apps/oss/views/file.py:50
-msgid "Delete file"
-msgstr "删除文件"
-
-#: apps/resource_manage/views/document.py:30
-#: apps/resource_manage/views/document.py:31
-#: apps/resource_manage/views/document.py:32
-msgid "Create system knowledge"
-msgstr "创建系统知识库"
-
-#: apps/resource_manage/views/document.py:36
-#: apps/resource_manage/views/document.py:56
-#: apps/resource_manage/views/document.py:83
-#: apps/resource_manage/views/document.py:113
-#: apps/resource_manage/views/document.py:130
-#: apps/resource_manage/views/document.py:155
-#: apps/resource_manage/views/document.py:183
-#: apps/resource_manage/views/document.py:210
-#: apps/resource_manage/views/document.py:237
-#: apps/resource_manage/views/document.py:267
-#: apps/resource_manage/views/document.py:296
-#: apps/resource_manage/views/document.py:317
-#: apps/resource_manage/views/document.py:345
-#: apps/resource_manage/views/document.py:362
-#: apps/resource_manage/views/document.py:383
-#: apps/resource_manage/views/document.py:411
-#: apps/resource_manage/views/document.py:435
-#: apps/resource_manage/views/document.py:460
-#: apps/resource_manage/views/document.py:485
-#: apps/resource_manage/views/document.py:507
-#: apps/resource_manage/views/document.py:530
-#: apps/resource_manage/views/document.py:553
-#: apps/resource_manage/views/document.py:571
-#: apps/resource_manage/views/document.py:585
-msgid "System Knowledge/Documentation"
-msgstr "系统知识库/文档"
-
-#: apps/resource_manage/views/document.py:51
-#: apps/resource_manage/views/document.py:52
-#: apps/resource_manage/views/document.py:53
-msgid "Get system document"
-msgstr "获取文档"
-
-#: apps/resource_manage/views/document.py:77
-#: apps/resource_manage/views/document.py:78
-#: apps/resource_manage/views/document.py:79
-msgid "Segmented system document"
-msgstr "分段文档"
-
-#: apps/resource_manage/views/document.py:108
-#: apps/resource_manage/views/document.py:109
-#: apps/resource_manage/views/document.py:110
-msgid "Get a list of system segment IDs"
-msgstr "获取分段ID列表"
-
-#: apps/resource_manage/views/document.py:124
-#: apps/resource_manage/views/document.py:125
-#: apps/resource_manage/views/document.py:126
-msgid "Cancel system tasks in batches"
-msgstr "批量取消任务"
-
-#: apps/resource_manage/views/document.py:149
-#: apps/resource_manage/views/document.py:150
-#: apps/resource_manage/views/document.py:151
-msgid "Create system knowledges in batches"
-msgstr "批量创建知识库"
-
-#: apps/resource_manage/views/document.py:177
-#: apps/resource_manage/views/document.py:178
-#: apps/resource_manage/views/document.py:179
-msgid "Batch sync system knowledges"
-msgstr "批量同步知识库"
-
-#: apps/resource_manage/views/document.py:204
-#: apps/resource_manage/views/document.py:206
-msgid "Delete system document in batches"
-msgstr "批量删除文档"
-
-#: apps/resource_manage/views/document.py:205
-msgid "Delete system knowledge in batches"
-msgstr "批量删除知识库"
-
-#: apps/resource_manage/views/document.py:232
-#: apps/resource_manage/views/document.py:233
-msgid "Batch refresh system document vector library"
-msgstr "批量刷新文档向量库"
-
-#: apps/resource_manage/views/document.py:261
-#: apps/resource_manage/views/document.py:262
-#: apps/resource_manage/views/document.py:263
-msgid "Batch generate related system problems"
-msgstr "批量生成相关问题"
-
-#: apps/resource_manage/views/document.py:290
-#: apps/resource_manage/views/document.py:291
-#: apps/resource_manage/views/document.py:292
-msgid "Modify system document hit processing methods in batches"
-msgstr "批量修改文档命中处理方式"
-
-#: apps/resource_manage/views/document.py:312
-#: apps/resource_manage/views/document.py:313
-msgid "Migrate system knowledges in batches"
-msgstr "批量迁移知识库"
-
-#: apps/resource_manage/views/document.py:340
-#: apps/resource_manage/views/document.py:341
-#: apps/resource_manage/views/document.py:342
-msgid "Get system document details"
-msgstr "获取文档详情"
-
-#: apps/resource_manage/views/document.py:356
-#: apps/resource_manage/views/document.py:357
-#: apps/resource_manage/views/document.py:358
-msgid "Modify system document"
-msgstr "修改文档"
-
-#: apps/resource_manage/views/document.py:378
-#: apps/resource_manage/views/document.py:379
-#: apps/resource_manage/views/document.py:380
-msgid "Delete system document"
-msgstr "删除文档"
-
-#: apps/resource_manage/views/document.py:405
-#: apps/resource_manage/views/document.py:406
-#: apps/resource_manage/views/document.py:407
-msgid "Synchronize system web site types"
-msgstr "同步网站类型"
-
-#: apps/resource_manage/views/document.py:429
-#: apps/resource_manage/views/document.py:430
-#: apps/resource_manage/views/document.py:431
-msgid "Refresh system knowledge vector library"
-msgstr "刷新文档向量库"
-
-#: apps/resource_manage/views/document.py:454
-#: apps/resource_manage/views/document.py:455
-#: apps/resource_manage/views/document.py:456
-msgid "Cancel system task"
-msgstr "取消任务"
-
-#: apps/resource_manage/views/document.py:480
-#: apps/resource_manage/views/document.py:481
-#: apps/resource_manage/views/document.py:482
-msgid "Get system document by pagination"
-msgstr "分页获取文档"
-
-#: apps/resource_manage/views/document.py:503
-#: apps/resource_manage/views/document.py:504
-msgid "Export system knowledge"
-msgstr "导出知识库"
-
-#: apps/resource_manage/views/document.py:526
-#: apps/resource_manage/views/document.py:527
-msgid "Export Zip system knowledge"
-msgstr "导出Zip知识库"
-
-#: apps/resource_manage/views/document.py:549
-#: apps/resource_manage/views/document.py:550
-msgid "Download system source file"
-msgstr "下载系统源文件"
-
-#: apps/resource_manage/views/document.py:567
-#: apps/resource_manage/views/document.py:568
-msgid "Get system QA template"
-msgstr "获取系统问答模板"
-
-#: apps/resource_manage/views/document.py:581
-#: apps/resource_manage/views/document.py:582
-msgid "Get system form template"
-msgstr "获取系统表单模板"
-
-#: apps/resource_manage/views/knowledge.py:26
-#: apps/resource_manage/views/knowledge.py:27
-#: apps/resource_manage/views/knowledge.py:28
-msgid "Get system knowledge list"
-msgstr "获取系统知识库列表"
-
-#: apps/resource_manage/views/knowledge.py:31
-#: apps/resource_manage/views/knowledge.py:50
-#: apps/resource_manage/views/knowledge.py:72
-#: apps/resource_manage/views/knowledge.py:87
-#: apps/resource_manage/views/knowledge.py:102
-#: apps/resource_manage/views/knowledge.py:121
-#: apps/resource_manage/views/knowledge.py:147
-#: apps/resource_manage/views/knowledge.py:174
-#: apps/resource_manage/views/knowledge.py:192
-#: apps/resource_manage/views/knowledge.py:210
-#: apps/resource_manage/views/knowledge.py:231
-#: apps/resource_manage/views/knowledge.py:252
-#: apps/resource_manage/views/knowledge.py:272
-msgid "System Knowledge"
-msgstr "系统知识库"
-
-#: apps/resource_manage/views/knowledge.py:45
-#: apps/resource_manage/views/knowledge.py:46
-#: apps/resource_manage/views/knowledge.py:47
-msgid "Get system knowledge list by pagination"
-msgstr "获取系统知识库分页列表"
-
-#: apps/resource_manage/views/knowledge.py:66
-#: apps/resource_manage/views/knowledge.py:67
-#: apps/resource_manage/views/knowledge.py:68
-msgid "Update system knowledge"
-msgstr "更新系统知识库"
-
-#: apps/resource_manage/views/knowledge.py:82
-#: apps/resource_manage/views/knowledge.py:83
-#: apps/resource_manage/views/knowledge.py:84
-msgid "Get system knowledge"
-msgstr "获取知识库"
-
-#: apps/resource_manage/views/knowledge.py:97
-#: apps/resource_manage/views/knowledge.py:98
-#: apps/resource_manage/views/knowledge.py:99
-msgid "Delete system knowledge"
-msgstr "删除知识库"
-
-#: apps/resource_manage/views/knowledge.py:115
-#: apps/resource_manage/views/knowledge.py:116
-#: apps/resource_manage/views/knowledge.py:117
-msgid "Synchronize the system knowledge base of the website"
-msgstr "同步网站知识库"
-
-#: apps/resource_manage/views/knowledge.py:141
-#: apps/resource_manage/views/knowledge.py:142
-#: apps/resource_manage/views/knowledge.py:143
-msgid "System Hit test list"
-msgstr "命中测试列表"
-
-#: apps/resource_manage/views/knowledge.py:168
-#: apps/resource_manage/views/knowledge.py:169
-#: apps/resource_manage/views/knowledge.py:170
-msgid "System Re-vectorize"
-msgstr "重新向量化"
-
-#: apps/resource_manage/views/knowledge.py:188
-#: apps/resource_manage/views/knowledge.py:189
-msgid "Export system knowledge base"
-msgstr "导出系统知识库"
-
-#: apps/resource_manage/views/knowledge.py:206
-#: apps/resource_manage/views/knowledge.py:207
-msgid "Export system knowledge base containing images"
-msgstr "导出包含图片的系统知识库"
-
-#: apps/resource_manage/views/knowledge.py:225
-#: apps/resource_manage/views/knowledge.py:226
-#: apps/resource_manage/views/knowledge.py:227
-msgid "System generate related"
-msgstr "生成相关"
-
-#: apps/resource_manage/views/knowledge.py:247
-#: apps/resource_manage/views/knowledge.py:248
-#: apps/resource_manage/views/knowledge.py:249
-msgid "Get model for system knowledge base"
-msgstr "获取系统知识库模型"
-
-#: apps/resource_manage/views/knowledge.py:267
-#: apps/resource_manage/views/knowledge.py:268
-#: apps/resource_manage/views/knowledge.py:269
-msgid "Get embedding model for system knowledge base"
-msgstr "获取系统知识库嵌入模型"
-
-#: apps/resource_manage/views/paragraph.py:24
-#: apps/resource_manage/views/paragraph.py:25
-#: apps/resource_manage/views/paragraph.py:26
-msgid "System paragraph list"
-msgstr "段落列表"
-
-#: apps/resource_manage/views/paragraph.py:29
-#: apps/resource_manage/views/paragraph.py:50
-#: apps/resource_manage/views/paragraph.py:76
-#: apps/resource_manage/views/paragraph.py:93
-#: apps/resource_manage/views/paragraph.py:125
-#: apps/resource_manage/views/paragraph.py:151
-#: apps/resource_manage/views/paragraph.py:179
-#: apps/resource_manage/views/paragraph.py:201
-#: apps/resource_manage/views/paragraph.py:233
-#: apps/resource_manage/views/paragraph.py:259
-#: apps/resource_manage/views/paragraph.py:283
-#: apps/resource_manage/views/paragraph.py:314
-#: apps/resource_manage/views/paragraph.py:344
-#: apps/resource_manage/views/paragraph.py:370
-msgid "System Knowledge/Documentation/Paragraph"
-msgstr "系统知识库/文档/段落"
-
-#: apps/resource_manage/views/paragraph.py:45
-#: apps/resource_manage/views/paragraph.py:46
-msgid "Create system paragraph"
-msgstr "创建段落"
-
-#: apps/resource_manage/views/paragraph.py:70
-#: apps/resource_manage/views/paragraph.py:71
-#: apps/resource_manage/views/paragraph.py:72
-msgid "Batch system paragraph"
-msgstr "批量关联段落"
-
-#: apps/resource_manage/views/paragraph.py:88
-#: apps/resource_manage/views/paragraph.py:89
-msgid "Migrate system paragraphs in batches"
-msgstr "批量迁移段落"
-
-#: apps/resource_manage/views/paragraph.py:119
-#: apps/resource_manage/views/paragraph.py:120
-#: apps/resource_manage/views/paragraph.py:121
-msgid "Batch generate system related"
-msgstr "批量生成相关"
-
-#: apps/resource_manage/views/paragraph.py:145
-#: apps/resource_manage/views/paragraph.py:146
-#: apps/resource_manage/views/paragraph.py:147
-msgid "Modify system paragraph data"
-msgstr "修改段落数据"
-
-#: apps/resource_manage/views/paragraph.py:174
-#: apps/resource_manage/views/paragraph.py:175
-#: apps/resource_manage/views/paragraph.py:176
-msgid "Get system paragraph details"
-msgstr "获取段落详情"
-
-#: apps/resource_manage/views/paragraph.py:196
-#: apps/resource_manage/views/paragraph.py:197
-#: apps/resource_manage/views/paragraph.py:198
-msgid "Delete system paragraph"
-msgstr "删除段落"
-
-#: apps/resource_manage/views/paragraph.py:227
-#: apps/resource_manage/views/paragraph.py:228
-#: apps/resource_manage/views/paragraph.py:229
-msgid "Add system associated questions"
-msgstr "添加关联问题"
-
-#: apps/resource_manage/views/paragraph.py:254
-#: apps/resource_manage/views/paragraph.py:255
-#: apps/resource_manage/views/paragraph.py:256
-msgid "Get a list of system paragraph questions"
+#: apps/knowledge/views/paragraph.py:310
+#: apps/knowledge/views/paragraph.py:311
+#: apps/knowledge/views/paragraph.py:312
+msgid "Get a list of paragraph questions"
 msgstr "获取段落问题列表"
 
-#: apps/resource_manage/views/paragraph.py:277
-#: apps/resource_manage/views/paragraph.py:278
-#: apps/resource_manage/views/paragraph.py:279
-msgid "Disassociation system issue"
-msgstr "取消关联问题"
-
-#: apps/resource_manage/views/paragraph.py:308
-#: apps/resource_manage/views/paragraph.py:309
-#: apps/resource_manage/views/paragraph.py:310
-msgid "Related system questions"
-msgstr "关联问题"
-
-#: apps/resource_manage/views/paragraph.py:339
-#: apps/resource_manage/views/paragraph.py:340
-#: apps/resource_manage/views/paragraph.py:341
-msgid "Get system paragraph list by pagination"
-msgstr "获取段落列表"
-
-#: apps/resource_manage/views/problem.py:23
-#: apps/resource_manage/views/problem.py:24
-#: apps/resource_manage/views/problem.py:25
-msgid "System question list"
-msgstr "问题列表"
-
-#: apps/resource_manage/views/problem.py:28
-#: apps/resource_manage/views/problem.py:50
-#: apps/resource_manage/views/problem.py:71
-#: apps/resource_manage/views/problem.py:94
-#: apps/resource_manage/views/problem.py:115
-#: apps/resource_manage/views/problem.py:135
-#: apps/resource_manage/views/problem.py:158
-#: apps/resource_manage/views/problem.py:182
-msgid "System Knowledge/Documentation/Paragraph/Question"
-msgstr "系统知识库/文档/段落/问题"
-
-#: apps/resource_manage/views/problem.py:44
-#: apps/resource_manage/views/problem.py:45
-#: apps/resource_manage/views/problem.py:46
-msgid "Create system question"
-msgstr "创建问题"
-
-#: apps/resource_manage/views/problem.py:66
-#: apps/resource_manage/views/problem.py:67
-#: apps/resource_manage/views/problem.py:68
-msgid "Get a list of associated system paragraphs"
-msgstr "获取关联段落列表"
-
-#: apps/resource_manage/views/problem.py:88
-#: apps/resource_manage/views/problem.py:89
-#: apps/resource_manage/views/problem.py:90
-msgid "Batch associated system paragraphs"
-msgstr "批量关联段落"
-
-#: apps/resource_manage/views/problem.py:109
-#: apps/resource_manage/views/problem.py:110
-#: apps/resource_manage/views/problem.py:111
-msgid "Batch deletion system issues"
-msgstr "批量删除问题"
-
-#: apps/resource_manage/views/problem.py:130
-#: apps/resource_manage/views/problem.py:131
-#: apps/resource_manage/views/problem.py:132
-msgid "Delete system question"
-msgstr "删除问题"
-
-#: apps/resource_manage/views/problem.py:152
-#: apps/resource_manage/views/problem.py:153
-#: apps/resource_manage/views/problem.py:154
-msgid "Modify system question"
-msgstr "修改问题"
-
-#: apps/resource_manage/views/problem.py:177
-#: apps/resource_manage/views/problem.py:178
-#: apps/resource_manage/views/problem.py:179
-msgid "Get the list of system questions by page"
-msgstr "分页获取问题列表"
-
-#: apps/resource_manage/views/tool.py:24 apps/resource_manage/views/tool.py:25
-#: apps/resource_manage/views/tool.py:26
-msgid "Get system tool"
-msgstr "获取工具"
-
-#: apps/resource_manage/views/tool.py:29 apps/resource_manage/views/tool.py:50
-#: apps/resource_manage/views/tool.py:65 apps/resource_manage/views/tool.py:80
-#: apps/resource_manage/views/tool.py:98 apps/resource_manage/views/tool.py:119
-#: apps/resource_manage/views/tool.py:137
-#: apps/resource_manage/views/tool.py:156
-#: apps/resource_manage/views/tool.py:179
-msgid "System Tool"
-msgstr "工具"
-
-#: apps/resource_manage/views/tool.py:44 apps/resource_manage/views/tool.py:45
-#: apps/resource_manage/views/tool.py:46
-msgid "Update system tool"
-msgstr "更新工具"
-
-#: apps/resource_manage/views/tool.py:60 apps/resource_manage/views/tool.py:61
-#: apps/resource_manage/views/tool.py:62
-msgid "Get system tool by id"
-msgstr "获取工具"
-
-#: apps/resource_manage/views/tool.py:75 apps/resource_manage/views/tool.py:76
-#: apps/resource_manage/views/tool.py:77
-msgid "Delete system tool"
-msgstr "删除工具"
-
-#: apps/resource_manage/views/tool.py:93 apps/resource_manage/views/tool.py:94
-#: apps/resource_manage/views/tool.py:95
-msgid "Get system tool list by pagination"
-msgstr "获取工具列表"
-
-#: apps/resource_manage/views/tool.py:114
-#: apps/resource_manage/views/tool.py:115
-#: apps/resource_manage/views/tool.py:116
-msgid "Export system tool"
-msgstr "导出工具"
-
-#: apps/resource_manage/views/tool.py:132
-#: apps/resource_manage/views/tool.py:133
-#: apps/resource_manage/views/tool.py:134
-msgid "Debug system tool"
-msgstr "调试工具"
-
-#: apps/resource_manage/views/tool.py:150
-#: apps/resource_manage/views/tool.py:151
-#: apps/resource_manage/views/tool.py:152
-msgid "Check system code"
-msgstr "检查代码"
-
-#: apps/resource_manage/views/tool.py:173
-#: apps/resource_manage/views/tool.py:174
-#: apps/resource_manage/views/tool.py:175
-msgid "Edit system tool icon"
-msgstr "修改工具图标"
-
-#: apps/role_setting/api/role_setting.py:16
-#: apps/role_setting/api/role_setting.py:22
-#: apps/role_setting/api/role_setting.py:33
-#: apps/role_setting/api/role_setting.py:143
-#: apps/role_setting/serializers/role_setting_serializers.py:193
-#: apps/workspace/api/workspace.py:81 apps/xpack/api/chat_user.py:104
-msgid "ID"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:17
-#: apps/role_setting/api/role_setting.py:23
-#: apps/role_setting/api/role_setting.py:34 apps/users/serializers/user.py:258
-#: apps/xpack/api/knowledge_lark.py:24 apps/xpack/serializers/chat_user.py:235
-msgid "Name"
-msgstr "用户名"
-
-#: apps/role_setting/api/role_setting.py:18
-#: apps/role_setting/api/role_setting.py:29
-#: apps/role_setting/serializers/role_setting_serializers.py:194
-msgid "Enable"
-msgstr "启用"
-
-#: apps/role_setting/api/role_setting.py:26
-msgid "Permission"
-msgstr "权限"
-
-#: apps/role_setting/api/role_setting.py:37
-msgid "Children"
-msgstr "子级"
-
-#: apps/role_setting/api/role_setting.py:55
-#: apps/role_setting/serializers/role_setting_serializers.py:107
-msgid "Role type"
-msgstr "角色类型"
-
-#: apps/role_setting/api/role_setting.py:76
-msgid "Internal role"
-msgstr "内置角色"
-
-#: apps/role_setting/api/role_setting.py:80
-msgid "Custom role"
-msgstr "自定义角色"
-
-#: apps/role_setting/api/role_setting.py:108
-#: apps/role_setting/api/role_setting.py:128
-#: apps/role_setting/api/role_setting.py:164
-#: apps/role_setting/serializers/role_setting_serializers.py:110
-#: apps/role_setting/serializers/role_setting_serializers.py:329
-#: apps/users/api/user.py:26 apps/workspace/api/workspace.py:86
-msgid "Role ID"
-msgstr "角色 ID"
-
-#: apps/role_setting/api/role_setting.py:135
-msgid "User relation ID"
-msgstr "用户关系 ID"
-
-#: apps/role_setting/api/role_setting.py:145
-#: apps/role_setting/api/role_setting.py:185
-#: apps/role_setting/serializers/role_setting_serializers.py:330
-#: apps/users/api/user.py:77 apps/users/serializers/login.py:27
-#: apps/users/serializers/user.py:56 apps/users/serializers/user.py:114
-#: apps/workspace/api/workspace.py:83 apps/workspace/api/workspace.py:124
-#: apps/workspace/serializers/workspace_serializers.py:240
-#: apps/xpack/api/auth_config.py:24 apps/xpack/api/chat_user.py:105
-#: apps/xpack/api/user_group.py:75 apps/xpack/serializers/chat_user.py:62
-#: apps/xpack/serializers/chat_user.py:564
-msgid "Username"
-msgstr "用户名"
-
-#: apps/role_setting/api/role_setting.py:146 apps/workspace/api/workspace.py:84
-#: apps/xpack/api/chat_user.py:106
-msgid "Nickname"
-msgstr "姓名"
-
-#: apps/role_setting/api/role_setting.py:148
-msgid "Workspace Name"
-msgstr "工作空间"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:104
-msgid "Role name"
-msgstr "角色名称"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:122
-#: apps/role_setting/serializers/role_setting_serializers.py:200
-#: apps/role_setting/serializers/role_setting_serializers.py:325
-#: apps/role_setting/serializers/role_setting_serializers.py:337
-msgid "Role does not exist"
-msgstr "角色不存在"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:124
-#: apps/role_setting/serializers/role_setting_serializers.py:202
-msgid "Cannot modify built-in role"
-msgstr "不能修改内置角色"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:132
-msgid "Role name already exists"
-msgstr "角色名称已存在"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:152
-msgid "Invalid role type"
-msgstr "无效的角色类型"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:204
-msgid "Cannot delete built-in role"
-msgstr "无法删除内置角色"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:262
-#: apps/users/api/user.py:135 apps/users/serializers/user.py:471
-#: apps/workspace/serializers/workspace_serializers.py:161
-#: apps/xpack/api/user_group.py:90 apps/xpack/serializers/chat_user.py:158
-#: apps/xpack/serializers/chat_user.py:172
-#: apps/xpack/serializers/chat_user.py:502
-msgid "User IDs"
-msgstr "用户 ID"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:267
-#: apps/users/api/user.py:30
-msgid "Workspace IDs"
-msgstr "工作空间 ID"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:272
-#: apps/workspace/serializers/workspace_serializers.py:172
-msgid "Members"
-msgstr "成员集合"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:312
-#: apps/workspace/serializers/workspace_serializers.py:223
-msgid "User relation does not exist"
-msgstr "用户关系不存在"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:316
-#: apps/workspace/serializers/workspace_serializers.py:226
-msgid "Cannot remove member from built-in role"
-msgstr "不能从内置角色中移除成员"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:370
-msgid "Only update members to normal users"
-msgstr "只能为普通用户更新成员"
-
-#: apps/role_setting/views/role_setting.py:39
-#: apps/role_setting/views/role_setting.py:40
-#: apps/role_setting/views/role_setting.py:41
-msgid "Get role permission template"
-msgstr "获取角色权限模板"
-
-#: apps/role_setting/views/role_setting.py:62
-#: apps/role_setting/views/role_setting.py:63
-#: apps/role_setting/views/role_setting.py:64
-msgid "Create or update role"
-msgstr "创建或更新角色"
-
-#: apps/role_setting/views/role_setting.py:80
-#: apps/role_setting/views/role_setting.py:81
-#: apps/role_setting/views/role_setting.py:82
-msgid "Get role list"
-msgstr "获取角色列表"
-
-#: apps/role_setting/views/role_setting.py:98
-#: apps/role_setting/views/role_setting.py:99
-#: apps/role_setting/views/role_setting.py:100
-msgid "Delete role"
-msgstr "删除角色"
-
-#: apps/role_setting/views/role_setting.py:120
-#: apps/role_setting/views/role_setting.py:121
-#: apps/role_setting/views/role_setting.py:122
-msgid "Create or update role permission"
-msgstr "创建或更新角色权限"
-
-#: apps/role_setting/views/role_setting.py:140
-#: apps/role_setting/views/role_setting.py:141
-#: apps/role_setting/views/role_setting.py:142
-msgid "Get role permission"
-msgstr "获取角色权限"
-
-#: apps/role_setting/views/role_setting.py:161
-#: apps/role_setting/views/role_setting.py:162
-#: apps/role_setting/views/role_setting.py:163
-msgid "Add member to system role"
-msgstr "系统角色添加成员"
-
-#: apps/role_setting/views/role_setting.py:186
-#: apps/role_setting/views/role_setting.py:187
-#: apps/role_setting/views/role_setting.py:188
-msgid "Remove member from system role"
-msgstr "系统角色移除成员"
-
-#: apps/role_setting/views/role_setting.py:205
-#: apps/role_setting/views/role_setting.py:206
-#: apps/role_setting/views/role_setting.py:207
-msgid "Get system role member list"
-msgstr "获取系统角色成员列表"
-
-#: apps/role_setting/views/role_setting.py:223
-#: apps/role_setting/views/role_setting.py:224
-#: apps/role_setting/views/role_setting.py:225
-msgid "Get Workspace role list"
-msgstr "获取工作空间角色列表"
-
-#: apps/role_setting/views/role_setting.py:227
-#: apps/role_setting/views/role_setting.py:248
-#: apps/role_setting/views/role_setting.py:273
-#: apps/role_setting/views/role_setting.py:292
-msgid "Workspace Role"
-msgstr "工作空间角色"
-
-#: apps/role_setting/views/role_setting.py:242
-#: apps/role_setting/views/role_setting.py:243
-#: apps/role_setting/views/role_setting.py:244
-msgid "Add member to workspace role"
-msgstr "工作空间角色添加成员"
-
-#: apps/role_setting/views/role_setting.py:268
-#: apps/role_setting/views/role_setting.py:269
-#: apps/role_setting/views/role_setting.py:270
-msgid "Remove member from workspace role"
-msgstr "工作空间角色移除成员"
-
-#: apps/role_setting/views/role_setting.py:287
-#: apps/role_setting/views/role_setting.py:288
-#: apps/role_setting/views/role_setting.py:289
-msgid "Get workspace role member list"
-msgstr "获取工作空间角色成员列表"
-
-#: apps/shared/api/shared_knowledge.py:242 apps/xpack/api/knowledge_lark.py:54
-msgid "Folder token"
-msgstr "文件夹 Token"
-
-#: apps/shared/api/shared_tool.py:19 apps/shared/api/shared_tool.py:46
-#: apps/shared/api/shared_tool.py:93 apps/shared/api/shared_tool.py:133
-#: apps/shared/serializers/shared_tool.py:43
-#: apps/shared/serializers/shared_tool.py:83 apps/tools/serializers/tool.py:142
-#: apps/tools/serializers/tool.py:158 apps/tools/serializers/tool.py:454
-msgid "tool name"
-msgstr "工具名称"
-
-#: apps/shared/api/shared_tool.py:26 apps/shared/api/shared_tool.py:53
-#: apps/shared/api/shared_tool.py:100 apps/shared/api/shared_tool.py:140
-#: apps/shared/serializers/shared_tool.py:44
-#: apps/shared/serializers/shared_tool.py:85 apps/tools/serializers/tool.py:144
-#: apps/tools/serializers/tool.py:159
-msgid "tool description"
-msgstr "工具描述"
-
-#: apps/shared/api/shared_tool.py:166 apps/shared/api/shared_tool.py:184
-#: apps/shared/api/shared_tool.py:256 apps/shared/api/shared_tool.py:288
-#: apps/shared/api/shared_tool.py:310 apps/shared/serializers/shared_tool.py:66
-#: apps/shared/serializers/shared_tool.py:107
-#: apps/tools/serializers/tool.py:267
-msgid "tool id"
-msgstr "工具 ID"
-
-#: apps/shared/serializers/shared_knowledge.py:35
-#: apps/shared/serializers/shared_model.py:20
-#: apps/shared/serializers/shared_tool.py:19
-msgid "workspace id list"
-msgstr "工作空间ID"
-
-#: apps/shared/serializers/shared_knowledge.py:36
-#: apps/shared/serializers/shared_model.py:21
-#: apps/shared/serializers/shared_tool.py:20
-msgid "authentication type"
-msgstr "认证类型"
-
-#: apps/shared/serializers/shared_knowledge.py:196
-#: apps/shared/serializers/shared_knowledge.py:216
-#: apps/shared/serializers/shared_knowledge.py:236
-msgid "Knowledge does not exist"
-msgstr "知识库不存在"
-
-#: apps/shared/serializers/shared_knowledge.py:218
-#: apps/shared/serializers/shared_knowledge.py:238
-msgid "Only shared knowledge can be authorized"
-msgstr "仅限共享知识库可以被授权"
-
-#: apps/shared/serializers/shared_tool.py:74
-msgid "Only shared tools can be deleted"
-msgstr "仅限共享工具可以被删除"
-
-#: apps/shared/serializers/shared_tool.py:76
-msgid "System tools cannot be deleted"
-msgstr "系统工具不能被删除"
-
-#: apps/shared/serializers/shared_tool.py:118
-#: apps/shared/serializers/shared_tool.py:138
-msgid "Tool does not exist"
-msgstr "工具不存在"
-
-#: apps/shared/serializers/shared_tool.py:120
-#: apps/shared/serializers/shared_tool.py:140
-msgid "Only shared tools can be authorized"
-msgstr "仅限共享工具可以被授权"
-
-#: apps/shared/views/shared_dataset_lark_views.py:25
-#: apps/shared/views/shared_dataset_lark_views.py:26
-#: apps/shared/views/shared_dataset_lark_views.py:27
-#: apps/xpack/views/dataset_lark_views.py:23
-#: apps/xpack/views/dataset_lark_views.py:24
-#: apps/xpack/views/dataset_lark_views.py:25
-msgid "Create a lark knowledge base"
-msgstr "创建知识库"
-
-#: apps/shared/views/shared_dataset_lark_views.py:44
-#: apps/shared/views/shared_dataset_lark_views.py:45
-#: apps/shared/views/shared_dataset_lark_views.py:46
-#: apps/xpack/views/dataset_lark_views.py:44
-#: apps/xpack/views/dataset_lark_views.py:45
-#: apps/xpack/views/dataset_lark_views.py:46
-msgid "Update a lark knowledge base"
-msgstr "更新飞书知识库"
-
-#: apps/shared/views/shared_dataset_lark_views.py:67
-#: apps/shared/views/shared_dataset_lark_views.py:68
-#: apps/shared/views/shared_dataset_lark_views.py:69
-#: apps/xpack/views/dataset_lark_views.py:67
-#: apps/xpack/views/dataset_lark_views.py:68
-#: apps/xpack/views/dataset_lark_views.py:69
-msgid "Get document list from lark"
-msgstr "获取飞书文档列表"
-
-#: apps/shared/views/shared_dataset_lark_views.py:72
-#: apps/shared/views/shared_dataset_lark_views.py:90
-#: apps/shared/views/shared_dataset_lark_views.py:109
-#: apps/shared/views/shared_dataset_lark_views.py:129
-#: apps/shared/views/shared_document.py:36
-#: apps/shared/views/shared_document.py:56
-#: apps/shared/views/shared_document.py:83
-#: apps/shared/views/shared_document.py:114
-#: apps/shared/views/shared_document.py:131
-#: apps/shared/views/shared_document.py:156
-#: apps/shared/views/shared_document.py:184
-#: apps/shared/views/shared_document.py:211
-#: apps/shared/views/shared_document.py:238
-#: apps/shared/views/shared_document.py:268
-#: apps/shared/views/shared_document.py:297
-#: apps/shared/views/shared_document.py:318
-#: apps/shared/views/shared_document.py:346
-#: apps/shared/views/shared_document.py:363
-#: apps/shared/views/shared_document.py:384
-#: apps/shared/views/shared_document.py:412
-#: apps/shared/views/shared_document.py:436
-#: apps/shared/views/shared_document.py:461
-#: apps/shared/views/shared_document.py:486
-#: apps/shared/views/shared_document.py:508
-#: apps/shared/views/shared_document.py:531
-#: apps/shared/views/shared_document.py:554
-#: apps/shared/views/shared_document.py:575
-#: apps/shared/views/shared_document.py:602
-#: apps/shared/views/shared_document.py:629
-#: apps/shared/views/shared_document.py:651
-#: apps/shared/views/shared_document.py:665
-msgid "Shared Knowledge/Documentation"
-msgstr "共享知识库/文档"
-
-#: apps/shared/views/shared_dataset_lark_views.py:85
-#: apps/shared/views/shared_dataset_lark_views.py:86
-#: apps/shared/views/shared_dataset_lark_views.py:87
-#: apps/xpack/views/dataset_lark_views.py:86
-#: apps/xpack/views/dataset_lark_views.py:87
-#: apps/xpack/views/dataset_lark_views.py:88
-msgid "Import documents to the lark knowledge base"
-msgstr "导入文档到飞书知识库"
-
-#: apps/shared/views/shared_dataset_lark_views.py:104
-#: apps/shared/views/shared_dataset_lark_views.py:105
-#: apps/shared/views/shared_dataset_lark_views.py:106
-#: apps/xpack/views/dataset_lark_views.py:106
-#: apps/xpack/views/dataset_lark_views.py:107
-#: apps/xpack/views/dataset_lark_views.py:108
-msgid "Synchronize lark document"
-msgstr "同步飞书文档"
-
-#: apps/shared/views/shared_dataset_lark_views.py:123
-#: apps/shared/views/shared_dataset_lark_views.py:124
-#: apps/shared/views/shared_dataset_lark_views.py:125
-#: apps/xpack/views/dataset_lark_views.py:126
-#: apps/xpack/views/dataset_lark_views.py:127
-#: apps/xpack/views/dataset_lark_views.py:128
-msgid "Batch synchronize lark document"
-msgstr "批量同步飞书文档"
-
-#: apps/shared/views/shared_document.py:30
-#: apps/shared/views/shared_document.py:31
-#: apps/shared/views/shared_document.py:32
-msgid "Create shared document"
-msgstr "创建共享文档"
-
-#: apps/shared/views/shared_document.py:51
-#: apps/shared/views/shared_document.py:52
-#: apps/shared/views/shared_document.py:53
-msgid "Get shared document"
-msgstr "获取共享文档"
-
-#: apps/shared/views/shared_document.py:77
-#: apps/shared/views/shared_document.py:78
-#: apps/shared/views/shared_document.py:79
-msgid "Segmented shared document"
-msgstr "分段共享文档"
-
-#: apps/shared/views/shared_document.py:109
-#: apps/shared/views/shared_document.py:110
-#: apps/shared/views/shared_document.py:111
-msgid "Get a list of shared segment IDs"
-msgstr "获取共享分段 ID 列表"
-
-#: apps/shared/views/shared_document.py:125
-#: apps/shared/views/shared_document.py:126
-#: apps/shared/views/shared_document.py:127
-msgid "Cancel shared tasks in batches"
-msgstr "批量取消任务"
-
-#: apps/shared/views/shared_document.py:150
-#: apps/shared/views/shared_document.py:151
-#: apps/shared/views/shared_document.py:152
-msgid "Create shared documents in batches"
-msgstr "批量创建共享文档"
-
-#: apps/shared/views/shared_document.py:178
-#: apps/shared/views/shared_document.py:179
-#: apps/shared/views/shared_document.py:180
-msgid "Batch sync shared documents"
-msgstr "批量同步共享文档"
-
-#: apps/shared/views/shared_document.py:205
-#: apps/shared/views/shared_document.py:206
-#: apps/shared/views/shared_document.py:207
-msgid "Delete shared documents in batches"
-msgstr "批量删除共享文档"
-
-#: apps/shared/views/shared_document.py:233
-#: apps/shared/views/shared_document.py:234
-msgid "Batch refresh shared document vector library"
-msgstr "批量刷新共享文档向量库"
-
-#: apps/shared/views/shared_document.py:262
-#: apps/shared/views/shared_document.py:263
-#: apps/shared/views/shared_document.py:264
-msgid "Batch generate related shared problems"
-msgstr "批量生成相关问题"
-
-#: apps/shared/views/shared_document.py:291
-#: apps/shared/views/shared_document.py:292
-#: apps/shared/views/shared_document.py:293
-msgid "Modify shared document hit processing methods in batches"
-msgstr "批量修改文档命中处理方法"
-
-#: apps/shared/views/shared_document.py:313
-#: apps/shared/views/shared_document.py:314
-msgid "Migrate shared documents in batches"
-msgstr "批量迁移共享文档"
-
-#: apps/shared/views/shared_document.py:341
-#: apps/shared/views/shared_document.py:342
-#: apps/shared/views/shared_document.py:343
-msgid "Get shared document details"
-msgstr "文档文档详情"
-
-#: apps/shared/views/shared_document.py:357
-#: apps/shared/views/shared_document.py:358
-#: apps/shared/views/shared_document.py:359
-msgid "Modify shared document"
-msgstr "修改共享文档"
-
-#: apps/shared/views/shared_document.py:379
-#: apps/shared/views/shared_document.py:380
-#: apps/shared/views/shared_document.py:381
-msgid "Delete shared document"
-msgstr "删除共享文档"
-
-#: apps/shared/views/shared_document.py:406
-#: apps/shared/views/shared_document.py:407
-#: apps/shared/views/shared_document.py:408
-msgid "Synchronize shared web site types"
-msgstr "同步共享网站类型"
-
-#: apps/shared/views/shared_document.py:430
-#: apps/shared/views/shared_document.py:431
-#: apps/shared/views/shared_document.py:432
-msgid "Refresh shared document vector library"
-msgstr "刷新共享文档向量库"
-
-#: apps/shared/views/shared_document.py:455
-#: apps/shared/views/shared_document.py:456
-#: apps/shared/views/shared_document.py:457
-msgid "Cancel shared task"
-msgstr "取消任务"
-
-#: apps/shared/views/shared_document.py:481
-#: apps/shared/views/shared_document.py:482
-#: apps/shared/views/shared_document.py:483
-msgid "Get shared document by pagination"
-msgstr "获取共享文档分页列表"
-
-#: apps/shared/views/shared_document.py:504
-#: apps/shared/views/shared_document.py:505
-msgid "Export shared document"
-msgstr "导出共享文档"
-
-#: apps/shared/views/shared_document.py:527
-#: apps/shared/views/shared_document.py:528
-msgid "Export Zip shared document"
-msgstr "导出共享文档 Zip"
-
-#: apps/shared/views/shared_document.py:550
-#: apps/shared/views/shared_document.py:551
-msgid "Download shared source file"
-msgstr "下载共享源文件"
-
-#: apps/shared/views/shared_document.py:569
-#: apps/shared/views/shared_document.py:571
-msgid "Create Web site shared documents"
-msgstr "创建网站文档"
-
-#: apps/shared/views/shared_document.py:596
-#: apps/shared/views/shared_document.py:597
-#: apps/shared/views/shared_document.py:598
-msgid "Import QA and create shared documentation"
-msgstr "导入问答并创建文档"
-
-#: apps/shared/views/shared_document.py:623
-#: apps/shared/views/shared_document.py:624
-#: apps/shared/views/shared_document.py:625
-msgid "Import tables and create shared documents"
-msgstr "导入表格并创建文档"
-
-#: apps/shared/views/shared_document.py:647
-#: apps/shared/views/shared_document.py:648
-msgid "Get shared QA template"
-msgstr "获取共享问答模板"
-
-#: apps/shared/views/shared_document.py:661
-#: apps/shared/views/shared_document.py:662
-msgid "Get shared form template"
-msgstr "获取共享表格模板"
-
-#: apps/shared/views/shared_knowledge.py:28
-#: apps/shared/views/shared_knowledge.py:29
-#: apps/shared/views/shared_knowledge.py:30
-msgid "Get share resource knowledge"
-msgstr "获取共享资源知识库"
-
-#: apps/shared/views/shared_knowledge.py:48
-#: apps/shared/views/shared_knowledge.py:49
-#: apps/shared/views/shared_knowledge.py:50
-msgid "Get shared knowledge list by pagination"
-msgstr "获取共享知识库分页列表"
-
-#: apps/shared/views/shared_knowledge.py:70
-#: apps/shared/views/shared_knowledge.py:71
-#: apps/shared/views/shared_knowledge.py:72
-msgid "Update shared knowledge"
-msgstr "更新共享知识库"
-
-#: apps/shared/views/shared_knowledge.py:86
-#: apps/shared/views/shared_knowledge.py:87
-#: apps/shared/views/shared_knowledge.py:88
-msgid "Get shared knowledge"
-msgstr "获取共享知识库"
-
-#: apps/shared/views/shared_knowledge.py:101
-#: apps/shared/views/shared_knowledge.py:102
-#: apps/shared/views/shared_knowledge.py:103
-msgid "Delete shared knowledge"
-msgstr "删除共享知识库"
-
-#: apps/shared/views/shared_knowledge.py:119
-#: apps/shared/views/shared_knowledge.py:120
-#: apps/shared/views/shared_knowledge.py:121
-msgid "Synchronize the shared knowledge base of the website"
-msgstr "同步共享知识库网站"
-
-#: apps/shared/views/shared_knowledge.py:145
-#: apps/shared/views/shared_knowledge.py:146
-#: apps/shared/views/shared_knowledge.py:147
-msgid "Shared Hit test list"
-msgstr "命中测试列表"
-
-#: apps/shared/views/shared_knowledge.py:172
-#: apps/shared/views/shared_knowledge.py:173
-#: apps/shared/views/shared_knowledge.py:174
-msgid "Shared Re-vectorize"
-msgstr "重新向量化"
-
-#: apps/shared/views/shared_knowledge.py:192
-#: apps/shared/views/shared_knowledge.py:193
-msgid "Export shared knowledge base"
-msgstr "导出共享知识库"
-
-#: apps/shared/views/shared_knowledge.py:210
-#: apps/shared/views/shared_knowledge.py:211
-msgid "Export shared knowledge base containing images"
-msgstr "导出包含图片的共享知识库"
-
-#: apps/shared/views/shared_knowledge.py:229
-#: apps/shared/views/shared_knowledge.py:230
-#: apps/shared/views/shared_knowledge.py:231
-msgid "Shared generate related"
-msgstr "生成相关"
-
-#: apps/shared/views/shared_knowledge.py:251
-#: apps/shared/views/shared_knowledge.py:252
-#: apps/shared/views/shared_knowledge.py:253
-msgid "Get model for shared knowledge base"
-msgstr "获取共享知识库模型"
-
-#: apps/shared/views/shared_knowledge.py:271
-#: apps/shared/views/shared_knowledge.py:272
-#: apps/shared/views/shared_knowledge.py:273
-msgid "Get embedding model for shared knowledge base"
-msgstr "获取共享知识库嵌入模型"
-
-#: apps/shared/views/shared_knowledge.py:291
-#: apps/shared/views/shared_knowledge.py:293
-msgid "Authorization knowledge workspace"
-msgstr "授权知识工作空间"
-
-#: apps/shared/views/shared_knowledge.py:292
-msgid "Authorization knowledge workspace "
-msgstr "授权知识工作空间"
-
-#: apps/shared/views/shared_knowledge.py:307
-#: apps/shared/views/shared_knowledge.py:308
-#: apps/shared/views/shared_knowledge.py:309
-msgid "Get Authorization knowledge workspace"
-msgstr "获取授权知识工作空间"
-
-#: apps/shared/views/shared_knowledge.py:326
-#: apps/shared/views/shared_knowledge.py:327
-#: apps/shared/views/shared_knowledge.py:328
-msgid "Create shared base knowledge"
-msgstr "创建共享知识库"
-
-#: apps/shared/views/shared_knowledge.py:349
-#: apps/shared/views/shared_knowledge.py:350
-#: apps/shared/views/shared_knowledge.py:351
-msgid "Create shared web knowledge"
-msgstr "创建 web 知识库"
-
-#: apps/shared/views/shared_knowledge.py:381
-#: apps/shared/views/shared_knowledge.py:382
-#: apps/shared/views/shared_knowledge.py:383
-msgid "Get shared workspace knowledge"
-msgstr "获取共享工作空间知识库"
-
-#: apps/shared/views/shared_knowledge.py:402
-#: apps/shared/views/shared_knowledge.py:403
-#: apps/shared/views/shared_knowledge.py:404
-msgid "Get shared workspace knowledge list by pagination"
-msgstr "获取共享工作空间知识库分页列表"
-
-#: apps/shared/views/shared_model.py:213 apps/shared/views/shared_model.py:215
-msgid "Authorization model workspace"
-msgstr "授权模型工作空间"
-
-#: apps/shared/views/shared_model.py:214
-msgid "Authorization model workspace "
-msgstr "授权模型工作空间"
-
-#: apps/shared/views/shared_model.py:229 apps/shared/views/shared_model.py:230
-#: apps/shared/views/shared_model.py:231
-msgid "Get Authorization model workspace"
-msgstr "获取授权模型工作空间"
-
-#: apps/shared/views/shared_model.py:248 apps/shared/views/shared_model.py:249
-#: apps/shared/views/shared_model.py:250
-msgid "Get Share model by workspace id"
-msgstr "获取共享模型工作空间 ID"
-
-#: apps/shared/views/shared_model.py:265 apps/shared/views/shared_model.py:266
-#: apps/shared/views/shared_model.py:267
-msgid "Get Share model by workspace id with pagination"
-msgstr "获取共享模型工作空间 ID 分页列表"
-
-#: apps/shared/views/shared_paragraph.py:24
-#: apps/shared/views/shared_paragraph.py:25
-#: apps/shared/views/shared_paragraph.py:26
-msgid "Shared paragraph list"
-msgstr "共享段落列表"
-
-#: apps/shared/views/shared_paragraph.py:29
-#: apps/shared/views/shared_paragraph.py:50
-#: apps/shared/views/shared_paragraph.py:76
-#: apps/shared/views/shared_paragraph.py:93
-#: apps/shared/views/shared_paragraph.py:125
-#: apps/shared/views/shared_paragraph.py:151
-#: apps/shared/views/shared_paragraph.py:179
-#: apps/shared/views/shared_paragraph.py:201
-#: apps/shared/views/shared_paragraph.py:233
-#: apps/shared/views/shared_paragraph.py:259
-#: apps/shared/views/shared_paragraph.py:283
-#: apps/shared/views/shared_paragraph.py:314
-#: apps/shared/views/shared_paragraph.py:345
-#: apps/shared/views/shared_paragraph.py:371
-msgid "Shared Knowledge/Documentation/Paragraph"
-msgstr "共享知识库/文档/段落"
-
-#: apps/shared/views/shared_paragraph.py:45
-#: apps/shared/views/shared_paragraph.py:46
-msgid "Create shared paragraph"
-msgstr "创建段落"
-
-#: apps/shared/views/shared_paragraph.py:70
-#: apps/shared/views/shared_paragraph.py:71
-#: apps/shared/views/shared_paragraph.py:72
-msgid "Batch shared paragraph"
-msgstr "批量关联段落"
-
-#: apps/shared/views/shared_paragraph.py:88
-#: apps/shared/views/shared_paragraph.py:89
-msgid "Migrate shared paragraphs in batches"
-msgstr "批量迁移共享段落"
-
-#: apps/shared/views/shared_paragraph.py:119
-#: apps/shared/views/shared_paragraph.py:120
-#: apps/shared/views/shared_paragraph.py:121
-msgid "Batch generate shared related"
-msgstr "批量生成相关"
-
-#: apps/shared/views/shared_paragraph.py:145
-#: apps/shared/views/shared_paragraph.py:146
-#: apps/shared/views/shared_paragraph.py:147
-msgid "Modify shared paragraph data"
-msgstr "修改段落数据"
-
-#: apps/shared/views/shared_paragraph.py:174
-#: apps/shared/views/shared_paragraph.py:175
-#: apps/shared/views/shared_paragraph.py:176
-msgid "Get shared paragraph details"
-msgstr "获取段落详情"
-
-#: apps/shared/views/shared_paragraph.py:196
-#: apps/shared/views/shared_paragraph.py:197
-#: apps/shared/views/shared_paragraph.py:198
-msgid "Delete shared paragraph"
-msgstr "删除段落"
-
-#: apps/shared/views/shared_paragraph.py:227
-#: apps/shared/views/shared_paragraph.py:228
-#: apps/shared/views/shared_paragraph.py:229
-msgid "Add shared associated questions"
-msgstr "添加关联问题"
-
-#: apps/shared/views/shared_paragraph.py:254
-#: apps/shared/views/shared_paragraph.py:255
-#: apps/shared/views/shared_paragraph.py:256
+#: apps/knowledge/views/document.py:268
+#: apps/knowledge/views/document.py:269
+#: apps/knowledge/views/document.py:270
+msgid "Get a list of segment IDs"
+msgstr "获取分段列表"
+
+#: no source
 msgid "Get a list of shared paragraph questions"
 msgstr "获取共享段落问题列表"
 
-#: apps/shared/views/shared_paragraph.py:277
-#: apps/shared/views/shared_paragraph.py:278
-#: apps/shared/views/shared_paragraph.py:279
-msgid "Disassociation shared issue"
-msgstr "取消关联问题"
+#: no source
+msgid "Get a list of shared segment IDs"
+msgstr "获取共享分段 ID 列表"
 
-#: apps/shared/views/shared_paragraph.py:308
-#: apps/shared/views/shared_paragraph.py:309
-#: apps/shared/views/shared_paragraph.py:310
-msgid "Related shared questions"
-msgstr "关联问题"
+#: no source
+msgid "Get a list of system paragraph questions"
+msgstr "获取段落问题列表"
 
-#: apps/shared/views/shared_paragraph.py:340
-#: apps/shared/views/shared_paragraph.py:341
-#: apps/shared/views/shared_paragraph.py:342
-msgid "Get shared paragraph list by pagination"
-msgstr "获取段落列表"
+#: no source
+msgid "Get a list of system segment IDs"
+msgstr "获取分段ID列表"
 
-#: apps/shared/views/shared_problem.py:23
-#: apps/shared/views/shared_problem.py:24
-#: apps/shared/views/shared_problem.py:25
-msgid "Shared question list"
-msgstr "问题列表"
+#: apps/trigger/views/trigger_task.py:78
+#: apps/trigger/views/trigger_task.py:79
+#: apps/trigger/views/trigger_task.py:80
+msgid "Get a paginated list of execution records for trigger tasks."
+msgstr "获取触发器任务执行记录的分页列表。"
 
-#: apps/shared/views/shared_problem.py:28
-#: apps/shared/views/shared_problem.py:50
-#: apps/shared/views/shared_problem.py:71
-#: apps/shared/views/shared_problem.py:94
-#: apps/shared/views/shared_problem.py:115
-#: apps/shared/views/shared_problem.py:135
-#: apps/shared/views/shared_problem.py:158
-#: apps/shared/views/shared_problem.py:182
-msgid "Shared Knowledge/Documentation/Paragraph/Question"
-msgstr "知识库/文档/段落/问题"
+#: apps/application/views/application_chat.py:121
+#: apps/application/views/application_chat.py:122
+#: apps/application/views/application_chat.py:123
+msgid "Get a temporary session id based on the application id"
+msgstr "获取智能体的临时会话 ID"
 
-#: apps/shared/views/shared_problem.py:44
-#: apps/shared/views/shared_problem.py:45
-#: apps/shared/views/shared_problem.py:46
-msgid "Create shared question"
-msgstr "创建问题"
+#: apps/knowledge/views/knowledge.py:570
+#: apps/knowledge/views/knowledge.py:571
+#: apps/knowledge/views/knowledge.py:572
+msgid "Get all tags of knowledge base"
+msgstr ""
 
-#: apps/shared/views/shared_problem.py:66
-#: apps/shared/views/shared_problem.py:67
-#: apps/shared/views/shared_problem.py:68
-msgid "Get a list of associated shared paragraphs"
-msgstr "获取关联段落列表"
+#: apps/users/views/user.py:130
+#: apps/users/views/user.py:131
+#: apps/users/views/user.py:132
+msgid "Get all user"
+msgstr "获取所有用户"
 
-#: apps/shared/views/shared_problem.py:88
-#: apps/shared/views/shared_problem.py:89
-#: apps/shared/views/shared_problem.py:90
-msgid "Batch associated shared paragraphs"
-msgstr "批量关联段落"
+#: apps/application/views/application_access_token.py:61
+#: apps/application/views/application_access_token.py:62
+#: apps/application/views/application_access_token.py:63
+msgid "Get application access restriction information"
+msgstr "获取智能体访问限制信息"
 
-#: apps/shared/views/shared_problem.py:109
-#: apps/shared/views/shared_problem.py:110
-#: apps/shared/views/shared_problem.py:111
-msgid "Batch deletion shared issues"
-msgstr "批量删除问题"
+#: apps/application/views/application_api_key.py:59
+msgid "GET application ApiKey List"
+msgstr "获取智能体的 API 密钥列表"
 
-#: apps/shared/views/shared_problem.py:130
-#: apps/shared/views/shared_problem.py:131
-#: apps/shared/views/shared_problem.py:132
-msgid "Delete shared question"
-msgstr "删除问题"
+#: apps/chat/views/chat.py:140
+#: apps/chat/views/chat.py:141
+#: apps/chat/views/chat.py:142
+msgid "Get application authentication information"
+msgstr "获取智能体认证信息"
 
-#: apps/shared/views/shared_problem.py:152
-#: apps/shared/views/shared_problem.py:153
-#: apps/shared/views/shared_problem.py:154
-msgid "Modify shared question"
-msgstr "修改问题"
+#: apps/application/views/application.py:221
+#: apps/application/views/application.py:222
+#: apps/application/views/application.py:223
+msgid "Get application details"
+msgstr "获取智能体详情"
 
-#: apps/shared/views/shared_problem.py:177
-#: apps/shared/views/shared_problem.py:178
-#: apps/shared/views/shared_problem.py:179
-msgid "Get the list of shared questions by page"
-msgstr "分页获取问题列表"
+#: apps/chat/views/chat.py:123
+#: apps/chat/views/chat.py:124
+#: apps/chat/views/chat.py:125
+msgid "Get application related information"
+msgstr "获取智能体相关信息"
 
-#: apps/shared/views/shared_tool.py:25 apps/shared/views/shared_tool.py:26
-#: apps/shared/views/shared_tool.py:27
-msgid "Get share resource tool"
-msgstr "获取共享资源工具"
+#: no source
+msgid "Get Application Settings"
+msgstr "获取智能体设置"
 
-#: apps/shared/views/shared_tool.py:43 apps/shared/views/shared_tool.py:44
-#: apps/shared/views/shared_tool.py:45
-msgid "Create shared tool"
-msgstr "创建共享工具"
+#: apps/application/views/application_version.py:79
+#: apps/application/views/application_version.py:80
+#: apps/application/views/application_version.py:81
+msgid "Get application version details"
+msgstr "获取智能体版本详情"
 
-#: apps/shared/views/shared_tool.py:62 apps/shared/views/shared_tool.py:63
-#: apps/shared/views/shared_tool.py:64
-msgid "Update shared tool"
-msgstr "更新共享工具"
+#: apps/application/views/application.py:299
+#: apps/application/views/application.py:300
+#: apps/application/views/application.py:301
+msgid "Get Appstore apps"
+msgstr ""
 
-#: apps/shared/views/shared_tool.py:78 apps/shared/views/shared_tool.py:79
-#: apps/shared/views/shared_tool.py:80
-msgid "Get shared tool"
-msgstr "获取共享工具"
+#: apps/knowledge/views/knowledge.py:317
+#: apps/knowledge/views/knowledge.py:318
+#: apps/knowledge/views/knowledge.py:319
+#: apps/tools/views/tool.py:530
+#: apps/tools/views/tool.py:531
+#: apps/tools/views/tool.py:532
+#: apps/tools/views/tool_workflow.py:194
+#: apps/tools/views/tool_workflow.py:195
+#: apps/tools/views/tool_workflow.py:196
+msgid "Get Appstore tools"
+msgstr ""
 
-#: apps/shared/views/shared_tool.py:93 apps/shared/views/shared_tool.py:94
-#: apps/shared/views/shared_tool.py:95
-msgid "Delete shared tool"
-msgstr "删除共享工具"
+#: no source
+msgid "Get authentication configuration"
+msgstr "获取认证配置"
 
-#: apps/shared/views/shared_tool.py:111 apps/shared/views/shared_tool.py:112
-#: apps/shared/views/shared_tool.py:113
-msgid "Get shared tool list by pagination"
-msgstr "获取共享工具列表"
+#: no source
+msgid "Get Authentication Configuration"
+msgstr "获取认证配置"
 
-#: apps/shared/views/shared_tool.py:134 apps/shared/views/shared_tool.py:135
-#: apps/shared/views/shared_tool.py:136
-msgid "Import shared tool"
-msgstr "导入共享工具"
+#: no source
+msgid "Get authentication types"
+msgstr "获取认证类型"
 
-#: apps/shared/views/shared_tool.py:152 apps/shared/views/shared_tool.py:153
-#: apps/shared/views/shared_tool.py:154
-msgid "Export shared tool"
-msgstr "导出共享工具"
+#: no source
+msgid "Get Authorization knowledge workspace"
+msgstr "获取授权知识工作空间"
 
-#: apps/shared/views/shared_tool.py:170 apps/shared/views/shared_tool.py:171
-#: apps/shared/views/shared_tool.py:172
-msgid "Debug shared Tool"
-msgstr "调试共享工具"
+#: no source
+msgid "Get Authorization model workspace"
+msgstr "获取授权模型工作空间"
 
-#: apps/shared/views/shared_tool.py:188 apps/shared/views/shared_tool.py:189
-#: apps/shared/views/shared_tool.py:190
-msgid "Check shared code"
-msgstr "检查代码"
-
-#: apps/shared/views/shared_tool.py:212 apps/shared/views/shared_tool.py:213
-#: apps/shared/views/shared_tool.py:214
-msgid "Edit shared tool icon"
-msgstr "修改共享工具图标"
-
-#: apps/shared/views/shared_tool.py:233 apps/shared/views/shared_tool.py:235
-msgid "Authorization tool workspace"
-msgstr "授权工作空间工具"
-
-#: apps/shared/views/shared_tool.py:234
-msgid "Authorization tool workspace "
-msgstr "授权工作空间工具"
-
-#: apps/shared/views/shared_tool.py:249 apps/shared/views/shared_tool.py:250
-#: apps/shared/views/shared_tool.py:251
+#: no source
 msgid "Get Authorization tool workspace"
 msgstr "获取授权工作空间工具"
 
-#: apps/shared/views/shared_tool.py:268 apps/shared/views/shared_tool.py:269
-#: apps/shared/views/shared_tool.py:270
-msgid "Get shared workspace tool"
-msgstr "获取共享工作空间工具"
+#: apps/users/views/login.py:70
+#: apps/users/views/login.py:71
+#: apps/users/views/login.py:72
+msgid "Get captcha"
+msgstr "获取验证码"
 
-#: apps/shared/views/shared_tool.py:289 apps/shared/views/shared_tool.py:290
-#: apps/shared/views/shared_tool.py:291
-msgid "Get shared workspace tool list by pagination"
-msgstr "获取共享工作空间工具分页列表"
-
-#: apps/system_manage/serializers/email_setting.py:28
-msgid "SMTP host"
+#: apps/chat/views/chat.py:204
+#: apps/chat/views/chat.py:205
+#: apps/chat/views/chat.py:206
+msgid "Get Chat captcha"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:29
-msgid "SMTP port"
+#: apps/application/views/application_chat_link.py:45
+#: apps/application/views/application_chat_link.py:46
+#: apps/application/views/application_chat_link.py:47
+msgid "Get chat record by share link"
+msgstr "通过分享链接获取聊天记录"
+
+#: no source
+msgid "Get chat user information"
+msgstr "获取对话用户信息"
+
+#: no source
+msgid "Get chat user list"
+msgstr "获取对话用户列表"
+
+#: apps/chat/views/chat_record.py:186
+#: apps/chat/views/chat_record.py:187
+#: apps/chat/views/chat_record.py:188
+msgid "Get conversation details"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:30
-#: apps/system_manage/serializers/email_setting.py:34
-msgid "Sender's email"
-msgstr "发送者邮箱"
+#: apps/application/views/application_chat_record.py:86
+#: apps/application/views/application_chat_record.py:87
+#: apps/application/views/application_chat_record.py:88
+msgid "Get conversation record details"
+msgstr "获取对话记录详情"
 
-#: apps/system_manage/serializers/email_setting.py:31 apps/users/api/user.py:93
-#: apps/users/serializers/login.py:28 apps/users/serializers/user.py:57
-#: apps/users/serializers/user.py:126 apps/users/serializers/user.py:291
-#: apps/users/serializers/user.py:517 apps/xpack/api/auth_config.py:25
-#: apps/xpack/api/chat_user.py:71 apps/xpack/serializers/chat_auth.py:24
-#: apps/xpack/serializers/chat_user.py:74
-#: apps/xpack/serializers/chat_user.py:267
-#: apps/xpack/serializers/chat_user.py:601
-msgid "Password"
-msgstr "密码"
+#: apps/users/views/user.py:68
+#: apps/users/views/user.py:69
+#: apps/users/views/user.py:70
+#: apps/users/views/user.py:82
+#: apps/users/views/user.py:83
+msgid "Get current user information"
+msgstr "获取当前用户信息"
 
-#: apps/system_manage/serializers/email_setting.py:32
-msgid "Whether to enable TLS"
-msgstr "是否启用 TLS"
+#: no source
+msgid "Get current user role list"
+msgstr "获取当前用户角色列表"
 
-#: apps/system_manage/serializers/email_setting.py:33
-msgid "Whether to enable SSL"
-msgstr "是否启用 SSL"
+#: apps/users/views/user.py:191
+#: apps/users/views/user.py:192
+#: apps/users/views/user.py:193
+msgid "Get default password"
+msgstr "获取默认密码"
 
-#: apps/system_manage/serializers/email_setting.py:49
-msgid "Email verification failed"
-msgstr "邮件认证失败"
+#: apps/knowledge/views/document.py:87
+#: apps/knowledge/views/document.py:88
+#: apps/knowledge/views/document.py:89
+msgid "Get document"
+msgstr "获取文档"
 
-#: apps/system_manage/serializers/user_resource_permission.py:53
-msgid "target id"
-msgstr "当前 ID"
+#: apps/knowledge/views/document.py:840
+#: apps/knowledge/views/document.py:841
+#: apps/knowledge/views/document.py:842
+msgid "Get document by pagination"
+msgstr "分页获取文档"
 
-#: apps/system_manage/serializers/user_resource_permission.py:70
-msgid "Non-existent application|knowledge base id["
-msgstr "不存在的智能体|知识库 ID["
+#: apps/knowledge/views/document.py:127
+#: apps/knowledge/views/document.py:128
+#: apps/knowledge/views/document.py:129
+msgid "Get document details"
+msgstr "文档文档详情"
 
-#: apps/system_manage/views/email_setting.py:50
-#: apps/system_manage/views/email_setting.py:51
-#: apps/system_manage/views/email_setting.py:52
-msgid "Create or update email settings"
-msgstr "创建或更新邮件设置"
+#: no source
+msgid "Get document list from lark"
+msgstr "获取飞书文档列表"
 
-#: apps/system_manage/views/email_setting.py:55
-#: apps/system_manage/views/email_setting.py:70
-#: apps/system_manage/views/email_setting.py:86
-msgid "Email Settings"
-msgstr "邮箱设置"
-
-#: apps/system_manage/views/email_setting.py:66
-#: apps/system_manage/views/email_setting.py:67
-msgid "Test email settings"
-msgstr "测试邮箱设置"
+#: apps/knowledge/views/document.py:1009
+#: apps/knowledge/views/document.py:1010
+#: apps/knowledge/views/document.py:1011
+msgid "Get document tags"
+msgstr ""
 
 #: apps/system_manage/views/email_setting.py:82
 #: apps/system_manage/views/email_setting.py:83
@@ -6604,2904 +3682,7456 @@ msgstr "测试邮箱设置"
 msgid "Get email settings"
 msgstr "获取邮箱设置"
 
+#: apps/chat/views/chat_embed.py:22
+#: apps/chat/views/chat_embed.py:23
+#: apps/chat/views/chat_embed.py:24
+msgid "Get embedded js"
+msgstr "获取嵌入式 JavaScript"
+
+#: no source
+msgid "Get embedding model for knowledge base"
+msgstr "获取知识库向量模型"
+
+#: no source
+msgid "Get embedding model for shared knowledge base"
+msgstr "获取共享知识库嵌入模型"
+
+#: no source
+msgid "Get embedding model for system knowledge base"
+msgstr "获取系统知识库嵌入模型"
+
+#: apps/oss/views/file.py:18
+#: apps/oss/views/file.py:19
+#: apps/oss/views/file.py:20
+msgid "Get file"
+msgstr "获取文件"
+
+#: apps/folders/views/folder.py:126
+#: apps/folders/views/folder.py:127
+#: apps/folders/views/folder.py:128
+msgid "Get folder"
+msgstr "获取文件夹"
+
+#: apps/folders/views/folder.py:67
+#: apps/folders/views/folder.py:68
+#: apps/folders/views/folder.py:69
+msgid "Get folder tree"
+msgstr "获取文件夹树"
+
+#: apps/knowledge/views/document.py:1336
+#: apps/knowledge/views/document.py:1337
+msgid "Get form template"
+msgstr "获取表格模板"
+
+#: apps/chat/views/chat_record.py:49
+#: apps/chat/views/chat_record.py:50
+#: apps/chat/views/chat_record.py:51
+msgid "Get historical conversation"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:125
+#: apps/chat/views/chat_record.py:126
+#: apps/chat/views/chat_record.py:127
+msgid "Get historical conversation by page"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:145
+#: apps/chat/views/chat_record.py:146
+#: apps/chat/views/chat_record.py:147
+msgid "Get historical conversation records"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:166
+#: apps/chat/views/chat_record.py:167
+msgid "Get historical conversation records by page"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:165
+msgid "Get historical conversation records by page "
+msgstr ""
+
+#: apps/tools/views/tool.py:482
+#: apps/tools/views/tool.py:483
+#: apps/tools/views/tool.py:484
+msgid "Get internal tool"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:119
+#: apps/knowledge/views/knowledge.py:120
+#: apps/knowledge/views/knowledge.py:121
+msgid "Get knowledge"
+msgstr "获取知识库"
+
+#: apps/knowledge/views/knowledge.py:37
+#: apps/knowledge/views/knowledge.py:38
+#: apps/knowledge/views/knowledge.py:39
+msgid "Get knowledge by folder"
+msgstr "根据文件夹获取知识库"
+
+#: apps/knowledge/views/tag.py:44
+msgid "Get Knowledge Tag"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:45
+msgid "Get knowledge tag"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow_version.py:89
+#: apps/knowledge/views/knowledge_workflow_version.py:90
+#: apps/knowledge/views/knowledge_workflow_version.py:91
+msgid "Get knowledge version details"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:398
+#: apps/knowledge/views/knowledge_workflow.py:399
+#: apps/knowledge/views/knowledge_workflow.py:400
+msgid "Get knowledge workflow"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:170
+#: apps/knowledge/views/knowledge_workflow.py:171
+#: apps/knowledge/views/knowledge_workflow.py:172
+msgid "Get knowledge workflow action"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:428
+#: apps/knowledge/views/knowledge_workflow.py:429
+#: apps/knowledge/views/knowledge_workflow.py:430
+msgid "Get knowledge workflow version list"
+msgstr ""
+
+#: no source
+msgid "Get license information"
+msgstr "获取许可证信息"
+
 #: apps/system_manage/views/system_profile.py:22
 #: apps/system_manage/views/system_profile.py:23
 msgid "Get MaxKB related information"
 msgstr "获取 MaxKB 相关信息"
 
-#: apps/system_manage/views/system_profile.py:25
-msgid "System parameters"
-msgstr "系统参数"
+#: no source
+msgid "Get menu operate log"
+msgstr "获取菜单操作日志"
 
-#: apps/system_manage/views/user_resource_permission.py:40
-#: apps/system_manage/views/user_resource_permission.py:41
-msgid "Obtain resource authorization list"
-msgstr "获取资源授权列表"
+#: apps/models_provider/views/provide.py:75
+#: apps/models_provider/views/provide.py:76
+#: apps/models_provider/views/provide.py:77
+msgid "Get model default parameters"
+msgstr "获取模型默认参数"
 
-#: apps/system_manage/views/user_resource_permission.py:44
-#: apps/system_manage/views/user_resource_permission.py:60
-msgid "Resources authorization"
-msgstr "资源授权"
+#: apps/knowledge/views/knowledge.py:512
+#: apps/knowledge/views/knowledge.py:513
+#: apps/knowledge/views/knowledge.py:514
+msgid "Get model for knowledge base"
+msgstr "获取知识库模型"
 
-#: apps/system_manage/views/user_resource_permission.py:55
-#: apps/system_manage/views/user_resource_permission.py:56
-msgid "Modify the resource authorization list"
-msgstr "修改资源授权列表"
+#: no source
+msgid "Get model for shared knowledge base"
+msgstr "获取共享知识库模型"
 
-#: apps/tools/serializers/tool.py:118 apps/tools/serializers/tool.py:169
-msgid "variable name"
-msgstr "变量名称"
+#: no source
+msgid "Get model for system knowledge base"
+msgstr "获取系统知识库模型"
 
-#: apps/tools/serializers/tool.py:122
-msgid "fields only support string|int|dict|array|float"
-msgstr "字段仅支持字符串|整数|字典|数组|浮点数"
+#: apps/models_provider/views/model.py:181
+#: apps/models_provider/views/model.py:182
+#: apps/models_provider/views/model.py:183
+msgid "Get model parameter form"
+msgstr "获取模型参数表单"
 
-#: apps/tools/serializers/tool.py:131
-msgid "field name"
-msgstr "字段名称"
+#: no source
+msgid "Get paginated operate log"
+msgstr "获取分页操作日志"
 
-#: apps/tools/serializers/tool.py:132
-msgid "field label"
-msgstr "标签"
+#: apps/knowledge/views/paragraph.py:211
+#: apps/knowledge/views/paragraph.py:212
+#: apps/knowledge/views/paragraph.py:213
+msgid "Get paragraph details"
+msgstr "获取段落详情"
 
-#: apps/tools/serializers/tool.py:146 apps/tools/serializers/tool.py:160
-#: apps/tools/serializers/tool.py:174
-msgid "tool content"
-msgstr "工具内容"
+#: apps/knowledge/views/paragraph.py:415
+#: apps/knowledge/views/paragraph.py:416
+#: apps/knowledge/views/paragraph.py:417
+msgid "Get paragraph list by pagination"
+msgstr "获取段落列表"
 
-#: apps/tools/serializers/tool.py:148 apps/tools/serializers/tool.py:161
-#: apps/tools/serializers/tool.py:175
-msgid "input field list"
-msgstr "输入字段列表"
+#: no source
+msgid "Get platform configuration"
+msgstr "获取平台配置"
 
-#: apps/tools/serializers/tool.py:150 apps/tools/serializers/tool.py:162
-#: apps/tools/serializers/tool.py:176
-msgid "init field list"
-msgstr "内置字段列表"
+#: no source
+msgid "Get platform information"
+msgstr "获取平台信息"
 
-#: apps/tools/serializers/tool.py:163 apps/tools/serializers/tool.py:177
-msgid "init params"
-msgstr "内置参数"
+#: no source
+msgid "Get platform status"
+msgstr "获取平台状态"
 
-#: apps/tools/serializers/tool.py:170
-msgid "variable value"
-msgstr "变量名称"
+#: apps/knowledge/views/document.py:1322
+#: apps/knowledge/views/document.py:1323
+msgid "Get QA template"
+msgstr "获取问答模板"
 
-#: apps/tools/serializers/tool.py:182
-msgid "function content"
-msgstr "工具内容"
+#: no source
+msgid "Get Resource chat user group List"
+msgstr "获取资源对话用户组列表"
 
-#: apps/tools/serializers/tool.py:238
-msgid "field has no value set"
-msgstr "字段未设置值"
+#: no source
+msgid "Get Resource chat user group page List"
+msgstr "获取资源对话用户组分页列表"
 
-#: apps/tools/serializers/tool.py:262
-#, python-brace-format
-msgid "Field: {name} Type: {_type} Value: {value} Type conversion error"
-msgstr "字段：{name} 类型：{_type} 值：{value} 类型转换错误"
+#: no source
+msgid "Get Resource chat user List"
+msgstr "获取资源对话用户列表"
 
-#: apps/tools/serializers/tool.py:275
-msgid "Tool not found"
-msgstr "工具不存在"
+#: no source
+msgid "Get Resource chat user page group List"
+msgstr "获取资源对话用户分页组列表"
 
-#: apps/tools/serializers/tool.py:388
-msgid "function ID"
-msgstr "工具 ID"
+#: no source
+msgid "Get Resource chat user page List"
+msgstr "获取资源对话用户分页列表"
 
-#: apps/tools/views/tool.py:33 apps/tools/views/tool.py:34
-#: apps/tools/views/tool.py:35
-msgid "Create tool"
-msgstr "创建工具"
+#: no source
+msgid "Get resource model list"
+msgstr "获取资源管理模型列表"
 
-#: apps/tools/views/tool.py:56 apps/tools/views/tool.py:57
-#: apps/tools/views/tool.py:58
-msgid "Get tool by folder"
-msgstr "通过文件夹获取工具"
+#: no source
+msgid "Get role list"
+msgstr "获取角色列表"
 
-#: apps/tools/views/tool.py:77 apps/tools/views/tool.py:78
-#: apps/tools/views/tool.py:79
-msgid "Debug Tool"
-msgstr "调试工具"
+#: no source
+msgid "Get role permission"
+msgstr "获取角色权限"
 
-#: apps/tools/views/tool.py:98 apps/tools/views/tool.py:99
-#: apps/tools/views/tool.py:100
-msgid "Update tool"
-msgstr "更新工具"
+#: no source
+msgid "Get role permission template"
+msgstr "获取角色权限模板"
 
-#: apps/tools/views/tool.py:122 apps/tools/views/tool.py:123
-#: apps/tools/views/tool.py:124
+#: no source
+msgid "Get Share model"
+msgstr "获取共享模型"
+
+#: apps/models_provider/views/model.py:273
+#: apps/models_provider/views/model.py:274
+#: apps/models_provider/views/model.py:275
+msgid "Get Share model by workspace id"
+msgstr "获取共享模型工作空间 ID"
+
+#: no source
+msgid "Get Share model by workspace id with pagination"
+msgstr "获取共享模型工作空间 ID 分页列表"
+
+#: no source
+msgid "Get share resource knowledge"
+msgstr "获取共享资源知识库"
+
+#: no source
+msgid "Get share resource tool"
+msgstr "获取共享资源工具"
+
+#: no source
+msgid "Get shared document"
+msgstr "获取共享文档"
+
+#: no source
+msgid "Get shared document by pagination"
+msgstr "获取共享文档分页列表"
+
+#: no source
+msgid "Get shared document details"
+msgstr "文档文档详情"
+
+#: no source
+msgid "Get shared form template"
+msgstr "获取共享表格模板"
+
+#: no source
+msgid "Get shared knowledge"
+msgstr "获取共享知识库"
+
+#: no source
+msgid "Get shared knowledge list by pagination"
+msgstr "获取共享知识库分页列表"
+
+#: no source
+msgid "Get shared paragraph details"
+msgstr "获取段落详情"
+
+#: no source
+msgid "Get shared paragraph list by pagination"
+msgstr "获取段落列表"
+
+#: no source
+msgid "Get shared QA template"
+msgstr "获取共享问答模板"
+
+#: no source
+msgid "Get shared tool"
+msgstr "获取共享工具"
+
+#: no source
+msgid "Get shared tool list by pagination"
+msgstr "获取共享工具列表"
+
+#: no source
+msgid "Get shared workspace knowledge"
+msgstr "获取共享工作空间知识库"
+
+#: no source
+msgid "Get shared workspace knowledge list by pagination"
+msgstr "获取共享工作空间知识库分页列表"
+
+#: no source
+msgid "Get shared workspace tool"
+msgstr "获取共享工作空间工具"
+
+#: no source
+msgid "Get shared workspace tool list by pagination"
+msgstr "获取共享工作空间工具分页列表"
+
+#: no source
+msgid "Get system document"
+msgstr "获取文档"
+
+#: no source
+msgid "Get system document by pagination"
+msgstr "分页获取文档"
+
+#: no source
+msgid "Get system document details"
+msgstr "获取文档详情"
+
+#: no source
+msgid "Get system form template"
+msgstr "获取系统表单模板"
+
+#: no source
+msgid "Get system knowledge"
+msgstr "获取知识库"
+
+#: no source
+msgid "Get system knowledge list"
+msgstr "获取系统知识库列表"
+
+#: no source
+msgid "Get system knowledge list by pagination"
+msgstr "获取系统知识库分页列表"
+
+#: no source
+msgid "Get system paragraph details"
+msgstr "获取段落详情"
+
+#: no source
+msgid "Get system paragraph list by pagination"
+msgstr "获取段落列表"
+
+#: no source
+msgid "Get system QA template"
+msgstr "获取系统问答模板"
+
+#: no source
+msgid "Get system role member list"
+msgstr "获取系统角色成员列表"
+
+#: no source
+msgid "Get System Task source trigger details"
+msgstr "获取系统任务来源触发器详情"
+
+#: no source
+msgid "Get system tool"
+msgstr "获取工具"
+
+#: no source
+msgid "Get system tool by id"
+msgstr "获取工具"
+
+#: no source
+msgid "Get system tool list by pagination"
+msgstr "获取工具列表"
+
+#: no source
+msgid "Get system workspace list"
+msgstr "获取系统工作空间列表"
+
+#: no source
+msgid "Get system workspace member list"
+msgstr "获取系统工作空间成员列表"
+
+#: no source
+msgid "Get SystemAPIKey List"
+msgstr "获取系统 API 密钥列表"
+
+#: apps/trigger/views/trigger.py:318
+#: apps/trigger/views/trigger.py:319
+#: apps/trigger/views/trigger.py:320
+msgid "Get Task source trigger details"
+msgstr "获取资源端触发器详情"
+
+#: apps/application/views/application.py:75
+#: apps/application/views/application.py:76
+#: apps/application/views/application.py:77
+msgid "Get the application list"
+msgstr "获取智能体列表"
+
+#: apps/application/views/application.py:94
+#: apps/application/views/application.py:95
+#: apps/application/views/application.py:96
+msgid "Get the application list by page"
+msgstr "分页获取智能体列表"
+
+#: apps/application/views/application_version.py:30
+#: apps/application/views/application_version.py:31
+#: apps/application/views/application_version.py:32
+msgid "Get the application version list"
+msgstr "获取智能体版本列表"
+
+#: apps/application/views/application_chat.py:44
+#: apps/application/views/application_chat.py:45
+#: apps/application/views/application_chat.py:46
+msgid "Get the conversation list"
+msgstr "获取对话列表"
+
+#: apps/application/views/application_chat.py:69
+#: apps/application/views/application_chat.py:70
+#: apps/application/views/application_chat.py:71
+msgid "Get the conversation list by page"
+msgstr "分页获取对话列表"
+
+#: apps/application/views/application_chat_record.py:31
+#: apps/application/views/application_chat_record.py:32
+#: apps/application/views/application_chat_record.py:33
+msgid "Get the conversation record list"
+msgstr "获取对话记录列表"
+
+#: apps/application/views/application_chat_record.py:57
+#: apps/application/views/application_chat_record.py:58
+#: apps/application/views/application_chat_record.py:59
+msgid "Get the conversation record list by page"
+msgstr "分页获取对话记录列表"
+
+#: apps/knowledge/views/knowledge.py:220
+#: apps/knowledge/views/knowledge.py:221
+#: apps/knowledge/views/knowledge.py:222
+msgid "Get the knowledge base paginated list"
+msgstr "获取知识库分页列表"
+
+#: apps/knowledge/views/knowledge_workflow_version.py:40
+#: apps/knowledge/views/knowledge_workflow_version.py:41
+#: apps/knowledge/views/knowledge_workflow_version.py:42
+msgid "Get the knowledge version list"
+msgstr ""
+
+#: apps/application/views/application_version.py:54
+#: apps/application/views/application_version.py:55
+#: apps/application/views/application_version.py:56
+msgid "Get the list of application versions by page"
+msgstr "分页获取智能体版本列表"
+
+#: apps/knowledge/views/knowledge_workflow_version.py:64
+#: apps/knowledge/views/knowledge_workflow_version.py:65
+#: apps/knowledge/views/knowledge_workflow_version.py:66
+msgid "Get the list of knowledge versions by page"
+msgstr ""
+
+#: apps/application/views/application_chat_record.py:140
+#: apps/application/views/application_chat_record.py:141
+#: apps/application/views/application_chat_record.py:142
+msgid "Get the list of marked paragraphs"
+msgstr "获取标记段落列表"
+
+#: apps/tools/views/tool_workflow.py:158
+#: apps/tools/views/tool_workflow.py:159
+#: apps/tools/views/tool_workflow.py:160
+msgid "Get the list of MCP tools"
+msgstr ""
+
+#: apps/knowledge/views/problem.py:232
+#: apps/knowledge/views/problem.py:233
+#: apps/knowledge/views/problem.py:234
+msgid "Get the list of questions by page"
+msgstr "分页获取问题列表"
+
+#: no source
+msgid "Get the list of shared questions by page"
+msgstr "分页获取问题列表"
+
+#: no source
+msgid "Get the list of system questions by page"
+msgstr "分页获取问题列表"
+
+#: apps/knowledge/views/termbase.py:238
+#: apps/knowledge/views/termbase.py:239
+#: apps/knowledge/views/termbase.py:240
+msgid "Get the list of termbase by page"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:65
+#: apps/tools/views/tool_workflow_version.py:66
+#: apps/tools/views/tool_workflow_version.py:67
+msgid "Get the list of tool versions by page"
+msgstr ""
+
+#: apps/models_provider/views/provide.py:92
+#: apps/models_provider/views/provide.py:93
+#: apps/models_provider/views/provide.py:94
+msgid "Get the model creation form"
+msgstr "获取模型创建表单"
+
+#: apps/chat/views/chat.py:184
+#: apps/chat/views/chat.py:185
+#: apps/chat/views/chat.py:186
+msgid "Get the session id according to the application id"
+msgstr "根据智能体 ID 获取会话 ID"
+
+#: no source
+msgid "Get the System trigger list of source"
+msgstr "获取来源的系统触发器列表"
+
+#: apps/trigger/views/trigger_task.py:28
+#: apps/trigger/views/trigger_task.py:29
+#: apps/trigger/views/trigger_task.py:30
+msgid "Get the task list of triggers"
+msgstr "获取触发器任务列表"
+
+#: apps/tools/views/tool_workflow_version.py:41
+#: apps/tools/views/tool_workflow_version.py:42
+#: apps/tools/views/tool_workflow_version.py:43
+msgid "Get the tool version list"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:79
+#: apps/trigger/views/trigger.py:80
+#: apps/trigger/views/trigger.py:81
+msgid "Get the trigger list"
+msgstr "获取触发器列表"
+
+#: apps/trigger/views/trigger.py:227
+#: apps/trigger/views/trigger.py:228
+#: apps/trigger/views/trigger.py:229
+msgid "Get the trigger list by page"
+msgstr "分页获取触发器列表"
+
+#: apps/trigger/views/trigger.py:290
+#: apps/trigger/views/trigger.py:291
+#: apps/trigger/views/trigger.py:292
+msgid "Get the trigger list of source"
+msgstr "获取资源端触发器列表"
+
+#: apps/tools/views/tool.py:149
+#: apps/tools/views/tool.py:150
+#: apps/tools/views/tool.py:151
 msgid "Get tool"
 msgstr "获取工具"
 
-#: apps/tools/views/tool.py:141 apps/tools/views/tool.py:142
-#: apps/tools/views/tool.py:143
-msgid "Delete tool"
-msgstr "删除工具"
+#: apps/tools/views/tool.py:68
+#: apps/tools/views/tool.py:69
+#: apps/tools/views/tool.py:70
+msgid "Get tool by folder"
+msgstr "通过文件夹获取工具"
 
-#: apps/tools/views/tool.py:167 apps/tools/views/tool.py:168
-#: apps/tools/views/tool.py:169
+#: apps/tools/views/tool.py:314
+#: apps/tools/views/tool.py:315
+msgid "Get tool list"
+msgstr "获取工具列表"
+
+#: apps/tools/views/tool.py:313
+msgid "Get tool list "
+msgstr ""
+
+#: apps/tools/views/tool.py:282
+#: apps/tools/views/tool.py:283
+#: apps/tools/views/tool.py:284
 msgid "Get tool list by pagination"
 msgstr "获取工具列表"
 
-#: apps/tools/views/tool.py:195 apps/tools/views/tool.py:196
-#: apps/tools/views/tool.py:197
+#: apps/tools/views/tool.py:640
+#: apps/tools/views/tool.py:641
+#: apps/tools/views/tool.py:642
+msgid "Get tool record"
+msgstr ""
+
+#: apps/tools/views/tool.py:611
+#: apps/tools/views/tool.py:612
+#: apps/tools/views/tool.py:613
+msgid "Get tool records"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:90
+#: apps/tools/views/tool_workflow_version.py:91
+#: apps/tools/views/tool_workflow_version.py:92
+msgid "Get tool version details"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:100
+#: apps/tools/views/tool_workflow.py:101
+#: apps/tools/views/tool_workflow.py:102
+msgid "Get tool workflow"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:105
+#: apps/trigger/views/trigger.py:106
+#: apps/trigger/views/trigger.py:107
+msgid "Get trigger details"
+msgstr "获取触发器详情"
+
+#: apps/oss/views/file.py:76
+#: apps/oss/views/file.py:78
+#: apps/oss/views/file.py:79
+msgid "Get url"
+msgstr ""
+
+#: apps/system_manage/views/user_resource_permission.py:110
+#: apps/system_manage/views/user_resource_permission.py:111
+#: apps/system_manage/views/user_resource_permission.py:112
+msgid "Get user authorization status of resource"
+msgstr "获取资源对用户的授权状态"
+
+#: apps/system_manage/views/user_resource_permission.py:176
+#: apps/system_manage/views/user_resource_permission.py:177
+#: apps/system_manage/views/user_resource_permission.py:178
+msgid "Get user authorization status of resource by page"
+msgstr "分页获取资源对用户的授权状态"
+
+#: no source
+msgid "Get user group list"
+msgstr "获取用户组列表"
+
+#: apps/users/views/user.py:219
+#: apps/users/views/user.py:220
+#: apps/users/views/user.py:221
+msgid "Get user information"
+msgstr "获取用户信息"
+
+#: no source
+msgid "Get user list by group"
+msgstr "获取用户组列表"
+
+#: apps/users/views/user.py:146
+#: apps/users/views/user.py:147
+#: apps/users/views/user.py:148
+msgid "Get user list under workspace"
+msgstr "获取工作空间下用户列表"
+
+#: apps/users/views/user.py:161
+#: apps/users/views/user.py:162
+#: apps/users/views/user.py:163
+msgid "Get user member under workspace"
+msgstr "获取工作空间下用户成员"
+
+#: apps/users/views/user.py:284
+#: apps/users/views/user.py:285
+#: apps/users/views/user.py:286
+msgid "Get user paginated list"
+msgstr "获取用户分页列表"
+
+#: apps/system_manage/views/valid.py:25
+#: apps/system_manage/views/valid.py:26
+#: apps/system_manage/views/valid.py:27
+msgid "Get verification results"
+msgstr "获取验证结果"
+
+#: no source
+msgid "Get workspace list"
+msgstr "获取工作空间列表"
+
+#: no source
+msgid "Get workspace list by current user"
+msgstr "获取当前用户工作空间列表"
+
+#: no source
+msgid "Get workspace list by user"
+msgstr "根据用户获取工作空间列表"
+
+#: no source
+msgid "Get workspace member list"
+msgstr "获取工作空间成员列表"
+
+#: no source
+msgid "Get Workspace role list"
+msgstr "获取工作空间角色列表"
+
+#: no source
+msgid "Get workspace role member list"
+msgstr "获取工作空间角色成员列表"
+
+#: apps/chat/serializers/chat.py:91
+msgid "Global variables"
+msgstr "全局变量"
+
+#: no source
+msgid "Good at common conversational tasks, supports 32K contexts"
+msgstr "擅长通用对话任务，支持 32K 上下文"
+
+#: no source
+msgid "Good at handling programming tasks, supports 16K contexts"
+msgstr "擅长处理编程任务，支持 16K 上下文"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:53
+msgid "gpt-3.5-turbo snapshot on January 25, 2024, supporting context length 16,385 tokens"
+msgstr "2024年1月25日的gpt-3.5-turbo快照，支持上下文长度16,385 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:57
+msgid "gpt-3.5-turbo snapshot on November 6, 2023, supporting context length 16,385 tokens"
+msgstr "2023年11月6日的gpt-3.5-turbo快照，支持上下文长度16,385 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:69
+msgid "gpt-4-turbo snapshot on April 9, 2024, supporting context length 128,000 tokens"
+msgstr "2024年4月9日的gpt-4-turbo快照，支持上下文长度128,000 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:72
+msgid "gpt-4-turbo snapshot on January 25, 2024, supporting context length 128,000 tokens"
+msgstr "2024年1月25日的gpt-4-turbo快照，支持上下文长度128,000 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:75
+msgid "gpt-4-turbo snapshot on November 6, 2023, supporting context length 128,000 tokens"
+msgstr "2023年11月6日的gpt-4-turbo快照，支持上下文长度128,000 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:65
+msgid "gpt-4o snapshot on May 13, 2024, supporting context length 128,000 tokens"
+msgstr "2024年5月13日的gpt-4o快照，支持上下文长度128,000 tokens"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:19
+msgid "Group id"
+msgstr ""
+
+#: no source
+msgid "Group ID"
+msgstr "用户组 ID"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:20
+msgid "group_name"
+msgstr ""
+
+#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:34
+msgid "Have strong multi-modal understanding capabilities. Able to understand up to five images simultaneously and supports video content understanding"
+msgstr "具有强大的多模态理解能力。能够同时理解多达五张图像，并支持视频内容理解"
+
+#: no source
+msgid "header font color"
+msgstr "标题字体颜色"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:71
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:73
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:76
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:73
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:73
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tti.py:61
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py:44
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:52
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:56
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:33
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:53
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:46
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:50
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:36
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:55
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:68
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:54
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:54
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:52
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/gemini_model_provider/model/stt.py:48
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:56
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:35
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:47
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:47
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/minimax_model_provider/model/tts.py:44
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:37
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:54
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:54
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:36
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:55
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:54
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:22
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:56
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/tencent_model_provider/model/tti.py:56
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:49
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:44
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:52
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:56
+#: apps/models_provider/impl/volcanic_engine_model_provider/model/tts.py:79
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:46
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:66
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:43
+#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:75
+#: apps/models_provider/impl/xf_model_provider/model/tts/super_humanoid_tts.py:101
+#: apps/models_provider/impl/xf_model_provider/model/tts/tts.py:103
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:31
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:52
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:44
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:44
+#: apps/models_provider/impl/xinference_model_provider/model/tts.py:48
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:52
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:55
+#: apps/models_provider/impl/zhipu_model_provider/model/tti.py:54
+msgid "Hello"
+msgstr "你好"
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:48
+msgid "High-speed version of M2.7 for low-latency scenarios. 204K context window"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:22
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:17
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:16
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:15
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:14
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:18
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:18
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:16
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:16
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:13
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:18
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:19
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:18
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:23
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:14
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:16
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:16
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:41
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:16
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:16
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:16
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:22
+msgid "Higher values make the output more random, while lower values make it more focused and deterministic"
+msgstr "较高的数值会使输出更加随机，而较低的数值会使其更加集中和确定"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:34
+msgid "Hindi"
+msgstr "印地语"
+
+#: apps/application/serializers/application.py:350
+#: apps/application/serializers/application.py:597
+msgid "Historical chat records"
+msgstr "历史聊天记录"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:32
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:27
+msgid "History Questions"
+msgstr "历史问题"
+
+#: apps/knowledge/serializers/document.py:170
+#: apps/knowledge/serializers/document.py:248
+#: apps/knowledge/serializers/document.py:478
+msgid "hit handling method"
+msgstr "命中处理方法"
+
+#: apps/knowledge/serializers/knowledge.py:770
+msgid "Hit handling method"
+msgstr "命中处理方式"
+
+#: apps/knowledge/serializers/document.py:1505
+msgid "Hit handling method is required"
+msgstr "命中处理方法是必需的"
+
+#: apps/knowledge/views/knowledge.py:284
+#: apps/knowledge/views/knowledge.py:285
+#: apps/knowledge/views/knowledge.py:286
+msgid "Hit test list"
+msgstr "命中测试列表"
+
+#: apps/common/constants/permission_constants.py:360
+#: apps/common/constants/permission_constants.py:418
+#: apps/common/constants/permission_constants.py:428
+msgid "Hit-Test"
+msgstr "命中测试"
+
+#: apps/common/constants/permission_constants.py:409
+#: apps/homepage/views/homepage.py:38
+#: apps/homepage/views/homepage.py:63
+#: apps/homepage/views/homepage.py:88
+#: apps/homepage/views/homepage.py:113
+#: apps/homepage/views/homepage.py:138
+#: apps/homepage/views/homepage.py:163
+#: apps/homepage/views/homepage.py:188
+#: apps/homepage/views/homepage.py:212
+#: apps/homepage/views/homepage.py:237
+#: apps/homepage/views/homepage.py:264
+#: apps/homepage/views/homepage.py:285
+#: apps/homepage/views/homepage.py:306
+#: apps/homepage/views/homepage.py:327
+msgid "Home page"
+msgstr "首页"
+
+#: apps/chat/api/chat_embed_api.py:24
+msgid "host"
+msgstr ""
+
+#: apps/chat/serializers/chat_embed_serializers.py:25
+msgid "Host"
+msgstr ""
+
+#: apps/oss/serializers/file.py:99
+msgid "HTTP Range"
+msgstr ""
+
+#: apps/oss/serializers/file.py:100
+msgid "HTTP Range header for partial content requests, e.g., \"bytes=0-1023\""
+msgstr ""
+
+#: no source
+msgid "HttpClient query failed: "
+msgstr "HttpClient 查询失败: "
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:102
+msgid "Hunyuan graph model"
+msgstr "混元生图模型"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:71
+msgid "Hunyuan's latest code generation model, after training the base model with 200B high-quality code data, and iterating on high-quality SFT data for half a year, the context long window length has been increased to 8K, and it ranks among the top in the automatic evaluation indicators of code generation in the five major languages; the five major languages In the manual high-quality evaluation of 10 comprehensive code tasks that consider all aspects, the performance is in the first echelon."
+msgstr "混元最新代码生成模型，经过 200B 高质量代码数据增训基座模型，迭代半年高质量 SFT 数据训练，上下文长窗口长度增大到 8K，五大语言代码生成自动评测指标上位居前列；五大语言10项考量各方面综合代码任务人工高质量评测上，性能处于第一梯队"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:65
+msgid "Hunyuan's latest MOE architecture FunctionCall model has been trained with high-quality FunctionCall data and has a context window of 32K, leading in multiple dimensions of evaluation indicators."
+msgstr "混元最新 MOE 架构 FunctionCall 模型，经过高质量的 FunctionCall 数据训练，上下文窗口达 32K，在多个维度的评测指标上处于领先。"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:59
+msgid "Hunyuan's latest version of the role-playing model, a role-playing model launched by Hunyuan's official fine-tuning training, is based on the Hunyuan model combined with the role-playing scene data set for additional training, and has better basic effects in role-playing scenes."
+msgstr "混元最新版角色扮演模型，混元官方精调训练推出的角色扮演模型，基于混元模型结合角色扮演场景数据集进行增训，在角色扮演场景具有更好的基础效果"
+
+#: apps/application/serializers/application.py:611
+msgid "Icon"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:19
+#: apps/tools/serializers/tool.py:1379
+msgid "icon"
+msgstr "图标"
+
+#: no source
+msgid "icon url"
+msgstr "图标"
+
+#: apps/knowledge/serializers/knowledge.py:1360
+#: apps/knowledge/serializers/knowledge.py:1505
+#: apps/users/api/user.py:76
+msgid "id"
+msgstr "ID"
+
+#: apps/knowledge/serializers/knowledge.py:1280
+#: apps/knowledge/serializers/knowledge.py:1386
+msgid "id does not exist"
+msgstr "知识库 ID 不存在"
+
+#: apps/knowledge/serializers/common.py:52
+#: apps/knowledge/serializers/document.py:124
+#: apps/knowledge/serializers/document.py:231
+#: apps/knowledge/serializers/document.py:247
+#: apps/trigger/serializers/trigger.py:32
+msgid "id list"
+msgstr "ID 列表"
+
+#: apps/application/serializers/application.py:1754
+msgid "id list cannot be empty"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:114
+msgid "Ideal for content creation, conversational AI, language understanding, R&D, and enterprise applications"
+msgstr "非常适合内容创作、对话式人工智能、语言理解、研发和企业智能体"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:120
+msgid "Ideal for limited computing power and resources, edge devices, and faster training times."
+msgstr "非常适合有限的计算能力和资源、边缘设备和更快的训练时间。"
+
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:17
+msgid "If not passed, the default value is 'zh'"
+msgstr "如果未传递，则默认值为'zh'"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:15
+msgid "If not passed, the default value is 16000"
+msgstr "如果未传入，则默认值为 16000"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:12
+msgid "If not passed, the default value is 16k_zh (Chinese universal)"
+msgstr "如果未传递，默认值为 16k_zh（中文通用）"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:13
+msgid "If not passed, the default value is 201 (Japanese anime style)"
+msgstr "如果未传递，则默认值为201（日本动漫风格）"
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:19
+msgid "If not passed, the default value is iat"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:24
+msgid "If not passed, the default value is mandarin"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:14
+msgid "If not passed, the default value is streaming_asr_demo"
+msgstr "如果未传入，则默认值为 streaming_asr_demo"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:13
+msgid "If not passed, the default value is What is this audio saying? Only answer the audio content"
+msgstr "如果未传递，默认值为 这段音频在说什么，只回答音频的内容"
+
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:14
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:14
+msgid "If not passed, the default value is zh"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:14
+msgid "If not passed, the default value is zh_cn"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:49
+msgid "If not transmitted, the default value is 768:768."
+msgstr "不传默认使用768:768。"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:16
+msgid "If the gap between width, height and 512 is too large, the picture rendering effect will be poor and the probability of excessive delay will increase significantly. Recommended ratio and corresponding width and height before super score: width*height"
+msgstr "宽、高与512差距过大，则出图效果不佳、延迟过长概率显著增加。超分前建议比例及对应宽高：width*height"
+
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:85
+msgid "iFlytek Spark"
+msgstr "讯飞星火"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:23
+msgid "iFlytek Xiaojing"
+msgstr "讯飞小婧"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:22
+msgid "iFlytek Xiaoping"
+msgstr "讯飞小萍"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:20
+msgid "iFlytek Xiaoyan"
+msgstr "讯飞小燕"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:21
+msgid "iFlytek Xujiu"
+msgstr "讯飞许久"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:24
+msgid "iFlytek Xuxiaobao"
+msgstr "讯飞许小宝"
+
+#: apps/application/serializers/application.py:684
+#: apps/application/serializers/application.py:1454
+#: apps/knowledge/serializers/knowledge_workflow.py:381
+#: apps/knowledge/serializers/knowledge_workflow.py:628
+#: apps/tools/serializers/tool.py:496
+#: apps/tools/serializers/tool_workflow.py:362
+msgid "Illegal download callback url"
+msgstr ""
+
+#: apps/application/serializers/application.py:660
+#: apps/application/serializers/application.py:1395
+#: apps/knowledge/serializers/knowledge_workflow.py:367
+#: apps/knowledge/serializers/knowledge_workflow.py:614
+#: apps/tools/serializers/tool.py:481
+#: apps/tools/serializers/tool.py:1319
+#: apps/tools/serializers/tool_workflow.py:346
+msgid "Illegal download url"
+msgstr ""
+
+#: apps/chat/serializers/chat_authentication.py:120
+msgid "Illegal User"
+msgstr "非法用户"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:25
+msgid "illustration"
+msgstr "插图"
+
+#: no source
+msgid "Image download failed, check network"
+msgstr "图片下载失败，请检查网络"
+
+#: apps/models_provider/base_model_provider.py:152
+msgid "Image Generation"
+msgstr "图片生成"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:15
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:14
+msgid "Image size"
+msgstr "图片尺寸"
+
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:15
+msgid "Image size, only cogview-3-plus supports this parameter. Optional range: [1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440], the default is 1024x1024."
+msgstr "图片尺寸，仅 cogview-3-plus 支持该参数。可选范围：[1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440]，默认是1024x1024。"
+
+#: apps/models_provider/base_model_provider.py:156
+msgid "Image to Video"
+msgstr "图生视频"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:24
+msgid "impasto style"
+msgstr "厚涂风格"
+
+#: apps/common/constants/permission_constants.py:361
+msgid "Import"
+msgstr "导入"
+
+#: apps/application/views/application.py:115
+#: apps/application/views/application.py:116
+#: apps/application/views/application.py:117
+msgid "Import Application"
+msgstr "导入智能体"
+
+#: no source
+msgid "Import documents to the lark knowledge base"
+msgstr "导入文档到飞书知识库"
+
+#: apps/knowledge/views/knowledge.py:448
+#: apps/knowledge/views/knowledge.py:449
+#: apps/knowledge/views/knowledge.py:450
+msgid "Import knowledge bundle"
+msgstr "导入知识库"
+
+#: apps/knowledge/views/knowledge_workflow.py:325
+#: apps/knowledge/views/knowledge_workflow.py:326
+#: apps/knowledge/views/knowledge_workflow.py:327
+msgid "Import knowledge workflow"
+msgstr "导入知识工作流"
+
+#: apps/knowledge/views/document.py:1239
+#: apps/knowledge/views/document.py:1240
+#: apps/knowledge/views/document.py:1241
+msgid "Import QA and create documentation"
+msgstr "导入问答并创建文档"
+
+#: no source
+msgid "Import QA and create shared documentation"
+msgstr "导入问答并创建文档"
+
+#: no source
+msgid "Import shared tool"
+msgstr "导入共享工具"
+
+#: apps/knowledge/views/document.py:1281
+#: apps/knowledge/views/document.py:1282
+#: apps/knowledge/views/document.py:1283
+msgid "Import tables and create documents"
+msgstr "导入表格并创建文档"
+
+#: no source
+msgid "Import tables and create shared documents"
+msgstr "导入表格并创建文档"
+
+#: apps/tools/views/tool.py:345
+#: apps/tools/views/tool.py:346
+#: apps/tools/views/tool.py:347
 msgid "Import tool"
 msgstr "导入工具"
 
-#: apps/tools/views/tool.py:218 apps/tools/views/tool.py:219
-#: apps/tools/views/tool.py:220
-msgid "Export tool"
-msgstr "导出工具"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:27
+msgid "Impressionism 1 (Monet)"
+msgstr "印象派1（莫奈）"
 
-#: apps/tools/views/tool.py:244 apps/tools/views/tool.py:245
-#: apps/tools/views/tool.py:246
-msgid "Check code"
-msgstr "检查代码"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:28
+msgid "Impressionism 2"
+msgstr "印象派2"
 
-#: apps/tools/views/tool.py:268 apps/tools/views/tool.py:269
-#: apps/tools/views/tool.py:270
-msgid "Edit tool icon"
-msgstr "修改工具图标"
+#: apps/application/serializers/application_chat.py:173
+msgid "inaccurate"
+msgstr "内容不准确"
 
-#: apps/users/api/user.py:154
-msgid "Email or Username"
-msgstr "邮箱或用户名"
+#: apps/homepage/api/home_page_api.py:386
+msgid "Inactive model count"
+msgstr "停用模型数量"
+
+#: apps/homepage/api/home_page_api.py:349
+msgid "Inactive tool count"
+msgstr "停用工具数量"
+
+#: apps/application/serializers/application_chat.py:173
+msgid "incomplete"
+msgstr "内容不完善"
+
+#: apps/trigger/serializers/task_source_trigger.py:51
+msgid "Incorrect trigger task"
+msgstr "触发器任务不正确"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:27
+msgid "Indonesian language"
+msgstr "印尼语"
+
+#: apps/tools/serializers/tool.py:291
+#: apps/tools/serializers/tool.py:307
+#: apps/tools/serializers/tool.py:330
+msgid "init field list"
+msgstr "内置字段列表"
+
+#: apps/tools/serializers/tool.py:1574
+msgid "Init Field List"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:308
+#: apps/tools/serializers/tool.py:331
+msgid "init params"
+msgstr "内置参数"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:18
+msgid "ink painting"
+msgstr "水墨画"
+
+#: apps/tools/serializers/tool.py:289
+#: apps/tools/serializers/tool.py:306
+#: apps/tools/serializers/tool.py:329
+msgid "input field list"
+msgstr "输入字段列表"
+
+#: apps/tools/serializers/tool.py:1575
+msgid "Input Field List"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:34
+#: apps/tools/serializers/tool.py:275
+msgid "input type"
+msgstr "输入类型"
+
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:14
+#: apps/application/flow/step_node/variable_splitting_node/i_variable_splitting_node.py:14
+msgid "input variable"
+msgstr ""
+
+#: no source
+msgid "input_field_list must be a dict"
+msgstr "input_field_list 必须是字典类型"
+
+#: apps/maxkb/settings/base/model.py:99
+#: apps/maxkb/settings/base/web.py:116
+msgid "Intelligent customer service platform"
+msgstr "强大易用的企业级智能体平台"
+
+#: no source
+msgid "Internal role"
+msgstr "内置角色"
+
+#: apps/trigger/serializers/trigger.py:220
+msgid "interval_unit must be one of %s"
+msgstr "interval_unit 必须是以下值之一: %s"
+
+#: apps/trigger/serializers/trigger.py:215
+msgid "interval_value must be an integer greater than or equal to 1"
+msgstr "interval_value 必须是大于或等于 1 的整数"
+
+#: apps/users/serializers/login.py:291
+msgid "Invalid access token"
+msgstr "无效的访问令牌"
+
+#: apps/chat/serializers/chat_authentication.py:49
+#: apps/chat/serializers/chat_authentication.py:60
+#: apps/chat/serializers/chat_authentication.py:62
+msgid "Invalid access_token"
+msgstr "access_token 无效"
+
+#: apps/application/serializers/application_chat_link.py:79
+msgid "Invalid chat record ids"
+msgstr "无效的聊天记录ID"
+
+#: apps/trigger/serializers/trigger.py:236
+msgid "Invalid cron expression: %s"
+msgstr "Cron 表达式不合法：%s"
+
+#: apps/users/serializers/login.py:112
+#: apps/users/serializers/user.py:551
+#: apps/users/views/user.py:396
+msgid "Invalid encrypted data"
+msgstr ""
+
+#: no source
+msgid "Invalid json format."
+msgstr "json 格式无效。"
+
+#: no source
+msgid "Invalid license file format"
+msgstr "无效的 license 文件格式"
+
+#: no source
+msgid "Invalid role type"
+msgstr "无效的角色类型"
+
+#: no source
+msgid "Invalid Slack request"
+msgstr "Slack 请求无效"
+
+#: no source
+msgid "Invalid source type"
+msgstr "无效的来源类型"
+
+#: apps/trigger/serializers/trigger.py:162
+msgid "Invalid time format: %s, must be HH:MM (e.g., 09:00)"
+msgstr "时间格式无效: %s，必须是 HH:MM 格式 (例如: 09:00)"
+
+#: apps/application/serializers/application_chat.py:221
+msgid "Ip Address"
+msgstr "IP地址"
+
+#: apps/chat/serializers/chat.py:221
+#: apps/chat/serializers/chat.py:292
+#: apps/chat/serializers/chat.py:537
+msgid "IP Address"
+msgstr ""
+
+#: no source
+msgid "ip_address"
+msgstr "IP 地址"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:43
+#: apps/knowledge/serializers/knowledge.py:772
+#: apps/knowledge/serializers/paragraph.py:76
+#: apps/tools/serializers/tool.py:293
+#: apps/tools/serializers/tool.py:311
+#: apps/trigger/serializers/trigger.py:255
+#: apps/trigger/serializers/trigger.py:277
+#: apps/trigger/serializers/trigger.py:312
+#: apps/trigger/serializers/trigger.py:641
+#: apps/users/serializers/user.py:253
+msgid "Is active"
+msgstr "是否启用"
+
+#: apps/users/serializers/user.py:408
+msgid "Is Active"
+msgstr "是否启用"
+
+#: no source
+msgid "Is Append"
+msgstr "是否追加"
+
+#: no source
+msgid "is auth"
+msgstr "是否认证"
+
+#: no source
+msgid "Is auth"
+msgstr "是否授权"
+
+#: apps/application/serializers/application_api_key.py:26
+msgid "Is cross-domain allowed"
+msgstr "是否允许跨域"
+
+#: apps/application/serializers/application_chat.py:39
+msgid "Is delete"
+msgstr "删除"
+
+#: apps/users/serializers/user.py:56
+msgid "Is Edit Password"
+msgstr "是否编辑密码"
+
+#: no source
+msgid "Is Exist"
+msgstr "是否存在"
+
+#: apps/application/serializers/application_access_token.py:26
+msgid "Is it enabled"
+msgstr "是否开启"
+
+#: apps/application/api/application_chat_record.py:53
+#: apps/application/serializers/application_chat_record.py:94
+msgid "Is it in order"
+msgstr "是否有序"
+
+#: apps/application/serializers/application_api_key.py:32
+msgid "Is permanent"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:77
+msgid "Is the answer in streaming mode"
+msgstr "是否流式回答"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:25
+msgid "Is this field required"
+msgstr "{keys} 是必填项"
+
+#: apps/trigger/serializers/trigger.py:33
+msgid "is_active"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:23
+msgid "Japanese"
+msgstr "日语"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:37
+msgid "Japanese animation"
+msgstr "日系动漫"
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:22
+msgid "Japanese male"
+msgstr "日语男"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:14
+msgid "Key"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:341
+#: apps/common/constants/permission_constants.py:354
+#: apps/common/constants/permission_constants.py:412
+#: apps/common/constants/permission_constants.py:422
+#: apps/common/constants/permission_constants.py:435
+#: apps/knowledge/views/knowledge_workflow.py:259
+msgid "Knowledge"
+msgstr "知识库"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:267
+msgid "knowledge action id"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:42
+#: apps/knowledge/views/knowledge.py:71
+#: apps/knowledge/views/knowledge.py:98
+#: apps/knowledge/views/knowledge.py:124
+#: apps/knowledge/views/knowledge.py:149
+#: apps/knowledge/views/knowledge.py:187
+#: apps/knowledge/views/knowledge.py:225
+#: apps/knowledge/views/knowledge.py:255
+#: apps/knowledge/views/knowledge.py:290
+#: apps/knowledge/views/knowledge.py:340
+#: apps/knowledge/views/knowledge.py:367
+#: apps/knowledge/views/knowledge.py:394
+#: apps/knowledge/views/knowledge.py:421
+#: apps/knowledge/views/knowledge.py:454
+#: apps/knowledge/views/knowledge.py:488
+#: apps/knowledge/views/knowledge.py:517
+#: apps/knowledge/views/knowledge.py:575
+#: apps/knowledge/views/knowledge.py:600
+#: apps/knowledge/views/knowledge.py:628
+#: apps/knowledge/views/knowledge_workflow.py:82
+#: apps/knowledge/views/knowledge_workflow.py:116
+#: apps/knowledge/views/knowledge_workflow.py:146
+#: apps/knowledge/views/knowledge_workflow.py:175
+#: apps/knowledge/views/knowledge_workflow.py:204
+#: apps/knowledge/views/knowledge_workflow.py:234
+#: apps/knowledge/views/knowledge_workflow.py:298
+#: apps/knowledge/views/knowledge_workflow.py:331
+#: apps/knowledge/views/knowledge_workflow.py:372
+#: apps/knowledge/views/knowledge_workflow.py:403
+#: apps/knowledge/views/knowledge_workflow.py:433
+#: apps/knowledge/views/knowledge_workflow.py:464
+msgid "Knowledge Base"
+msgstr "知识库"
+
+#: no source
+msgid "knowledge Base"
+msgstr "知识库"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:89
+msgid "knowledge base data"
+msgstr ""
+
+#: apps/application/serializers/application.py:231
+#: apps/application/serializers/application_chat_record.py:250
+#: apps/application/serializers/application_chat_record.py:376
+#: apps/application/serializers/application_chat_record.py:476
+msgid "Knowledge base id"
+msgstr "知识库"
+
+#: apps/application/serializers/application.py:232
+msgid "Knowledge Base List"
+msgstr "知识库列表"
+
+#: no source
+msgid "Knowledge base name duplicate!"
+msgstr "知识库名称重复！"
+
+#: no source
+msgid "Knowledge base not found!"
+msgstr "知识库未找到！"
+
+#: apps/knowledge/serializers/common.py:125
+#: apps/knowledge/serializers/common.py:161
+msgid "Knowledge base setting error, please reset the knowledge base"
+msgstr "知识库设置错误，请重置知识库"
+
+#: apps/knowledge/views/document.py:59
+#: apps/knowledge/views/document.py:92
+#: apps/knowledge/views/document.py:132
+#: apps/knowledge/views/document.py:158
+#: apps/knowledge/views/document.py:191
+#: apps/knowledge/views/document.py:230
+#: apps/knowledge/views/document.py:273
+#: apps/knowledge/views/document.py:293
+#: apps/knowledge/views/document.py:331
+#: apps/knowledge/views/document.py:369
+#: apps/knowledge/views/document.py:407
+#: apps/knowledge/views/document.py:444
+#: apps/knowledge/views/document.py:481
+#: apps/knowledge/views/document.py:519
+#: apps/knowledge/views/document.py:559
+#: apps/knowledge/views/document.py:599
+#: apps/knowledge/views/document.py:638
+#: apps/knowledge/views/document.py:677
+#: apps/knowledge/views/document.py:716
+#: apps/knowledge/views/document.py:754
+#: apps/knowledge/views/document.py:845
+#: apps/knowledge/views/document.py:890
+#: apps/knowledge/views/document.py:923
+#: apps/knowledge/views/document.py:956
+#: apps/knowledge/views/document.py:981
+#: apps/knowledge/views/document.py:1014
+#: apps/knowledge/views/document.py:1044
+#: apps/knowledge/views/document.py:1078
+#: apps/knowledge/views/document.py:1159
+#: apps/knowledge/views/document.py:1203
+#: apps/knowledge/views/document.py:1245
+#: apps/knowledge/views/document.py:1287
+#: apps/knowledge/views/document.py:1326
+#: apps/knowledge/views/document.py:1340
+msgid "Knowledge Base/Documentation"
+msgstr "知识库/文档"
+
+#: apps/knowledge/views/paragraph.py:29
+#: apps/knowledge/views/paragraph.py:55
+#: apps/knowledge/views/paragraph.py:87
+#: apps/knowledge/views/paragraph.py:110
+#: apps/knowledge/views/paragraph.py:149
+#: apps/knowledge/views/paragraph.py:181
+#: apps/knowledge/views/paragraph.py:216
+#: apps/knowledge/views/paragraph.py:244
+#: apps/knowledge/views/paragraph.py:282
+#: apps/knowledge/views/paragraph.py:315
+#: apps/knowledge/views/paragraph.py:345
+#: apps/knowledge/views/paragraph.py:383
+#: apps/knowledge/views/paragraph.py:420
+#: apps/knowledge/views/paragraph.py:452
+msgid "Knowledge Base/Documentation/Paragraph"
+msgstr "知识库/文档/段落"
+
+#: apps/knowledge/views/problem.py:28
+#: apps/knowledge/views/problem.py:56
+#: apps/knowledge/views/problem.py:84
+#: apps/knowledge/views/problem.py:113
+#: apps/knowledge/views/problem.py:143
+#: apps/knowledge/views/problem.py:172
+#: apps/knowledge/views/problem.py:204
+#: apps/knowledge/views/problem.py:237
+msgid "Knowledge Base/Documentation/Paragraph/Question"
+msgstr "知识库/文档/段落/问题"
+
+#: apps/knowledge/views/termbase.py:33
+#: apps/knowledge/views/termbase.py:64
+#: apps/knowledge/views/termbase.py:99
+#: apps/knowledge/views/termbase.py:134
+#: apps/knowledge/views/termbase.py:168
+#: apps/knowledge/views/termbase.py:205
+#: apps/knowledge/views/termbase.py:243
+msgid "Knowledge Base/Documentation/Termbase"
+msgstr ""
+
+#: apps/knowledge/views/document.py:1119
+#: apps/knowledge/views/tag.py:25
+#: apps/knowledge/views/tag.py:49
+#: apps/knowledge/views/tag.py:78
+#: apps/knowledge/views/tag.py:105
+#: apps/knowledge/views/tag.py:132
+msgid "Knowledge Base/Tag"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:280
+#: apps/homepage/views/homepage.py:281
+msgid "Knowledge data aggregation"
+msgstr "知识库数据聚合"
+
+#: apps/knowledge/serializers/knowledge.py:111
+#: apps/knowledge/serializers/knowledge.py:122
+#: apps/knowledge/serializers/knowledge.py:130
+#: apps/knowledge/serializers/knowledge.py:182
+msgid "knowledge description"
+msgstr "知识库描述"
+
+#: apps/knowledge/task/embedding.py:121
+msgid "Knowledge documentation: {document_names}"
+msgstr "知识库文档: {document_names}"
+
+#: no source
+msgid "Knowledge does not exist"
+msgstr "知识库不存在"
+
+#: apps/knowledge/serializers/knowledge.py:112
+#: apps/knowledge/serializers/knowledge.py:123
+msgid "knowledge embedding"
+msgstr "知识库向量"
+
+#: apps/application/api/application_chat_record.py:129
+#: apps/knowledge/serializers/knowledge.py:1472
+#: apps/knowledge/serializers/knowledge_version.py:45
+#: apps/knowledge/serializers/knowledge_version.py:82
+#: apps/knowledge/serializers/tag.py:47
+#: apps/knowledge/serializers/tag.py:94
+#: apps/knowledge/serializers/tag.py:168
+#: apps/knowledge/serializers/tag.py:202
+msgid "Knowledge ID"
+msgstr "知识库 ID"
+
+#: apps/knowledge/serializers/document.py:355
+#: apps/knowledge/serializers/document.py:473
+#: apps/knowledge/serializers/document.py:587
+#: apps/knowledge/serializers/document.py:686
+#: apps/knowledge/serializers/document.py:1207
+#: apps/knowledge/serializers/document.py:1293
+#: apps/knowledge/serializers/document.py:1315
+#: apps/knowledge/serializers/document.py:1652
+#: apps/knowledge/serializers/document.py:1698
+#: apps/knowledge/serializers/document.py:1773
+#: apps/knowledge/serializers/document.py:1814
+#: apps/knowledge/serializers/document.py:1843
+#: apps/knowledge/serializers/document.py:1879
+#: apps/knowledge/serializers/knowledge.py:316
+#: apps/knowledge/serializers/knowledge.py:1256
+#: apps/knowledge/serializers/knowledge_workflow.py:114
+#: apps/knowledge/serializers/knowledge_workflow.py:266
+#: apps/knowledge/serializers/knowledge_workflow.py:391
+#: apps/knowledge/serializers/knowledge_workflow.py:518
+#: apps/knowledge/serializers/knowledge_workflow.py:568
+#: apps/knowledge/serializers/knowledge_workflow.py:646
+#: apps/knowledge/serializers/paragraph.py:108
+#: apps/knowledge/serializers/paragraph.py:204
+#: apps/knowledge/serializers/paragraph.py:339
+#: apps/knowledge/serializers/paragraph.py:437
+#: apps/knowledge/serializers/paragraph.py:473
+#: apps/knowledge/serializers/paragraph.py:553
+#: apps/knowledge/serializers/paragraph.py:602
+#: apps/knowledge/serializers/paragraph.py:779
+#: apps/knowledge/serializers/problem.py:64
+#: apps/knowledge/serializers/problem.py:138
+#: apps/knowledge/serializers/problem.py:198
+#: apps/knowledge/serializers/problem.py:235
+#: apps/knowledge/serializers/termbase.py:36
+#: apps/knowledge/serializers/termbase.py:66
+#: apps/knowledge/serializers/termbase.py:104
+#: apps/knowledge/serializers/termbase.py:140
+msgid "knowledge id"
+msgstr "知识库 ID"
+
+#: no source
+msgid "Knowledge id"
+msgstr "知识库 ID"
+
+#: apps/application/serializers/application_chat_record.py:396
+#: apps/knowledge/serializers/document.py:368
+#: apps/knowledge/serializers/document.py:373
+#: apps/knowledge/serializers/document.py:597
+#: apps/knowledge/serializers/document.py:695
+#: apps/knowledge/serializers/document.py:1216
+#: apps/knowledge/serializers/document.py:1325
+#: apps/knowledge/serializers/document.py:1661
+#: apps/knowledge/serializers/document.py:1709
+#: apps/knowledge/serializers/document.py:1786
+#: apps/knowledge/serializers/document.py:1827
+#: apps/knowledge/serializers/document.py:1853
+#: apps/knowledge/serializers/document.py:1890
+#: apps/knowledge/serializers/knowledge.py:333
+#: apps/knowledge/serializers/knowledge.py:1277
+#: apps/knowledge/serializers/knowledge.py:1384
+#: apps/knowledge/serializers/knowledge_version.py:92
+#: apps/knowledge/serializers/knowledge_workflow.py:657
+#: apps/knowledge/serializers/paragraph.py:119
+#: apps/knowledge/serializers/paragraph.py:215
+#: apps/knowledge/serializers/paragraph.py:449
+#: apps/knowledge/serializers/paragraph.py:488
+#: apps/knowledge/serializers/paragraph.py:563
+#: apps/knowledge/serializers/paragraph.py:619
+#: apps/knowledge/serializers/paragraph.py:790
+#: apps/knowledge/serializers/problem.py:73
+#: apps/knowledge/serializers/problem.py:148
+#: apps/knowledge/serializers/problem.py:207
+#: apps/knowledge/serializers/problem.py:245
+#: apps/knowledge/serializers/tag.py:57
+#: apps/knowledge/serializers/tag.py:104
+#: apps/knowledge/serializers/tag.py:178
+#: apps/knowledge/serializers/tag.py:212
+#: apps/knowledge/serializers/termbase.py:45
+#: apps/knowledge/serializers/termbase.py:76
+#: apps/knowledge/serializers/termbase.py:113
+#: apps/knowledge/serializers/termbase.py:150
+msgid "Knowledge id does not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:14
+msgid "knowledge id list"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1008
+msgid "knowledge id not exist"
+msgstr "知识库 ID 不存在"
+
+#: apps/knowledge/serializers/common.py:249
+#: apps/knowledge/serializers/common.py:274
+msgid "Knowledge ID or Document ID must be provided"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1505
+msgid "knowledge ids"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1486
+msgid "Knowledge is already a workflow"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:109
+#: apps/knowledge/serializers/knowledge.py:120
+#: apps/knowledge/serializers/knowledge.py:129
+#: apps/knowledge/serializers/knowledge.py:178
+msgid "knowledge name"
+msgstr "知识库名称"
+
+#: apps/knowledge/serializers/knowledge.py:1484
+msgid "Knowledge not found"
+msgstr ""
+
+#: no source
+msgid "Knowledge Resource"
+msgstr "知识库资源"
+
+#: apps/knowledge/serializers/knowledge.py:189
+msgid "knowledge scope"
+msgstr "知识库范围"
+
+#: apps/knowledge/serializers/knowledge.py:125
+msgid "knowledge selector"
+msgstr "知识库选择器"
+
+#: apps/knowledge/serializers/knowledge_version.py:83
+msgid "Knowledge version ID"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:110
+#: apps/knowledge/views/knowledge_workflow.py:111
+#: apps/knowledge/views/knowledge_workflow.py:112
+msgid "Knowledge workflow debug"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:76
+#: apps/knowledge/views/knowledge_workflow.py:77
+#: apps/knowledge/views/knowledge_workflow.py:78
+msgid "Knowledge workflow upload document"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow_version.py:45
+#: apps/knowledge/views/knowledge_workflow_version.py:69
+#: apps/knowledge/views/knowledge_workflow_version.py:94
+#: apps/knowledge/views/knowledge_workflow_version.py:116
+msgid "Knowledge/Version"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:24
+msgid "Korean"
+msgstr "韩语"
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:26
+msgid "Korean female"
+msgstr "韩语女"
+
+#: apps/models_provider/api/provide.py:35
+msgid "label"
+msgstr "标签"
+
+#: apps/application/serializers/application_access_token.py:40
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:14
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:14
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:16
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:14
+#: apps/users/serializers/user.py:1188
+msgid "language"
+msgstr "语言"
 
 #: apps/users/api/user.py:224
 msgid "Language"
 msgstr "语言"
 
-#: apps/users/serializers/login.py:29 apps/users/serializers/login.py:69
-msgid "captcha"
-msgstr "验证码"
-
-#: apps/users/serializers/login.py:50
-#: apps/xpack/serializers/chat_user_serializer.py:120
-msgid "Captcha code error or expiration"
-msgstr "验证码错误或过期"
-
-#: apps/users/serializers/login.py:55
-#: apps/xpack/serializers/auth_config_serializer.py:192
-#: apps/xpack/serializers/chat_user_serializer.py:125
-#: apps/xpack/serializers/qr_login/qr_login.py:37
-msgid "The user has been disabled, please contact the administrator!"
-msgstr "用户已被禁用，请联系管理员！"
-
-#: apps/users/serializers/user.py:47
-msgid "Is Edit Password"
-msgstr "是否编辑密码"
-
-#: apps/users/serializers/user.py:48
-msgid "permissions"
-msgstr "无权限访问"
-
-#: apps/users/serializers/user.py:58 apps/users/serializers/user.py:106
-#: apps/users/serializers/user.py:250 apps/users/serializers/user.py:557
-#: apps/users/serializers/user.py:641 apps/xpack/api/chat_user.py:107
-#: apps/xpack/serializers/chat_user.py:54
-#: apps/xpack/serializers/chat_user.py:227
-msgid "Email"
-msgstr "邮箱"
-
-#: apps/users/serializers/user.py:59 apps/users/serializers/user.py:140
-#: apps/xpack/serializers/chat_user.py:88
-msgid "Nick name"
-msgstr "姓名"
-
-#: apps/users/serializers/user.py:60 apps/users/serializers/user.py:145
-#: apps/users/serializers/user.py:263 apps/xpack/api/chat_user.py:108
-#: apps/xpack/serializers/chat_user.py:93
-#: apps/xpack/serializers/chat_user.py:240
-msgid "Phone"
-msgstr "手机"
-
-#: apps/users/serializers/user.py:120 apps/xpack/serializers/chat_user.py:68
-msgid "Username must be 4-64 characters long"
-msgstr "用户名必须为4-64个字符"
-
-#: apps/users/serializers/user.py:133 apps/users/serializers/user.py:298
-#: apps/xpack/serializers/chat_user.py:81
-#: apps/xpack/serializers/chat_user.py:274
-msgid ""
-"The password must be 6-20 characters long and must be a combination of "
-"letters, numbers, and special characters."
-msgstr "密码必须为6-20个字符，且必须包含大小写字母、数字和特殊字符。"
-
-#: apps/users/serializers/user.py:170
-msgid "Email or username"
-msgstr "邮箱或用户名"
-
-#: apps/users/serializers/user.py:226
-msgid ""
-"The community version supports up to 2 users. If you need more users, please "
-"contact us (https://fit2cloud.com/)."
-msgstr ""
-"社区版支持最多2个用户，如需更多用户，请联系我们（https://fit2cloud.com/）。"
-
-#: apps/users/serializers/user.py:270 apps/xpack/api/auth_config.py:31
-#: apps/xpack/api/chat_user.py:109 apps/xpack/serializers/chat_user.py:247
-msgid "Is Active"
-msgstr "是否启用"
-
-#: apps/users/serializers/user.py:281 apps/xpack/serializers/chat_user.py:262
-msgid "Nickname is already in use"
-msgstr "Nickname已被使用"
-
-#: apps/users/serializers/user.py:286
-msgid "Email is already in use"
-msgstr "邮箱已被使用"
-
-#: apps/users/serializers/user.py:305 apps/xpack/serializers/chat_user.py:281
-msgid "Re Password"
-msgstr "确认密码"
-
-#: apps/users/serializers/user.py:310 apps/users/serializers/user.py:522
-#: apps/users/serializers/user.py:529 apps/xpack/serializers/chat_user.py:286
-#: apps/xpack/serializers/chat_user.py:606
-#: apps/xpack/serializers/chat_user.py:613
-msgid ""
-"The confirmation password must be 6-20 characters long and must be a "
-"combination of letters, numbers, and special characters."
-msgstr "确认密码必须为6-20个字符，且必须包含字母、数字和特殊字符。"
-
-#: apps/users/serializers/user.py:333 apps/xpack/serializers/chat_user.py:309
-msgid "User does not exist"
-msgstr "用户不存在"
-
-#: apps/users/serializers/user.py:348
-msgid "Unable to delete administrator"
-msgstr "无法删除管理员"
-
-#: apps/users/serializers/user.py:366
-msgid "Cannot modify administrator status"
-msgstr "不能修改管理员状态"
-
-#: apps/users/serializers/user.py:478 apps/xpack/serializers/chat_user.py:164
-#: apps/xpack/serializers/chat_user.py:192
-#: apps/xpack/serializers/chat_user.py:512
-msgid "User IDs cannot be empty"
-msgstr "用户 ID 不能为空"
-
-#: apps/users/serializers/user.py:524 apps/xpack/serializers/chat_user.py:608
-msgid "Confirm Password"
-msgstr "确认密码"
-
-#: apps/users/serializers/user.py:561 apps/users/serializers/user.py:647
-#: apps/xpack/api/knowledge_lark.py:26
-msgid "Type"
-msgstr "类型"
-
-#: apps/users/serializers/user.py:563 apps/users/serializers/user.py:651
-msgid "The type only supports register|reset_password"
-msgstr "类型仅支持 register|reset_password"
-
-#: apps/users/serializers/user.py:581
-#, python-brace-format
-msgid "Do not send emails again within {seconds} seconds"
-msgstr "不要在 {seconds} 秒内再次发送邮件"
-
-#: apps/users/serializers/user.py:611
-msgid ""
-"The email service has not been set up. Please contact the administrator to "
-"set up the email service in [Email Settings]."
-msgstr "邮箱服务尚未设置，请联系管理员在 [邮箱设置] 中设置邮箱服务。"
-
-#: apps/users/serializers/user.py:622
-#, python-brace-format
-msgid "【Intelligent knowledge base question and answer system-{action}】"
-msgstr "【智能知识库问答系统-{action}】"
-
-#: apps/users/serializers/user.py:623
-msgid "User registration"
-msgstr "用户注册"
-
-#: apps/users/serializers/user.py:623 apps/users/views/user.py:248
-#: apps/users/views/user.py:249 apps/users/views/user.py:250
-#: apps/users/views/user.py:283 apps/users/views/user.py:284
-#: apps/users/views/user.py:285
-msgid "Change password"
-msgstr "修改密码"
-
-#: apps/users/serializers/user.py:644
-msgid "Verification code"
-msgstr "验证码"
-
-#: apps/users/serializers/user.py:672
+#: apps/users/serializers/user.py:1198
 msgid "language only support:"
 msgstr "语言仅支持："
 
-#: apps/users/views/login.py:38 apps/users/views/login.py:39
-#: apps/users/views/login.py:40 apps/xpack/views/chat_user_auth.py:184
-#: apps/xpack/views/chat_user_auth.py:185
-#: apps/xpack/views/chat_user_auth.py:186
-msgid "Log in"
-msgstr "登录"
-
-#: apps/users/views/login.py:55 apps/users/views/login.py:56
-#: apps/users/views/login.py:57 apps/xpack/views/chat_user_auth.py:203
-#: apps/xpack/views/chat_user_auth.py:204
-#: apps/xpack/views/chat_user_auth.py:205
-msgid "Sign out"
-msgstr "登出"
-
-#: apps/users/views/user.py:60 apps/users/views/user.py:61
-#: apps/users/views/user.py:62 apps/users/views/user.py:74
-#: apps/users/views/user.py:75 apps/xpack/views/system_chat_user.py:359
-#: apps/xpack/views/system_chat_user.py:360
-#: apps/xpack/views/system_chat_user.py:361
-msgid "Get current user information"
-msgstr "获取当前用户信息"
-
-#: apps/users/views/user.py:120 apps/users/views/user.py:121
-#: apps/users/views/user.py:122
-msgid "Get all user"
-msgstr "获取所有用户"
-
-#: apps/users/views/user.py:133 apps/users/views/user.py:134
-#: apps/users/views/user.py:135
-msgid "Get user list under workspace"
-msgstr "获取工作空间下用户列表"
-
-#: apps/users/views/user.py:147 apps/users/views/user.py:148
-#: apps/users/views/user.py:149
-msgid "Get user member under workspace"
-msgstr "获取工作空间下用户成员"
-
-#: apps/users/views/user.py:161 apps/users/views/user.py:162
-#: apps/users/views/user.py:163
-msgid "Create user"
-msgstr "创建用户"
-
-#: apps/users/views/user.py:177 apps/users/views/user.py:178
-#: apps/users/views/user.py:179
-msgid "Get default password"
-msgstr "获取默认密码"
-
-#: apps/users/views/user.py:190 apps/users/views/user.py:191
-#: apps/users/views/user.py:192
-msgid "Delete user"
-msgstr "删除用户"
-
-#: apps/users/views/user.py:203 apps/users/views/user.py:204
-#: apps/users/views/user.py:205
-msgid "Get user information"
-msgstr "获取用户信息"
-
-#: apps/users/views/user.py:214 apps/users/views/user.py:215
-#: apps/users/views/user.py:216
-msgid "Update user information"
-msgstr "更新当前用户信息"
-
-#: apps/users/views/user.py:232 apps/users/views/user.py:233
-#: apps/users/views/user.py:234
-msgid "Batch delete user"
-msgstr "批量删除用户"
-
-#: apps/users/views/user.py:266 apps/users/views/user.py:267
-#: apps/users/views/user.py:268 apps/workspace/views/workspace_chat_user.py:168
-#: apps/workspace/views/workspace_chat_user.py:169
-#: apps/workspace/views/workspace_chat_user.py:170
-#: apps/xpack/views/system_chat_user.py:197
-#: apps/xpack/views/system_chat_user.py:198
-#: apps/xpack/views/system_chat_user.py:199
-msgid "Get user paginated list"
-msgstr "获取用户分页列表"
-
-#: apps/users/views/user.py:300 apps/users/views/user.py:301
-#: apps/users/views/user.py:302
-msgid "Send email"
-msgstr "发送邮件"
-
-#: apps/users/views/user.py:318 apps/users/views/user.py:319
-#: apps/users/views/user.py:320
-msgid "Check whether the verification code is correct"
-msgstr "检查验证码是否正确"
-
-#: apps/users/views/user.py:335 apps/users/views/user.py:336
-#: apps/users/views/user.py:337
-msgid "Send email to current user"
-msgstr "发送邮件给当前用户"
-
-#: apps/users/views/user.py:353 apps/users/views/user.py:354
-#: apps/users/views/user.py:355 apps/xpack/views/system_chat_user.py:336
-#: apps/xpack/views/system_chat_user.py:337
-#: apps/xpack/views/system_chat_user.py:338
-msgid "Modify current user password"
-msgstr "修改当前用户密码"
-
-#: apps/users/views/user.py:368 apps/xpack/views/system_chat_user.py:352
-msgid "Failed to change password"
-msgstr "修改密码失败"
-
-#: apps/workspace/api/workspace.py:73
-#: apps/workspace/serializers/workspace_serializers.py:213
-msgid "User Relation ID"
-msgstr "用户关系 ID"
-
-#: apps/workspace/api/workspace.py:87
-msgid "Role Name"
-msgstr "角色名称"
-
-#: apps/workspace/serializers/workspace_serializers.py:42
-#: apps/workspace/serializers/workspace_serializers.py:95
-#: apps/workspace/serializers/workspace_serializers.py:110
-#: apps/workspace/serializers/workspace_serializers.py:177
-#: apps/workspace/serializers/workspace_serializers.py:219
-#: apps/workspace/serializers/workspace_serializers.py:246
-msgid "Workspace does not exist"
-msgstr "工作空间不存在"
-
-#: apps/workspace/serializers/workspace_serializers.py:49
-msgid "Workspace name already exists"
-msgstr "工作空间名称已存在"
-
-#: apps/workspace/serializers/workspace_serializers.py:97
-#: apps/workspace/serializers/workspace_serializers.py:112
-msgid "Default workspace cannot be deleted"
-msgstr "默认工作空间不能被删除"
-
-#: apps/workspace/serializers/workspace_serializers.py:122
-msgid "Applications Resource"
-msgstr "智能体资源"
-
-#: apps/workspace/serializers/workspace_serializers.py:124
-msgid "Knowledge Resource"
-msgstr "知识库资源"
-
-#: apps/workspace/serializers/workspace_serializers.py:130
-msgid "This workspace contains %s, cannot be deleted."
-msgstr "该工作空间下存在 %s，不能被删除。"
-
-#: apps/workspace/serializers/workspace_serializers.py:166
-msgid "Role IDs"
-msgstr "角色 IDs"
-
-#: apps/workspace/views/workspace.py:32 apps/workspace/views/workspace.py:33
-#: apps/workspace/views/workspace.py:34
-msgid "Create or update workspace"
-msgstr "创建或更新工作空间"
-
-#: apps/workspace/views/workspace.py:45 apps/workspace/views/workspace.py:46
-#: apps/workspace/views/workspace.py:47
-msgid "Get system workspace list"
-msgstr "获取系统工作空间列表"
-
-#: apps/workspace/views/workspace.py:58 apps/workspace/views/workspace.py:59
-#: apps/workspace/views/workspace.py:60
-msgid "Delete workspace"
-msgstr "删除工作空间"
-
-#: apps/workspace/views/workspace.py:75 apps/workspace/views/workspace.py:76
-#: apps/workspace/views/workspace.py:77
-msgid "Check workspace can it be deleted"
-msgstr "检查工作空间是否可以被删除"
-
-#: apps/workspace/views/workspace.py:95 apps/workspace/views/workspace.py:96
-#: apps/workspace/views/workspace.py:97
-msgid "Add member to system workspace"
-msgstr "系统工作空间添加成员"
-
-#: apps/workspace/views/workspace.py:114 apps/workspace/views/workspace.py:115
-#: apps/workspace/views/workspace.py:116
-msgid "Remove member from system workspace"
-msgstr "系统工作空间移除成员"
-
-#: apps/workspace/views/workspace.py:133 apps/workspace/views/workspace.py:134
-#: apps/workspace/views/workspace.py:135
-msgid "Get system workspace member list"
-msgstr "获取系统工作空间成员列表"
-
-#: apps/workspace/views/workspace.py:151 apps/workspace/views/workspace.py:152
-#: apps/workspace/views/workspace.py:153
-msgid "Get workspace list"
-msgstr "获取工作空间列表"
-
-#: apps/workspace/views/workspace.py:164 apps/workspace/views/workspace.py:165
-#: apps/workspace/views/workspace.py:166
-msgid "Add member to workspace"
-msgstr "工作空间添加成员"
-
-#: apps/workspace/views/workspace.py:183 apps/workspace/views/workspace.py:184
-#: apps/workspace/views/workspace.py:185
-msgid "Remove member from workspace"
-msgstr "工作空间移除成员"
-
-#: apps/workspace/views/workspace.py:202 apps/workspace/views/workspace.py:203
-#: apps/workspace/views/workspace.py:204
-msgid "Get workspace member list"
-msgstr "获取工作空间成员列表"
-
-#: apps/workspace/views/workspace.py:219 apps/workspace/views/workspace.py:220
-#: apps/workspace/views/workspace.py:221
-msgid "Get workspace list by current user"
-msgstr "获取当前用户工作空间列表"
-
-#: apps/workspace/views/workspace.py:232 apps/workspace/views/workspace.py:233
-#: apps/workspace/views/workspace.py:234
-msgid "Get workspace list by user"
-msgstr "根据用户获取工作空间列表"
-
-#: apps/workspace/views/workspace.py:246 apps/workspace/views/workspace.py:247
-#: apps/workspace/views/workspace.py:248
-msgid "Get current user role list"
-msgstr "获取当前用户角色列表"
-
-#: apps/workspace/views/workspace_chat_user.py:44
-#: apps/workspace/views/workspace_chat_user.py:45
-#: apps/workspace/views/workspace_chat_user.py:46
-#: apps/workspace/views/workspace_chat_user.py:51
-#: apps/xpack/views/system_chat_user.py:57
-#: apps/xpack/views/system_chat_user.py:58
-#: apps/xpack/views/system_chat_user.py:59
-msgid "Create chat user"
-msgstr "创建对话用户"
-
-#: apps/workspace/views/workspace_chat_user.py:47
-#: apps/workspace/views/workspace_chat_user.py:51
-#: apps/workspace/views/workspace_chat_user.py:63
-#: apps/workspace/views/workspace_chat_user.py:67
-#: apps/workspace/views/workspace_chat_user.py:76
-#: apps/workspace/views/workspace_chat_user.py:87
-#: apps/workspace/views/workspace_chat_user.py:92
-#: apps/workspace/views/workspace_chat_user.py:105
-#: apps/workspace/views/workspace_chat_user.py:120
-#: apps/workspace/views/workspace_chat_user.py:124
-#: apps/workspace/views/workspace_chat_user.py:136
-#: apps/workspace/views/workspace_chat_user.py:140
-#: apps/workspace/views/workspace_chat_user.py:152
-#: apps/workspace/views/workspace_chat_user.py:171
-msgid "Workspace/Chat user"
-msgstr "工作空间/对话用户"
-
-#: apps/workspace/views/workspace_chat_user.py:60
-#: apps/workspace/views/workspace_chat_user.py:61
-#: apps/workspace/views/workspace_chat_user.py:62
-#: apps/workspace/views/workspace_chat_user.py:67
-#: apps/xpack/views/system_chat_user.py:86
-#: apps/xpack/views/system_chat_user.py:87
-#: apps/xpack/views/system_chat_user.py:88
-msgid "Delete chat user"
-msgstr "删除对话用户"
-
-#: apps/workspace/views/workspace_chat_user.py:73
-#: apps/workspace/views/workspace_chat_user.py:74
-#: apps/workspace/views/workspace_chat_user.py:75
-#: apps/xpack/views/system_chat_user.py:99
-#: apps/xpack/views/system_chat_user.py:100
-#: apps/xpack/views/system_chat_user.py:101
-msgid "Get chat user information"
-msgstr "获取对话用户信息"
-
-#: apps/workspace/views/workspace_chat_user.py:84
-#: apps/workspace/views/workspace_chat_user.py:85
-#: apps/workspace/views/workspace_chat_user.py:86
-#: apps/workspace/views/workspace_chat_user.py:92
-#: apps/xpack/views/system_chat_user.py:110
-#: apps/xpack/views/system_chat_user.py:111
-#: apps/xpack/views/system_chat_user.py:112
-msgid "Update chat user information"
-msgstr "更新对话用户信息"
-
-#: apps/workspace/views/workspace_chat_user.py:102
-#: apps/workspace/views/workspace_chat_user.py:103
-#: apps/workspace/views/workspace_chat_user.py:104
-#: apps/workspace/views/workspace_chat_user.py:261
-#: apps/workspace/views/workspace_chat_user.py:262
-#: apps/workspace/views/workspace_chat_user.py:263
-#: apps/xpack/views/system_chat_user.py:128
-#: apps/xpack/views/system_chat_user.py:129
-#: apps/xpack/views/system_chat_user.py:130
-#: apps/xpack/views/system_chat_user.py:318
-#: apps/xpack/views/system_chat_user.py:319
-#: apps/xpack/views/system_chat_user.py:320
-msgid "Get user list by group"
-msgstr "获取用户组列表"
-
-#: apps/workspace/views/workspace_chat_user.py:117
-#: apps/workspace/views/workspace_chat_user.py:118
-#: apps/workspace/views/workspace_chat_user.py:119
-#: apps/workspace/views/workspace_chat_user.py:124
-#: apps/xpack/views/system_chat_user.py:143
-#: apps/xpack/views/system_chat_user.py:144
-#: apps/xpack/views/system_chat_user.py:145
-msgid "Batch delete chat user"
-msgstr "批量删除对话用户"
-
-#: apps/workspace/views/workspace_chat_user.py:133
-#: apps/workspace/views/workspace_chat_user.py:134
-#: apps/workspace/views/workspace_chat_user.py:135
-#: apps/workspace/views/workspace_chat_user.py:140
-#: apps/xpack/views/system_chat_user.py:160
-#: apps/xpack/views/system_chat_user.py:161
-#: apps/xpack/views/system_chat_user.py:162
-msgid "Batch add chat user to group"
-msgstr "批量添加对话用户到用户组"
-
-#: apps/workspace/views/workspace_chat_user.py:149
-#: apps/workspace/views/workspace_chat_user.py:150
-#: apps/workspace/views/workspace_chat_user.py:151
-#: apps/xpack/views/system_chat_user.py:177
-#: apps/xpack/views/system_chat_user.py:178
-#: apps/xpack/views/system_chat_user.py:179
-msgid "Change chat user password"
-msgstr "修改对话用户密码"
-
-#: apps/workspace/views/workspace_chat_user.py:186
-#: apps/workspace/views/workspace_chat_user.py:187
-#: apps/workspace/views/workspace_chat_user.py:188
-#: apps/xpack/views/system_chat_user.py:230
-#: apps/xpack/views/system_chat_user.py:231
-#: apps/xpack/views/system_chat_user.py:232
-msgid "Create or update Chat User Group"
-msgstr "创建或更新对话用户组"
-
-#: apps/workspace/views/workspace_chat_user.py:191
-#: apps/workspace/views/workspace_chat_user.py:202
-#: apps/workspace/views/workspace_chat_user.py:216
-#: apps/workspace/views/workspace_chat_user.py:232
-#: apps/workspace/views/workspace_chat_user.py:249
-#: apps/workspace/views/workspace_chat_user.py:264
-msgid "Workspace/User Group"
-msgstr "工作空间/用户组"
-
-#: apps/workspace/views/workspace_chat_user.py:198
-#: apps/workspace/views/workspace_chat_user.py:199
-#: apps/workspace/views/workspace_chat_user.py:200
-#: apps/xpack/views/system_chat_user.py:243
-#: apps/xpack/views/system_chat_user.py:244
-#: apps/xpack/views/system_chat_user.py:245
-msgid "Get user group list"
-msgstr "获取用户组列表"
-
-#: apps/workspace/views/workspace_chat_user.py:211
-#: apps/workspace/views/workspace_chat_user.py:212
-#: apps/workspace/views/workspace_chat_user.py:213
-#: apps/xpack/views/system_chat_user.py:256
-#: apps/xpack/views/system_chat_user.py:257
-#: apps/xpack/views/system_chat_user.py:258
-msgid "Delete chat user group"
-msgstr "删除对话用户组"
-
-#: apps/workspace/views/workspace_chat_user.py:226
-#: apps/workspace/views/workspace_chat_user.py:227
-#: apps/workspace/views/workspace_chat_user.py:228
-#: apps/xpack/views/system_chat_user.py:273
-#: apps/xpack/views/system_chat_user.py:274
-#: apps/xpack/views/system_chat_user.py:275
-msgid "Add member to chat user group"
-msgstr "添加成员到对话用户组"
-
-#: apps/workspace/views/workspace_chat_user.py:243
-#: apps/workspace/views/workspace_chat_user.py:244
-#: apps/workspace/views/workspace_chat_user.py:245
-#: apps/xpack/views/system_chat_user.py:295
-#: apps/xpack/views/system_chat_user.py:296
-#: apps/xpack/views/system_chat_user.py:297
-msgid "Remove member from chat user group"
-msgstr "从对话用户组移除成员"
-
-#: apps/xpack/api/auth_config.py:29
-msgid "Auth Type"
-msgstr "认证类型"
-
-#: apps/xpack/api/auth_config.py:30
-msgid "Config"
-msgstr "配置"
-
-#: apps/xpack/api/auth_config.py:77
-msgid "Corp ID"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:78
-msgid "Agent ID"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:79
-msgid "App Secret"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:80
-msgid "Callback URL"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:84
-msgid "Key"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:106
-msgid "Access Token"
-msgstr ""
-
-#: apps/xpack/api/chat_user.py:31 apps/xpack/api/chat_user.py:83
-#: apps/xpack/api/chat_user.py:113 apps/xpack/serializers/chat_user.py:101
-#: apps/xpack/serializers/chat_user.py:177
-#: apps/xpack/serializers/chat_user.py:252
-msgid "User Group IDs"
-msgstr "用户组 IDs"
-
-#: apps/xpack/api/chat_user.py:118
-msgid "User Group Names"
-msgstr "用户组名称"
-
-#: apps/xpack/api/chat_user.py:132 apps/xpack/serializers/chat_user.py:120
-#: apps/xpack/serializers/resource_chat_user.py:37
-msgid "Username or Nickname"
-msgstr "用户名或姓名"
-
-#: apps/xpack/api/chat_user.py:148 apps/xpack/serializers/chat_user.py:360
-msgid "Sync Type"
-msgstr "同步类型"
-
-#: apps/xpack/api/knowledge_lark.py:25
-msgid "Token"
-msgstr "令牌"
-
-#: apps/xpack/api/knowledge_lark.py:27
-msgid "Is Exist"
-msgstr "是否存在"
-
-#: apps/xpack/api/license.py:13
-msgid "corporation"
-msgstr "公司"
-
-#: apps/xpack/api/license.py:14
-msgid "isv"
-msgstr ""
-
-#: apps/xpack/api/license.py:15
-msgid "expired"
-msgstr "过期时间"
-
-#: apps/xpack/api/license.py:16
-msgid "product"
-msgstr "产品"
-
-#: apps/xpack/api/license.py:17
-msgid "edition"
-msgstr "版本"
-
-#: apps/xpack/api/license.py:18
-msgid "license version"
-msgstr "license 版本"
-
-#: apps/xpack/api/license.py:19
-msgid "count"
-msgstr "数量"
-
-#: apps/xpack/api/license.py:20
-msgid "serial number"
-msgstr "序列号"
-
-#: apps/xpack/api/license.py:21
-msgid "remark"
-msgstr "备注"
-
-#: apps/xpack/api/license.py:26
-msgid "message"
-msgstr "消息"
-
-#: apps/xpack/api/license.py:27
-msgid "license details"
-msgstr "license 详情"
-
-#: apps/xpack/api/license.py:36
-#: apps/xpack/serializers/license/license_serializers.py:56
-msgid "license file"
-msgstr "license 文件"
-
-#: apps/xpack/api/license.py:37
-msgid "License file is required"
-msgstr "license 文件是必需的"
-
-#: apps/xpack/api/license.py:38
-msgid "Invalid license file format"
-msgstr "无效的 license 文件格式"
-
-#: apps/xpack/api/operate_log.py:12
-#: apps/xpack/serializers/operate_log_serializer.py:57
-msgid "menu"
-msgstr "菜单"
-
-#: apps/xpack/api/operate_log.py:13
-#: apps/xpack/serializers/operate_log_serializer.py:58
-msgid "operate"
-msgstr "操作"
-
-#: apps/xpack/api/operate_log.py:14
-msgid "menu_label"
-msgstr "菜单标签"
-
-#: apps/xpack/api/operate_log.py:15
-msgid "operate_label"
-msgstr "操作标签"
-
-#: apps/xpack/api/platform.py:35
-msgid "Platform type"
-msgstr "平台类型"
-
-#: apps/xpack/api/platform.py:50
-msgid "Platform configuration"
-msgstr "平台配置"
-
-#: apps/xpack/api/resource_chat_user_group.py:40
-#: apps/xpack/serializers/resource_chat_user.py:25
-#: apps/xpack/serializers/resource_chat_user_group.py:69
-msgid "is auth"
-msgstr "是否认证"
-
-#: apps/xpack/api/user_group.py:31 apps/xpack/api/user_group.py:99
-msgid "User Group ID"
-msgstr "用户组 ID"
-
-#: apps/xpack/api/user_group.py:54 apps/xpack/serializers/chat_user.py:406
-#: apps/xpack/serializers/chat_user.py:563
-msgid "Group ID"
-msgstr "用户组 ID"
-
-#: apps/xpack/api/user_group.py:114 apps/xpack/serializers/chat_user.py:541
-msgid "User group relation IDs"
-msgstr "用户组关系 ID"
-
-#: apps/xpack/serializers/application_setting_serializer.py:19
-msgid "theme color"
-msgstr "主题颜色"
-
-#: apps/xpack/serializers/application_setting_serializer.py:21
-msgid "header font color"
-msgstr "标题字体颜色"
-
-#: apps/xpack/serializers/application_setting_serializer.py:25
-msgid "float location type"
-msgstr "浮动位置类型"
-
-#: apps/xpack/serializers/application_setting_serializer.py:26
-msgid "float location value"
-msgstr "浮动位置值"
-
-#: apps/xpack/serializers/application_setting_serializer.py:30
-msgid "float location x"
-msgstr "浮动位置 X"
-
-#: apps/xpack/serializers/application_setting_serializer.py:31
-msgid "float location y"
-msgstr "浮动位置 Y"
-
-#: apps/xpack/serializers/application_setting_serializer.py:35
-msgid "show source"
-msgstr "显示来源"
-
-#: apps/xpack/serializers/application_setting_serializer.py:36
-msgid "show exec"
-msgstr "显示执行"
-
-#: apps/xpack/serializers/application_setting_serializer.py:38
-msgid "show history"
-msgstr "显示历史"
-
-#: apps/xpack/serializers/application_setting_serializer.py:39
-msgid "draggable"
-msgstr "是否可拖动"
-
-#: apps/xpack/serializers/application_setting_serializer.py:40
-msgid "show guide"
-msgstr "显示论坛"
-
-#: apps/xpack/serializers/application_setting_serializer.py:42
-msgid "icon url"
-msgstr "图标"
-
-#: apps/xpack/serializers/application_setting_serializer.py:43
-msgid "chat background"
-msgstr "聊天背景"
-
-#: apps/xpack/serializers/application_setting_serializer.py:44
-msgid "chat background url"
-msgstr "聊天背景地址"
-
-#: apps/xpack/serializers/application_setting_serializer.py:45
-msgid "avatar"
-msgstr "头像"
-
-#: apps/xpack/serializers/application_setting_serializer.py:46
-msgid "avatar url"
-msgstr "头像地址"
-
-#: apps/xpack/serializers/application_setting_serializer.py:47
-msgid "user avatar"
-msgstr "用户头像"
-
-#: apps/xpack/serializers/application_setting_serializer.py:48
-msgid "user avatar url"
-msgstr "用户头像地址"
-
-#: apps/xpack/serializers/application_setting_serializer.py:49
-msgid "float icon"
-msgstr "浮动图标"
-
-#: apps/xpack/serializers/application_setting_serializer.py:50
-msgid "float icon url"
-msgstr "浮动图标地址"
-
-#: apps/xpack/serializers/application_setting_serializer.py:51
-msgid "disclaimer"
-msgstr "免责申明"
-
-#: apps/xpack/serializers/application_setting_serializer.py:52
-msgid "disclaimer value"
-msgstr "免责申明内容"
-
-#: apps/xpack/serializers/application_setting_serializer.py:55
-msgid "show avatar"
-msgstr "显示头像"
-
-#: apps/xpack/serializers/application_setting_serializer.py:56
-msgid "show user avatar"
-msgstr "显示用户头像"
-
-#: apps/xpack/serializers/application_setting_serializer.py:124
-msgid "Float location field type error"
-msgstr "浮动位置字段类型错误"
-
-#: apps/xpack/serializers/application_setting_serializer.py:130
-msgid "Custom theme field type error"
-msgstr "自定义主题字段类型错误"
-
-#: apps/xpack/serializers/auth_config_serializer.py:27
-#: apps/xpack/serializers/platform_serializer.py:31
-msgid "App Secret is required"
-msgstr "App Secret 是必填项"
-
-#: apps/xpack/serializers/auth_config_serializer.py:28
-#: apps/xpack/serializers/platform_serializer.py:26
-#: apps/xpack/serializers/platform_serializer.py:34
-#: apps/xpack/serializers/platform_serializer.py:40
-#: apps/xpack/serializers/platform_serializer.py:46
-msgid "Callback URL is required"
-msgstr "Callback URL 是必填项"
-
-#: apps/xpack/serializers/auth_config_serializer.py:32
-#: apps/xpack/serializers/auth_config_serializer.py:41
-msgid "Corp ID is required"
-msgstr "Corp ID 是必填项"
-
-#: apps/xpack/serializers/auth_config_serializer.py:33
-#: apps/xpack/serializers/platform_serializer.py:22
-msgid "Agent ID is required"
-msgstr "Agent ID 是必填项"
-
-#: apps/xpack/serializers/auth_config_serializer.py:37
-#: apps/xpack/serializers/auth_config_serializer.py:42
-msgid "App Key is required"
-msgstr "App Key 是必填项"
-
-#: apps/xpack/serializers/auth_config_serializer.py:53
-msgid "LDAP server cannot be empty"
-msgstr "LDAP server不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:54
-msgid "Base DN cannot be empty"
-msgstr "Base DN不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:55
-msgid "Password cannot be empty"
-msgstr "密码不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:56
-msgid "OU cannot be empty"
-msgstr "OU不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:57
-msgid "LDAP filter cannot be empty"
-msgstr "LDAP过滤器不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:58
-msgid "LDAP mapping cannot be empty"
-msgstr "LDAP映射不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:62
-msgid "Authorization address cannot be empty"
-msgstr "认证地址不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:63
-msgid "Token address cannot be empty"
-msgstr "令牌地址不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:64
-msgid "User information address cannot be empty"
-msgstr "用户信息地址不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:65
-msgid "Scope cannot be empty"
-msgstr "范围不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:66
-msgid "Client ID cannot be empty"
-msgstr "客户端 ID 不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:67
-msgid "Client secret cannot be empty"
-msgstr "客户端密钥不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:68
-msgid "Redirect address cannot be empty"
-msgstr "重定向地址不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:69
-msgid "Field mapping cannot be empty"
-msgstr "字段映射不能为空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:262
-msgid "Configuration information is wrong and failed to save"
-msgstr "配置信息错误，保存失败"
-
-#: apps/xpack/serializers/auth_config_serializer.py:288
-msgid "Connection failed"
-msgstr "连接失败"
-
-#: apps/xpack/serializers/auth_config_serializer.py:306
-msgid "Platform does not exist"
-msgstr "平台不存在"
-
-#: apps/xpack/serializers/auth_config_serializer.py:316
-msgid "Unsupported platform type"
-msgstr "不支持的平台类型"
-
-#: apps/xpack/serializers/channel/chat_manage.py:100
-msgid "Think: "
-msgstr "思考内容: "
-
-#: apps/xpack/serializers/channel/chat_manage.py:103
-#: apps/xpack/serializers/channel/chat_manage.py:105
-msgid "AI reply: "
-msgstr "AI 回复: "
-
-#: apps/xpack/serializers/channel/chat_manage.py:318
-msgid "Thinking, please wait a moment!"
-msgstr "思考中，请稍等！"
-
-#: apps/xpack/serializers/channel/ding_talk.py:19
-#: apps/xpack/serializers/channel/wechat.py:91
-#: apps/xpack/serializers/channel/wechat.py:132
-#: apps/xpack/serializers/channel/wecom.py:78
-#: apps/xpack/serializers/channel/wecom.py:259
-msgid "The corresponding platform configuration was not found"
-msgstr "未找到对应的平台配置"
-
-#: apps/xpack/serializers/channel/ding_talk.py:27
-#: apps/xpack/serializers/channel/lark.py:117
-msgid "Currently only text messages are supported"
-msgstr "目前仅支持文本消息"
-
-#: apps/xpack/serializers/channel/ding_talk.py:91
-#: apps/xpack/serializers/channel/wechat.py:163
-#: apps/xpack/serializers/channel/wecom.py:189
-msgid "Image download failed, check network"
-msgstr "图片下载失败，请检查网络"
-
-#: apps/xpack/serializers/channel/ding_talk.py:92
-#: apps/xpack/serializers/channel/wechat.py:161
-#: apps/xpack/serializers/channel/wecom.py:185
-msgid "Please analyze the content of the image."
-msgstr "请分析图片内容。"
-
-#: apps/xpack/serializers/channel/ding_talk.py:95
-msgid "DingTalk application: {user}"
-msgstr "钉钉智能体: {user}"
-
-#: apps/xpack/serializers/channel/ding_talk.py:106
-#: apps/xpack/serializers/channel/ding_talk.py:151
-msgid "Content generated by AI"
-msgstr "AI 生成的内容"
-
-#: apps/xpack/serializers/channel/lark.py:92
-msgid "Lark application: "
-msgstr "飞书智能体: "
-
-#: apps/xpack/serializers/channel/slack.py:116
-msgid "The corresponding platform configuration for Slack was not found"
-msgstr "Slack 的对应平台配置未找到"
-
-#: apps/xpack/serializers/channel/slack.py:206
-msgid "Thinking..."
-msgstr "思考中..."
-
-#: apps/xpack/serializers/channel/slack.py:333
-msgid "Invalid json format."
-msgstr "json 格式无效。"
-
-#: apps/xpack/serializers/channel/slack.py:339
-msgid "Invalid Slack request"
-msgstr "Slack 请求无效"
-
-#: apps/xpack/serializers/channel/slack.py:347
-msgid "Slack application: {user}"
-msgstr "Slack 智能体: {user}"
-
-#: apps/xpack/serializers/channel/slack.py:480
-msgid "Stop"
-msgstr "停止"
-
-#: apps/xpack/serializers/channel/tools.py:58
-#, python-brace-format
-msgid ""
-"Thinking about 【{question}】...If you want me to continue answering, please "
-"reply {trigger_message}"
-msgstr "思考【{question}】...如果你想让我继续回答，请回复 {trigger_message}"
-
-#: apps/xpack/serializers/channel/tools.py:158
-msgid ""
-"\n"
-" ------------\n"
-"[To be continued, reply \"Continue to answer the question]"
-msgstr ""
-"\n"
-"------------\n"
-"[待续，回复 \"继续回答问题]"
-
-#: apps/xpack/serializers/channel/tools.py:238
-#, python-brace-format
-msgid ""
-"To be continued, reply \"{trigger_message}\" to continue answering the "
-"question"
-msgstr "待续，回复 \"{trigger_message}\" 继续回答问题"
-
-#: apps/xpack/serializers/channel/wechat.py:143
-#, python-brace-format
-msgid "WeChat Official Account: {account}"
-msgstr "微信公众账号: {account}"
-
-#: apps/xpack/serializers/channel/wechat.py:150
-#: apps/xpack/serializers/channel/wecom.py:171
-#: apps/xpack/serializers/channel/wecom.py:175
-msgid ""
-"The app does not enable the speech-to-text function or the speech-to-text "
-"function fails."
-msgstr "智能体未开启语音转文字功能或语音转文字功能失败。"
-
-#: apps/xpack/serializers/channel/wechat.py:189
-msgid "Message types not supported yet"
-msgstr "消息类型暂不支持"
-
-#: apps/xpack/serializers/channel/wechat.py:196
-msgid "Welcome to subscribe"
-msgstr "欢迎订阅"
-
-#: apps/xpack/serializers/channel/wecom.py:86
-msgid "Enterprise WeChat user: "
-msgstr "企业微信用户: "
-
-#: apps/xpack/serializers/channel/wecom.py:97
-msgid "Enterprise WeChat customer service: "
-msgstr "企业微信客服: "
-
-#: apps/xpack/serializers/channel/wecom.py:134
-#: apps/xpack/serializers/channel/wecom.py:150
-msgid "This type of message is not supported yet"
-msgstr "此类型消息暂不支持"
-
-#: apps/xpack/serializers/channel/wecom.py:254
-msgid "Signature missing"
-msgstr "签名缺失"
-
-#: apps/xpack/serializers/channel/wecom.py:266
-#: apps/xpack/serializers/channel/wecom.py:273
-#, python-brace-format
-msgid "An error occurred while processing the GET request {e}"
-msgstr "get 请求处理时发生错误 {e}"
-
-#: apps/xpack/serializers/chat_auth.py:51
-msgid "The password is incorrect"
-msgstr "密码不正确"
-
-#: apps/xpack/serializers/chat_user.py:42
-msgid "Some user groups do not exist"
-msgstr "某些用户组不存在"
-
-#: apps/xpack/serializers/chat_user.py:181
-msgid "Is Append"
-msgstr "是否追加"
-
-#: apps/xpack/serializers/chat_user.py:194
-msgid "User Group IDs cannot be empty"
-msgstr "用户组 IDs 不能为空"
-
-#: apps/xpack/serializers/chat_user.py:198
-msgid "Some users do not exist"
-msgstr "某些用户不存在"
-
-#: apps/xpack/serializers/chat_user.py:361
-msgid "Sync Type: LOCAL or LDAP"
-msgstr "同步类型: LOCAL 或 LDAP"
-
-#: apps/xpack/serializers/chat_user.py:403
-msgid "Unsupported sync type"
-msgstr "不支持的同步类型"
-
-#: apps/xpack/serializers/chat_user.py:412
-#: apps/xpack/serializers/chat_user.py:444
-#: apps/xpack/serializers/chat_user.py:483
-#: apps/xpack/serializers/chat_user.py:510
-#: apps/xpack/serializers/chat_user.py:548
-#: apps/xpack/serializers/chat_user.py:570
-msgid "User group does not exist"
-msgstr "用户组不存在"
-
-#: apps/xpack/serializers/chat_user.py:451
-msgid "User group name already exists"
-msgstr "用户组名称已存在"
-
-#: apps/xpack/serializers/chat_user.py:485
-msgid "Default user group cannot be deleted"
-msgstr "默认用户组不能被删除"
-
-#: apps/xpack/serializers/chat_user.py:550
-msgid "User group relation IDs cannot be empty"
-msgstr "用户组关系 IDs 不能为空"
-
-#: apps/xpack/serializers/chat_user_serializer.py:75
-msgid "Invalid access token"
-msgstr "无效的访问令牌"
-
-#: apps/xpack/serializers/chat_user_serializer.py:102
-msgid "The user does not have permission to access the application"
-msgstr "用户没有访问智能体的权限"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:56
-#: apps/xpack/serializers/dataset_lark_serializer.py:299
-msgid "app id"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:57
-#: apps/xpack/serializers/dataset_lark_serializer.py:300
-msgid "app secret"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:58
-#: apps/xpack/serializers/dataset_lark_serializer.py:105
-#: apps/xpack/serializers/dataset_lark_serializer.py:301
-msgid "folder token"
-msgstr "文件夹令牌"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:60
-msgid "embedding model"
-msgstr "向量模型"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:71
-#: apps/xpack/serializers/dataset_lark_serializer.py:311
-msgid "Network error or folder token error!"
-msgstr "网络错误或文件夹令牌错误！"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:113
-#: apps/xpack/serializers/dataset_lark_serializer.py:155
-#: apps/xpack/task/sync.py:308
-msgid "Knowledge base not found!"
-msgstr "知识库未找到！"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:125
-#: apps/xpack/task/sync.py:240
-msgid "Failed to get lark document list!"
-msgstr "获取飞书文档列表失败！"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:147
-msgid "Knowledge id"
-msgstr "知识库 ID"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:169
-msgid "Synchronization is only supported for lark documents"
-msgstr "仅支持飞书文档的同步"
-
-#: apps/xpack/serializers/license/license_serializers.py:102
-#: apps/xpack/serializers/license/license_serializers.py:123
-#: apps/xpack/serializers/license/license_tools.py:111
-msgid "The license is invalid"
-msgstr "许可证无效"
-
-#: apps/xpack/serializers/license/license_tools.py:136
-msgid "License usage limit exceeded."
-msgstr "License 使用限制已超出。"
-
-#: apps/xpack/serializers/license/license_tools.py:160
-msgid "The network is busy, try again later."
-msgstr "网络繁忙，请稍后再试。"
-
-#: apps/xpack/serializers/operate_log_serializer.py:59
-msgid "user"
-msgstr "用户"
-
-#: apps/xpack/serializers/operate_log_serializer.py:61
-msgid "ip_address"
-msgstr "IP 地址"
-
-#: apps/xpack/serializers/operate_log_serializer.py:62
-msgid "workspace_id"
-msgstr "工作空间ID"
-
-#: apps/xpack/serializers/operate_log_serializer.py:134
-msgid "Fail"
-msgstr "失败"
-
-#: apps/xpack/serializers/operate_log_serializer.py:171
-msgid "Menu"
-msgstr "菜单"
-
-#: apps/xpack/serializers/operate_log_serializer.py:172
-msgid "Operate"
-msgstr "操作"
-
-#: apps/xpack/serializers/operate_log_serializer.py:173
-msgid "Operate user"
-msgstr "操作用户"
-
-#: apps/xpack/serializers/operate_log_serializer.py:175
-msgid "Ip Address"
-msgstr "IP地址"
-
-#: apps/xpack/serializers/operate_log_serializer.py:176
-msgid "API Details"
-msgstr "API详情"
-
-#: apps/xpack/serializers/operate_log_serializer.py:177
-msgid "Operate Time"
-msgstr "操作时间"
-
-#: apps/xpack/serializers/platform_serializer.py:12
-msgid "app_id is required"
-msgstr "app_id 是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:13
-msgid "app_secret is required"
-msgstr "app_secret 是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:14
-msgid "token is required"
-msgstr "token 是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:15
-msgid "callback_url is required"
-msgstr "callback_url 是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:21
-#: apps/xpack/serializers/platform_serializer.py:30
-msgid "App ID is required"
-msgstr "App ID 是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:23
-msgid "Secret is required"
-msgstr "Secret 是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:24
-msgid "Token is required"
-msgstr "Token 是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:33
-msgid "Verification Token is required"
-msgstr "验证令牌是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:38
-msgid "Client ID is required"
-msgstr "Client ID 是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:39
-msgid "Client Secret is required"
-msgstr "客户端密钥是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:44
-msgid "Signing Secret is required"
-msgstr "签名密钥是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:45
-msgid "Bot User Token is required"
-msgstr "机器人用户令牌是必填项"
-
-#: apps/xpack/serializers/platform_serializer.py:66
-msgid "Check if the fields are correct"
-msgstr "检查字段是否正确"
-
-#: apps/xpack/serializers/platform_serializer.py:155
-#, python-brace-format
-msgid "The platform configuration corresponding to {type} was not found"
-msgstr "未找到对应 {type} 的平台配置"
-
-#: apps/xpack/serializers/resource_chat_user.py:35
-#: apps/xpack/serializers/resource_chat_user.py:111
-#: apps/xpack/serializers/resource_chat_user_group.py:18
-#: apps/xpack/serializers/resource_chat_user_group.py:86
-msgid "Resource id"
-msgstr "资源ID"
-
-#: apps/xpack/serializers/resource_chat_user.py:38
-#: apps/xpack/serializers/resource_chat_user.py:112
-msgid "User group id"
-msgstr "用户组ID"
-
-#: apps/xpack/serializers/resource_chat_user.py:94
-msgid "Is auth"
-msgstr "是否授权"
-
-#: apps/xpack/serializers/resource_chat_user_group.py:20
-msgid "User group name"
-msgstr "用户名"
-
-#: apps/xpack/serializers/resource_chat_user_group.py:68
-msgid "user_group_id"
-msgstr "用户组ID"
-
-#: apps/xpack/serializers/sso_auth/cas.py:32
-msgid "HttpClient query failed: "
-msgstr "HttpClient 查询失败: "
-
-#: apps/xpack/serializers/sso_auth/cas.py:58
-msgid "CAS authentication failed"
-msgstr "CAS 认证失败"
-
-#: apps/xpack/serializers/sso_auth/oauth2.py:165
-#: apps/xpack/serializers/sso_auth/oauth2.py:184
-#: apps/xpack/serializers/sso_auth/oauth2.py:187
-msgid "Failed to obtain user information"
-msgstr "获取用户信息失败"
-
-#: apps/xpack/serializers/system_api_key.py:12
-msgid "Allow cross domain"
-msgstr "允许跨域"
-
-#: apps/xpack/serializers/system_api_key.py:13
-msgid "Cross domain list"
-msgstr "跨域列表"
-
-#: apps/xpack/serializers/system_api_key.py:44
-msgid "system API key id"
-msgstr "系统 API 密钥 ID"
-
-#: apps/xpack/serializers/system_params.py:20
-msgid "theme"
-msgstr "主题"
-
-#: apps/xpack/serializers/system_params.py:22
-msgid "login logo"
-msgstr "登录 logo"
-
-#: apps/xpack/serializers/system_params.py:23
-msgid "login image"
-msgstr "登录图片"
-
-#: apps/xpack/serializers/system_params.py:24
-msgid "title"
-msgstr "标题"
-
-#: apps/xpack/serializers/system_params.py:25
-msgid "slogan"
-msgstr "标语"
-
-#: apps/xpack/serializers/system_params.py:26
-#: apps/xpack/serializers/system_params.py:27
-msgid "show user manual"
-msgstr "显示用户手册"
-
-#: apps/xpack/serializers/system_params.py:28
-msgid "user manual url"
-msgstr "用户手册网址"
-
-#: apps/xpack/serializers/system_params.py:29
-msgid "show forum"
-msgstr "显示论坛"
-
-#: apps/xpack/serializers/system_params.py:30
-msgid "forum url"
-msgstr "论坛网址"
-
-#: apps/xpack/serializers/system_params.py:31
-msgid "show project"
-msgstr "显示项目"
-
-#: apps/xpack/serializers/system_params.py:32
-msgid "project url"
-msgstr "项目网址"
-
-#: apps/xpack/views/application_setting.py:24
-#: apps/xpack/views/application_setting.py:25
-#: apps/xpack/views/application_setting.py:26
-msgid "Modify Application Settings"
-msgstr "修改智能体设置"
-
-#: apps/xpack/views/application_setting.py:42
-#: apps/xpack/views/application_setting.py:43
-#: apps/xpack/views/application_setting.py:44
-msgid "Get Application Settings"
-msgstr "获取智能体设置"
-
-#: apps/xpack/views/auth.py:52 apps/xpack/views/auth.py:53
-#: apps/xpack/views/auth.py:54 apps/xpack/views/chat_user_auth.py:46
-#: apps/xpack/views/chat_user_auth.py:47 apps/xpack/views/chat_user_auth.py:48
-msgid "Get authentication types"
-msgstr "获取认证类型"
-
-#: apps/xpack/views/auth.py:55 apps/xpack/views/auth.py:70
-#: apps/xpack/views/auth.py:90 apps/xpack/views/auth.py:108
-#: apps/xpack/views/auth.py:223 apps/xpack/views/auth.py:235
-#: apps/xpack/views/auth.py:249
-msgid "Authentication Configuration"
-msgstr "认证配置"
-
-#: apps/xpack/views/auth.py:67 apps/xpack/views/auth.py:68
-#: apps/xpack/views/auth.py:69 apps/xpack/views/chat_user_auth.py:62
-#: apps/xpack/views/chat_user_auth.py:63 apps/xpack/views/chat_user_auth.py:64
-msgid "Test LDAP connection"
-msgstr "测试 LDAP 连接"
-
-#: apps/xpack/views/auth.py:87 apps/xpack/views/auth.py:88
-#: apps/xpack/views/auth.py:89
-msgid "Add or modify authentication configuration"
-msgstr "添加或修改认证配置"
-
-#: apps/xpack/views/auth.py:105 apps/xpack/views/auth.py:106
-#: apps/xpack/views/auth.py:107
-msgid "Get authentication configuration"
-msgstr "获取认证配置"
-
-#: apps/xpack/views/auth.py:118 apps/xpack/views/auth.py:119
-#: apps/xpack/views/auth.py:120 apps/xpack/views/chat_user_auth.py:112
-#: apps/xpack/views/chat_user_auth.py:113
-#: apps/xpack/views/chat_user_auth.py:114
-msgid "Ldap Log in"
-msgstr "LDAP 登录"
-
-#: apps/xpack/views/auth.py:121 apps/xpack/views/auth.py:138
-#: apps/xpack/views/auth.py:157 apps/xpack/views/auth.py:176
-#: apps/xpack/views/auth.py:194 apps/xpack/views/auth.py:208
-#: apps/xpack/views/auth.py:266 apps/xpack/views/auth.py:286
-#: apps/xpack/views/auth.py:307 apps/xpack/views/auth.py:327
-#: apps/xpack/views/auth.py:348 apps/xpack/views/auth.py:368
-msgid "Three-party login"
-msgstr "三方登录"
-
-#: apps/xpack/views/auth.py:135 apps/xpack/views/auth.py:136
-#: apps/xpack/views/auth.py:137 apps/xpack/views/chat_user_auth.py:129
-#: apps/xpack/views/chat_user_auth.py:130
-#: apps/xpack/views/chat_user_auth.py:131
-msgid "CAS Log in"
-msgstr "CAS 登录"
-
-#: apps/xpack/views/auth.py:154 apps/xpack/views/auth.py:155
-#: apps/xpack/views/auth.py:156 apps/xpack/views/chat_user_auth.py:148
-#: apps/xpack/views/chat_user_auth.py:149
-#: apps/xpack/views/chat_user_auth.py:150
-msgid "OIDC Log in"
-msgstr "OIDC 登录"
-
-#: apps/xpack/views/auth.py:173 apps/xpack/views/auth.py:174
-#: apps/xpack/views/auth.py:175 apps/xpack/views/chat_user_auth.py:167
-#: apps/xpack/views/chat_user_auth.py:168
-#: apps/xpack/views/chat_user_auth.py:169
-msgid "OAuth2 Log in"
-msgstr "OAuth2 登录"
-
-#: apps/xpack/views/auth.py:191 apps/xpack/views/auth.py:192
-#: apps/xpack/views/auth.py:193 apps/xpack/views/chat_user_auth.py:220
-#: apps/xpack/views/chat_user_auth.py:221
-#: apps/xpack/views/chat_user_auth.py:222
-msgid "Scan code login type"
-msgstr "扫码登录类型"
-
-#: apps/xpack/views/auth.py:205 apps/xpack/views/auth.py:206
-#: apps/xpack/views/auth.py:207 apps/xpack/views/auth.py:220
-#: apps/xpack/views/auth.py:221 apps/xpack/views/auth.py:222
-#: apps/xpack/views/chat_user_auth.py:234
-#: apps/xpack/views/chat_user_auth.py:235
-#: apps/xpack/views/chat_user_auth.py:236
-#: apps/xpack/views/chat_user_auth.py:249
-#: apps/xpack/views/chat_user_auth.py:250
-#: apps/xpack/views/chat_user_auth.py:251
-msgid "Get platform information"
-msgstr "获取平台信息"
-
-#: apps/xpack/views/auth.py:232 apps/xpack/views/auth.py:233
-#: apps/xpack/views/auth.py:234 apps/xpack/views/chat_user_auth.py:261
-#: apps/xpack/views/chat_user_auth.py:262
-#: apps/xpack/views/chat_user_auth.py:263
-msgid "Modify platform information"
-msgstr "修改平台信息"
-
-#: apps/xpack/views/auth.py:246 apps/xpack/views/auth.py:247
-#: apps/xpack/views/auth.py:248 apps/xpack/views/chat_user_auth.py:275
-#: apps/xpack/views/chat_user_auth.py:276
-#: apps/xpack/views/chat_user_auth.py:277
-msgid "Test platform connection"
-msgstr "测试平台连接"
-
-#: apps/xpack/views/auth.py:263 apps/xpack/views/auth.py:264
-#: apps/xpack/views/auth.py:265 apps/xpack/views/chat_user_auth.py:292
-#: apps/xpack/views/chat_user_auth.py:293
-#: apps/xpack/views/chat_user_auth.py:294
-msgid "DingTalk callback"
-msgstr "钉钉回调"
-
-#: apps/xpack/views/auth.py:283 apps/xpack/views/auth.py:284
-#: apps/xpack/views/auth.py:285 apps/xpack/views/chat_user_auth.py:312
-#: apps/xpack/views/chat_user_auth.py:313
-#: apps/xpack/views/chat_user_auth.py:314
-msgid "DingTalk OAuth2 callback"
-msgstr "钉钉 OAuth2 回调"
-
-#: apps/xpack/views/auth.py:304 apps/xpack/views/auth.py:305
-#: apps/xpack/views/auth.py:306 apps/xpack/views/chat_user_auth.py:333
-#: apps/xpack/views/chat_user_auth.py:334
-#: apps/xpack/views/chat_user_auth.py:335
-msgid "WeCom callback"
-msgstr "企业微信回调"
-
-#: apps/xpack/views/auth.py:324 apps/xpack/views/auth.py:325
-#: apps/xpack/views/auth.py:326 apps/xpack/views/chat_user_auth.py:353
-#: apps/xpack/views/chat_user_auth.py:354
-#: apps/xpack/views/chat_user_auth.py:355
-msgid "WeCom OAuth2 callback"
-msgstr "企业微信 OAuth2 回调"
-
-#: apps/xpack/views/auth.py:345 apps/xpack/views/auth.py:346
-#: apps/xpack/views/auth.py:347 apps/xpack/views/chat_user_auth.py:374
-#: apps/xpack/views/chat_user_auth.py:375
-#: apps/xpack/views/chat_user_auth.py:376
-msgid "Lark callback"
-msgstr "飞书回调"
-
-#: apps/xpack/views/auth.py:365 apps/xpack/views/auth.py:366
-#: apps/xpack/views/auth.py:367 apps/xpack/views/chat_user_auth.py:394
-#: apps/xpack/views/chat_user_auth.py:395
-#: apps/xpack/views/chat_user_auth.py:396
-msgid "Lark OAuth2 callback"
-msgstr "飞书 OAuth2 回调"
-
-#: apps/xpack/views/chat_user_auth.py:49 apps/xpack/views/chat_user_auth.py:65
-#: apps/xpack/views/chat_user_auth.py:85 apps/xpack/views/chat_user_auth.py:252
-#: apps/xpack/views/chat_user_auth.py:264
-#: apps/xpack/views/chat_user_auth.py:278
-msgid "Chat User/Authentication Configuration"
-msgstr "对话用户/认证配置"
-
-#: apps/xpack/views/chat_user_auth.py:82 apps/xpack/views/chat_user_auth.py:83
-#: apps/xpack/views/chat_user_auth.py:84
-msgid "Add or modify Chat/Authentication Configuration"
-msgstr "添加或修改对话/认证配置"
-
-#: apps/xpack/views/chat_user_auth.py:99 apps/xpack/views/chat_user_auth.py:100
-#: apps/xpack/views/chat_user_auth.py:101
-msgid "Get Authentication Configuration"
-msgstr "获取认证配置"
-
-#: apps/xpack/views/chat_user_auth.py:102
-msgid "Chat User/login authentication"
-msgstr "对话用户/登录认证"
-
-#: apps/xpack/views/chat_user_auth.py:115
-#: apps/xpack/views/chat_user_auth.py:132
-#: apps/xpack/views/chat_user_auth.py:151
-#: apps/xpack/views/chat_user_auth.py:170
-#: apps/xpack/views/chat_user_auth.py:223
-#: apps/xpack/views/chat_user_auth.py:237
-#: apps/xpack/views/chat_user_auth.py:295
-#: apps/xpack/views/chat_user_auth.py:315
-#: apps/xpack/views/chat_user_auth.py:336
-#: apps/xpack/views/chat_user_auth.py:356
-#: apps/xpack/views/chat_user_auth.py:377
-#: apps/xpack/views/chat_user_auth.py:397
-msgid "Chat User/Three-party login"
-msgstr "对话用户/三方登录"
-
-#: apps/xpack/views/chat_user_auth.py:187
-msgid "Chat User/login"
-msgstr "对话用户/登录"
-
-#: apps/xpack/views/chat_user_auth.py:414
-#: apps/xpack/views/chat_user_auth.py:415
-#: apps/xpack/views/chat_user_auth.py:416
-msgid "Application Password Certification"
-msgstr "智能体密码认证"
-
-#: apps/xpack/views/license.py:31 apps/xpack/views/license.py:32
-#: apps/xpack/views/license.py:33
-msgid "Get license information"
-msgstr "获取许可证信息"
-
-#: apps/xpack/views/license.py:42 apps/xpack/views/license.py:44
-msgid "Update license information"
-msgstr "更新许可证信息"
-
-#: apps/xpack/views/license.py:43
-msgid "Update license information by uploading a new license file"
-msgstr "通过上传新许可证文件更新许可证信息"
-
-#: apps/xpack/views/operate_log.py:21 apps/xpack/views/operate_log.py:22
-#: apps/xpack/views/operate_log.py:23
-msgid "Get menu operate log"
-msgstr "获取菜单操作日志"
-
-#: apps/xpack/views/operate_log.py:25 apps/xpack/views/operate_log.py:41
-#: apps/xpack/views/operate_log.py:57
-msgid "System operate log"
-msgstr "系统操作日志"
-
-#: apps/xpack/views/operate_log.py:36 apps/xpack/views/operate_log.py:37
-#: apps/xpack/views/operate_log.py:38
-msgid "Get paginated operate log"
-msgstr "获取分页操作日志"
-
-#: apps/xpack/views/operate_log.py:54 apps/xpack/views/operate_log.py:55
-#: apps/xpack/views/operate_log.py:56
-msgid "Export operate log"
-msgstr "导出操作日志"
-
-#: apps/xpack/views/platform.py:60 apps/xpack/views/platform.py:61
-#: apps/xpack/views/platform.py:62
-msgid "Get platform configuration"
-msgstr "获取平台配置"
-
-#: apps/xpack/views/platform.py:65 apps/xpack/views/platform.py:79
-msgid "Application/application access"
-msgstr "智能体/智能体访问"
-
-#: apps/xpack/views/platform.py:73 apps/xpack/views/platform.py:74
-#: apps/xpack/views/platform.py:75
-msgid "Update platform configuration"
-msgstr "更新平台配置"
-
-#: apps/xpack/views/platform.py:94 apps/xpack/views/platform.py:95
-#: apps/xpack/views/platform.py:96
-msgid "Get platform status"
-msgstr "获取平台状态"
-
-#: apps/xpack/views/platform.py:98 apps/xpack/views/platform.py:118
-msgid "Application/Get platform status"
-msgstr "智能体/获取平台状态"
-
-#: apps/xpack/views/platform.py:113 apps/xpack/views/platform.py:114
-#: apps/xpack/views/platform.py:115
-msgid "Update platform status"
-msgstr "更新平台状态"
-
-#: apps/xpack/views/resource_chat_user.py:27
-#: apps/xpack/views/resource_chat_user.py:28
-#: apps/xpack/views/resource_chat_user.py:29
-msgid "Get Resource chat user List"
-msgstr "获取资源对话用户列表"
-
-#: apps/xpack/views/resource_chat_user.py:32
-#: apps/xpack/views/resource_chat_user.py:54
-#: apps/xpack/views/resource_chat_user.py:77
-#: apps/xpack/views/system_chat_user_group.py:24
-#: apps/xpack/views/system_chat_user_group.py:45
-#: apps/xpack/views/system_chat_user_group.py:67
-msgid "Chat user"
-msgstr "对话用户"
-
-#: apps/xpack/views/resource_chat_user.py:48
-#: apps/xpack/views/resource_chat_user.py:49
-#: apps/xpack/views/resource_chat_user.py:50
-msgid "Edit Resource chat user List"
-msgstr "编辑资源对话用户列表"
-
-#: apps/xpack/views/resource_chat_user.py:72
-#: apps/xpack/views/resource_chat_user.py:73
-#: apps/xpack/views/resource_chat_user.py:74
-msgid "Get Resource chat user page List"
-msgstr "获取资源对话用户分页列表"
-
-#: apps/xpack/views/system_api_key.py:19 apps/xpack/views/system_api_key.py:20
-#: apps/xpack/views/system_api_key.py:21
-msgid "Create SystemAPIKey"
-msgstr "创建系统 API 密钥"
-
-#: apps/xpack/views/system_api_key.py:34 apps/xpack/views/system_api_key.py:35
-#: apps/xpack/views/system_api_key.py:36
-msgid "Get SystemAPIKey List"
-msgstr "获取系统 API 密钥列表"
-
-#: apps/xpack/views/system_api_key.py:50 apps/xpack/views/system_api_key.py:51
-#: apps/xpack/views/system_api_key.py:52
-msgid "Update SystemAPIKey"
-msgstr "更新系统 API 密钥"
-
-#: apps/xpack/views/system_api_key.py:66 apps/xpack/views/system_api_key.py:67
-#: apps/xpack/views/system_api_key.py:68
-msgid "Delete SystemAPIKey"
-msgstr "删除系统 API 密钥"
-
-#: apps/xpack/views/system_chat_user.py:60
-#: apps/xpack/views/system_chat_user.py:76
-#: apps/xpack/views/system_chat_user.py:89
-#: apps/xpack/views/system_chat_user.py:102
-#: apps/xpack/views/system_chat_user.py:113
-#: apps/xpack/views/system_chat_user.py:131
-#: apps/xpack/views/system_chat_user.py:146
-#: apps/xpack/views/system_chat_user.py:163
-#: apps/xpack/views/system_chat_user.py:180
-#: apps/xpack/views/system_chat_user.py:200
-#: apps/xpack/views/system_chat_user.py:217
-msgid "System/Chat user"
-msgstr "系统/对话用户"
-
-#: apps/xpack/views/system_chat_user.py:73
-#: apps/xpack/views/system_chat_user.py:74
-#: apps/xpack/views/system_chat_user.py:75
-msgid "Get chat user list"
-msgstr "获取对话用户列表"
-
-#: apps/xpack/views/system_chat_user.py:214
-#: apps/xpack/views/system_chat_user.py:216
-msgid "Sync chat users"
-msgstr "同步对话用户"
-
-#: apps/xpack/views/system_chat_user.py:215
-msgid "Sync chat users from external source"
-msgstr "从外部源同步对话用户"
-
-#: apps/xpack/views/system_chat_user.py:235
-#: apps/xpack/views/system_chat_user.py:247
-#: apps/xpack/views/system_chat_user.py:261
-#: apps/xpack/views/system_chat_user.py:279
-#: apps/xpack/views/system_chat_user.py:301
-#: apps/xpack/views/system_chat_user.py:321
-msgid "System/User Group"
-msgstr "系统/用户组"
-
-#: apps/xpack/views/system_chat_user_group.py:19
-#: apps/xpack/views/system_chat_user_group.py:20
-#: apps/xpack/views/system_chat_user_group.py:21
-msgid "Get Resource chat user group List"
-msgstr "获取资源对话用户组列表"
-
-#: apps/xpack/views/system_chat_user_group.py:39
-#: apps/xpack/views/system_chat_user_group.py:40
-#: apps/xpack/views/system_chat_user_group.py:41
-msgid "Edit Resource chat user group List"
-msgstr "编辑资源对话用户组列表"
-
-#: apps/xpack/views/system_chat_user_group.py:62
-#: apps/xpack/views/system_chat_user_group.py:64
-msgid "Get Resource chat user group page List"
-msgstr "获取资源对话用户组分页列表"
-
-#: apps/xpack/views/system_chat_user_group.py:63
-msgid "Get Resource chat user page group List"
-msgstr "获取资源对话用户分页组列表"
-
-#: apps/xpack/views/system_params.py:22 apps/xpack/views/system_params.py:23
-#: apps/xpack/views/system_params.py:24
-msgid "View appearance settings"
-msgstr "查看外观设置"
-
-#: apps/xpack/views/system_params.py:39 apps/xpack/views/system_params.py:40
-#: apps/xpack/views/system_params.py:41
-msgid "Update appearance settings"
-msgstr "更新外观设置"
-
-msgid "Application Access"
-msgstr "智能体接入"
-
-msgid "Display execution details"
-msgstr "是否显示执行详情"
-
-msgid "LOCAL"
-msgstr "账号登录"
-
-msgid "CAS"
-msgstr "CAS"
-
-msgid "LDAP"
-msgstr "LDAP"
-
-msgid "OIDC"
-msgstr "OIDC"
-
-msgid "OAuth2"
-msgstr "OAuth2"
-
-msgid "dingtalk"
-msgstr "钉钉"
-
-msgid "wecom"
-msgstr "企业微信"
-
-msgid "lark"
-msgstr "飞书"
-
-msgid "Get tool list"
-msgstr "获取工具列表"
-
-msgid "Setting"
-msgstr "设置"
-
-msgid "Get verification results"
-msgstr "获取验证结果"
-
-msgid "Validation"
-msgstr "验证"
-
-msgid "Models Resource"
-msgstr "模型资源"
-
-msgid "Tools Resource"
-msgstr "工具资源"
-
-msgid "Get resource model list"
-msgstr "获取资源管理模型列表"
-
-msgid "System Model"
-msgstr "系统模型"
-
-msgid "Dialogue users"
-msgstr "对话用户"
-
-msgid "Conversation log"
-msgstr "对话日志"
-
-msgid "Public access link"
-msgstr "公共访问链接"
-
-msgid "User management"
-msgstr "用户管理"
-
-msgid "Chat User/logout"
-msgstr "对话用户/登出"
-
-msgid "Paragraph"
-msgstr "段落"
-
-msgid "User group"
-msgstr "用户组"
-
-msgid "Remove member from user group"
-msgstr "从用户组中移除成员"
-
-msgid "Create a web site knowledge base"
-msgstr "创建一个web知识库"
-
-msgid "Modify knowledge base information"
-msgstr "修改知识库信息"
-
-msgid "Delete knowledge base"
-msgstr "删除知识库"
-
-msgid "model"
-msgstr "模型"
-
-msgid "Batch add user to group"
-msgstr "批量添加用户到组"
-
-msgid "Add internal tool"
-msgstr "添加内置工具"
-
-msgid "Batch generate related"
-msgstr "批量生成相关"
-
-msgid "Update personal system API_KEY"
-msgstr "更新个人系统 API KEY"
-
-msgid "Delete user group"
-msgstr "删除用户组"
-
-msgid "Add user"
-msgstr "添加用户"
-
-msgid "folder"
-msgstr "文件夹"
-
-msgid "Create or update user group"
-msgstr "创建或更新用户组"
-
-msgid "Edit folder"
-msgstr "编辑文件夹"
-
-msgid "Email settings"
-msgstr "邮箱设置"
-
-msgid "trial listening"
-msgstr "试听"
-
-msgid "Add member to user group"
-msgstr "添加成员到用户组"
-
-msgid "System"
-msgstr "系统"
-
-msgid "Shared Knowledge/Document"
-msgstr "共享知识库/文档"
-
-msgid "System Application"
-msgstr "系统智能体"
-
-msgid "Hit-Test"
-msgstr "命中测试"
-
-msgid "Export Application"
-msgstr "导出智能体"
-
-msgid "Add ApiKey"
-msgstr "添加 API KEY"
-
-msgid "Delete application API_KEY"
-msgstr "删除智能体 API KEY"
-
-msgid "knowledge Base"
-msgstr "知识库"
-
-msgid "API KEY"
-msgstr "API KEY"
-
-msgid "Download"
-msgstr "下载"
-
-msgid "User"
-msgstr "用户"
-
-msgid "Delete personal system API_KEY"
-msgstr "删除个人系统API KEY"
-
-msgid "Add personal system API_KEY"
-msgstr "添加个人系统API KEY"
-
-msgid "Generate related documents"
-msgstr "生成相关文档"
-
-msgid "Modify application access token"
-msgstr "修改智能体程序访问令牌"
-
-msgid "File not exist. Only manually uploaded documents are supported"
-msgstr "文件不存在, 仅支持手动上传的文档"
-
-msgid "Resource"
-msgstr "资源管理"
-
-msgid "LDAP configuration not found or not active"
-msgstr "LDAP 配置未找到或未激活"
-
-msgid "Lark configuration not found or not active"
-msgstr "飞书配置未找到或未激活"
-
-msgid "Failed to get Lark collaborators"
-msgstr "获取飞书协作者失败"
-
-msgid "Failed to get Lark user details"
-msgstr "获取飞书用户详情失败"
-
-msgid "WeCom configuration not found or not active"
-msgstr "企业微信配置未找到或未激活"
-
-msgid "Failed to get WeCom access token"
-msgstr "获取企业微信访问令牌失败"
-
-msgid "Failed to get WeCom agent info"
-msgstr "获取企业微信代理信息失败"
-
-msgid "Failed to get WeCom department users"
-msgstr "获取企业微信部门用户失败"
-
-msgid "Failed to get WeCom user info"
-msgstr "获取企业微信用户信息失败"
-
-msgid "Publish status"
-msgstr "发布状态"
-
-msgid "Unpublished"
-msgstr "未发布"
-
-msgid "Published"
-msgstr "已发布"
-
-msgid "users_permission"
-msgstr "用户权限"
-
-msgid "Get user authorization status of resource"
-msgstr "获取资源对用户的授权状态"
-
-msgid "Edit user authorization status of resource"
-msgstr "修改资源对用户的授权状态"
-
-msgid "Get user authorization status of resource by page"
-msgstr "分页获取资源对用户的授权状态"
-
-msgid "Obtain resource authorization list by page"
-msgstr "分页获取资源授权列表"
-
-msgid "Engine model type"
-msgstr "引擎模型类型"
-
-msgid "If not passed, the default value is 16k_zh (Chinese universal)"
-msgstr "如果未传递，默认值为 16k_zh（中文通用）"
-
-msgid "Chinese telephone universal"
-msgstr "中文电话通用"
-
-msgid "English telephone universal"
-msgstr "英文电话通用"
-
-msgid "Commonly used in Chinese"
-msgstr "中文常用"
-
-msgid "Chinese, English, and Guangdong"
-msgstr "中文、英文和广东话"
-
-msgid "Chinese medical"
-msgstr "中文医疗"
-
-msgid "English"
-msgstr "英文"
-
-msgid "Cantonese"
-msgstr "粤语"
-
-msgid "Japanese"
-msgstr "日语"
-
-msgid "Korean"
-msgstr "韩语"
-
-msgid "Vietnamese"
-msgstr "越南语"
-
-msgid "Malay language"
-msgstr "马来语"
-
-msgid "Indonesian language"
-msgstr "印尼语"
-
-msgid "Filipino language"
-msgstr "菲律宾语"
-
-msgid "Thai"
-msgstr "泰语"
-
-msgid "Portuguese"
-msgstr "葡萄牙语"
-
-msgid "Turkish"
-msgstr "土耳其语"
-
-msgid "Arabic"
-msgstr "阿拉伯语"
-
-msgid "Spanish"
-msgstr "西班牙语"
-
-msgid "Hindi"
-msgstr "印地语"
-
-msgid "French"
-msgstr "法语"
-
-msgid "German"
-msgstr "德语"
-
-msgid "Multiple dialects, supporting 23 dialects"
-msgstr "多种方言，支持 23 种方言"
-
-msgid "This interface is used to recognize short audio files within 60 seconds. Supports Mandarin Chinese, English, Cantonese, Japanese, Vietnamese, Malay, Indonesian, Filipino, Thai, Portuguese, Turkish, Arabic, Hindi, French, German, and 23 Chinese dialects."
-msgstr "本接口用于识别 60 秒之内的短音频文件。支持中文普通话、英语、粤语、日语、越南语、马来语、印度尼西亚语、菲律宾语、泰语、葡萄牙语、土耳其语、阿拉伯语、印地语、法语、德语及 23 种汉语方言。"
-
-msgid "CueWord"
-msgstr "提示词"
-
-msgid "If not passed, the default value is What is this audio saying? Only answer the audio content"
-msgstr "如果未传递，默认值为 这段音频在说什么，只回答音频的内容"
-
-msgid "The Qwen Omni series model supports inputting multiple modalities of data, including video, audio, images, and text, and outputting audio and text."
-msgstr "Qwen-Omni 系列模型支持输入多种模态的数据，包括视频、音频、图片、文本，并输出音频与文本"
-
-msgid "resource authorization"
-msgstr "资源授权"
-
-msgid "The Qwen Audio based end-to-end speech recognition model supports audio recognition within 3 minutes. At present, it mainly supports Chinese and English recognition."
-msgstr "基于Qwen-Audio的端到端语音识别大模型，支持3分钟以内的音频识别，目前主要支持中英文识别。"
-
-msgid "If not passed, the default value is 'zh'"
-msgstr "如果未传递，则默认值为'zh'"
-
-msgid "System resources authorization"
-msgstr "系统资源授权"
-
-msgid "This folder contains resources that you dont have permission"
-msgstr "此文件夹包含您没有权限的资源"
-
-
-msgid "Text to Video"
-msgstr "文生视频"
-
-msgid "Image to Video"
-msgstr "图生视频"
-
-msgid "Authentication failed. Please verify that the parameters are correct"
-msgstr "认证失败，请检查参数是否正确"
-
-msgid "Chat context"
-msgstr "聊天上下文"
-
-msgid "Prompt template"
-msgstr "提示词模板"
-
-msgid "generate prompt"
-msgstr "生成提示词"
-
-msgid "Watermark"
-msgstr "水印"
-
-msgid "Whether to add watermark"
-msgstr "是否添加水印"
-
-msgid "Resolution"
-msgstr "分辨率"
-
-msgid "Ratio"
-msgstr "比例"
-
-msgid "Duration"
-msgstr "时长"
-
-msgid "Failed to generate video"
-msgstr "生成视频失败"
-
-msgid "password"
-msgstr "密码登录"
-
-msgid "Failed to obtain the image"
-msgstr "获取图片失败"
-
-msgid "Update auth setting"
-msgstr "更新认证设置"
-
-msgid "If not passed, the default value is streaming_asr_demo"
-msgstr "如果未传入，则默认值为 streaming_asr_demo"
-
-msgid "If not passed, the default value is 16000"
-msgstr "如果未传入，则默认值为 16000"
-
-msgid "Sample Rate"
-msgstr "采样率"
-
-msgid "Captcha is required"
-msgstr "验证码是必填项"
-
-msgid "Tag"
-msgstr "标签管理"
-
-msgid "Tag Setting"
-msgstr "标签设置"
-
-msgid "Download Original Document"
-msgstr "下载原文档"
-
-msgid "Replace Original Document"
-msgstr "替换原文档"
-
-msgid "Update License"
-msgstr "更新许可证"
-
-msgid "Tag Key"
-msgstr "标签"
-
-msgid "Tag Value"
-msgstr "标签值"
-
-msgid "Tag id does not exist"
-msgstr "标签 ID 不存在"
-
-msgid "Tag key already exists"
-msgstr "标签已存在"
-
-msgid "Tag value already exists"
-msgstr "标签值已存在"
-
-msgid "Non-existent id"
-msgstr "不存在的ID"
-
-msgid "No permission for the target folder"
-msgstr "没有目标文件夹的权限"
-
-msgid "Application token usage statistics"
-msgstr "智能体令牌使用统计"
-
-msgid "Application top question statistics"
-msgstr "智能体提问次数统计"
-
-msgid "SAML2 Metadata"
-msgstr "SAML2 元数据"
-
-msgid "SAML2 Log in"
-msgstr "SAML2 登录"
-
-msgid "SAML2 SSO"
-msgstr "SAML2 单点登录"
-
-msgid "Workflow"
-msgstr "工作流"
-
-msgid "Web source url"
-msgstr "Web 根地址"
-
-msgid "Web knowledge selector"
-msgstr "选择器"
-
-msgid "The default is body, you can enter .classname/#idname/tagname"
-msgstr "默认为 body，可输入 .classname/#idname/tagname"
-
-msgid "Please enter the Web root address"
-msgstr "请输入 Web 根地址"
-
-msgid "File size exceeds limit"
-msgstr "文件大小超出限制"
-
-msgid "File upload is not enabled"
-msgstr "文件上传未启用"
-
-msgid "Blocked unsafe redirect to internal host"
-msgstr "阻止不安全的重定向到内部主机"
-
-msgid "Audio file recognition - Tongyi Qwen"
-msgstr "录音文件识别-通义千问"
-
-msgid "Real-time speech recognition - Fun-ASR/Paraformer"
-msgstr "实时语音识别-Fun-ASR/Paraformer"
-
-msgid "Qwen-Omni"
-msgstr "多模态"
-
-msgid "Super-humanoid: Lingxiaoxuan Flow"
-msgstr "聆小璇"
-
-msgid "Super-humanoid: Lingyuyan Flow"
-msgstr "聆玉言"
-
-msgid "Super-humanoid: Lingfeiyi Flow"
-msgstr "聆飞逸"
-
-msgid "Super-humanoid: Lingxiaoyue Flow"
-msgstr "聆小玥"
-
-msgid "Super-humanoid: Sun Dasheng Flow"
-msgstr "孙大圣"
-
-msgid "Super-humanoid: Lingyuzhao Flow"
-msgstr "聆玉昭"
-
-msgid "Super-humanoid: Lingxiaotang Flow"
-msgstr "聆小糖"
-
-msgid "Super-humanoid: Lingxiaorong Flow"
-msgstr "聆小蓉"
-
-msgid "Super-humanoid: Xinyun Flow"
-msgstr "心云"
-
-msgid "Super-humanoid: Grant (EN)"
-msgstr "Grant"
-
-msgid "Super-humanoid: Lila (EN)"
-msgstr "Lila"
-
-msgid "Super-humanoid: Lingwanwan Pro"
-msgstr "聆万万"
-
-msgid "Super-humanoid: Yiyi Pro"
-msgstr "依依"
-
-msgid "Super-humanoid: Huifangnv Pro"
-msgstr "惠芳女"
-
-msgid "Super-humanoid: Lingxiaoying Pro"
-msgstr "聆小颖"
-
-msgid "Super-humanoid: Lingfeibo Pro"
-msgstr "聆飞博"
-
-msgid "Super-humanoid: Lingyuyan Pro"
-msgstr "聆玉言"
-
-msgid "Login failed %s times, account will be locked, you have %s more chances !"
-msgstr "登录失败 %s 次，账号将被锁定，您还有 %s 次机会！"
-
-msgid "This account has been locked for %s minutes, please try again later"
-msgstr "该账号已被锁定 %s 分钟，请稍后再试"
-
-msgid "User does not have permission to use API Key"
-msgstr "用户没有使用 API Key 的权限"
-
-msgid "Import knowledge workflow"
-msgstr "导入知识工作流"
-
-msgid "Export knowledge workflow"
-msgstr "导出知识工作流"
-
-msgid "Role IDs cannot be empty"
-msgstr "角色 ID 不能为空"
-
-msgid "Some roles do not exist"
-msgstr "部分角色不存在"
-
-msgid "Authorized pagination list for obtaining resources"
-msgstr "获取资源的关系分页列表"
-
-msgid "Resources mapping"
-msgstr "资源映射"
-
-msgid "Batch set user roles"
-msgstr "批量设置用户角色"
-
-msgid "Role Setting cannot be empty"
-msgstr "角色设置不能为空"
-
-msgid "View related resources"
-msgstr "查看关联资源"
-
-msgid "Feedback reason"
-msgstr "反馈理由"
-
-msgid "Other reason content"
-msgstr "其他反馈理由内容"
-
-msgid "accurate"
-msgstr "内容准确"
-
-msgid "complete"
-msgstr "内容完善"
-
-msgid "inaccurate"
-msgstr "内容不准确"
-
-msgid "incomplete"
-msgstr "内容不完善"
-
-msgid "Secret key is invalid"
-msgstr "密钥无效"
-
-msgid "Secret key is expired"
-msgstr "密钥已过期"
-
-msgid "Online Usage"
-msgstr "线上使用"
-
-msgid "API Call"
-msgstr "API 调用"
-
-msgid "Enterprise WeChat"
-msgstr "企业微信应用"
-
-msgid "WeChat Public Account"
-msgstr "微信公众号"
-
+#: apps/application/serializers/application_chat.py:292
 msgid "Lark"
 msgstr "飞书应用"
 
-msgid "DingTalk"
-msgstr "钉钉应用"
-
-msgid "Enterprise WeChat Robot"
-msgstr "企业微信机器人"
-
-msgid "Trigger"
-msgstr "触发器"
-
-msgid "Slack"
-msgstr "Slack 应用"
-
-msgid "Root Directory"
-msgstr "根目录"
-
-msgid "Create trigger"
-msgstr "创建触发器"
-
-msgid "Get the trigger list"
-msgstr "获取触发器列表"
-
-msgid "Get trigger details"
-msgstr "获取触发器详情"
-
-msgid "Modify the trigger"
-msgstr "修改触发器"
-
-msgid "Delete the trigger"
-msgstr "删除触发器"
-
-msgid "Activate trigger in batches"
-msgstr "批量启用/禁用触发器"
-
-msgid "Get the trigger list by page"
-msgstr "分页获取触发器列表"
-
-msgid "Create trigger in source"
-msgstr "资源端创建触发器"
-
-msgid "Delete trigger in batches"
-msgstr "批量删除触发器"
-
-msgid "Get the trigger list of source"
-msgstr "获取资源端触发器列表"
-
-msgid "Get Task source trigger details"
-msgstr "获取资源端触发器详情"
-
-msgid "Delete the task source trigger"
-msgstr "删除资源端触发器"
-
-msgid "Get the task list of triggers"
-msgstr "获取触发器任务列表"
-
-msgid "Retrieve detailed records of tasks executed by the trigger."
-msgstr "获取由该触发器执行的任务详细记录。"
-
-msgid "Get a paginated list of execution records for trigger tasks."
-msgstr "获取触发器任务执行记录的分页列表。"
-
-msgid "%s must be an array"
-msgstr "%s 必须是数组类型"
-
-msgid "%s must not be empty"
-msgstr "%s 不能为空"
-
-msgid "%s values must be between %s and %s"
-msgstr "%s 的值必须在 %s 到 %s 之间"
-
-msgid "Invalid time format: %s, must be HH:MM (e.g., 09:00)"
-msgstr "时间格式无效: %s，必须是 HH:MM 格式 (例如: 09:00)"
-
-msgid "schedule_type must be one of %s"
-msgstr "schedule_type 必须是以下值之一: %s"
-
-msgid "interval_value must be an integer greater than or equal to 1"
-msgstr "interval_value 必须是大于或等于 1 的整数"
-
-msgid "interval_unit must be one of %s"
-msgstr "interval_unit 必须是以下值之一: %s"
-
-msgid "body must be an array"
-msgstr "body 必须是数组类型"
-
-msgid "Error trigger type"
-msgstr "触发器类型错误"
-
-msgid "The following id does not exist: %s"
-msgstr "以下 id 不存在: %s"
-
-msgid "%s must be a dict"
-msgstr "%s 必须是字典类型"
-
-msgid "input_field_list must be a dict"
-msgstr "input_field_list 必须是字典类型"
-
-msgid "%s type requires %s field"
-msgstr "%s 类型需要 %s 字段"
-
-msgid "trigger name"
-msgstr "触发器名称"
-
-msgid "trigger description"
-msgstr "触发器描述"
-
-msgid "trigger setting"
-msgstr "触发器设置"
-
-msgid "Trigger ID"
-msgstr "触发器ID"
-
-msgid "Trigger task can not be empty"
-msgstr "触发器任务不能为空"
-
-msgid "%s id does not exist"
-msgstr "%s id 不存在"
-
-msgid "Trigger id does not exist"
-msgstr "触发器 id 不存在"
-
-msgid "Trigger not found"
-msgstr "未找到触发器"
-
-msgid "Trigger must have at least one task"
-msgstr "触发器必须至少有一个任务"
-
-msgid "Trigger task number must be one"
-msgstr "触发器任务数量必须为一个"
-
-msgid "Incorrect trigger task"
-msgstr "触发器任务不正确"
-
-msgid "Trigger task ID"
-msgstr "触发器任务ID"
-
-msgid "Trigger task record ID"
-msgstr "触发器任务记录ID"
-
-msgid "Trigger task record id does not exist"
-msgstr "触发器任务记录 id 不存在"
-
-msgid "Order field"
-msgstr "排序字段"
-
-msgid "System Trigger"
-msgstr "系统触发器"
-
-msgid "Get the System trigger list of source"
-msgstr "获取来源的系统触发器列表"
-
-msgid "Get System Task source trigger details"
-msgstr "获取系统任务来源触发器详情"
-
-msgid "Modify the System task source trigger"
-msgstr "修改系统任务来源触发器"
-
-msgid "Modify the task source trigger"
-msgstr "修改任务来源触发器"
-
-msgid "Delete the System task source trigger"
-msgstr "删除系统任务来源触发器"
-
-msgid "Invalid source type"
-msgstr "无效的来源类型"
-
-msgid "Shared tool is not supported"
-msgstr "不支持共享工具"
-
-msgid "Read Trigger"
-msgstr "查看触发器"
-
-msgid "Create Trigger"
-msgstr "创建触发器"
-
-msgid "Edit Trigger"
-msgstr "编辑触发器"
-
-msgid "Delete Trigger"
-msgstr "删除触发器"
-
-msgid "Read execute record"
-msgstr "查看执行记录"
-
-msgid "ADMIN"
-msgstr "系统管理员"
-
-msgid "WORKSPACE_MANAGE"
-msgstr "空间管理员"
-
-msgid "USER"
-msgstr "普通用户"
-
-msgid "Generate share link"
-msgstr "生成分享链接"
-
-msgid "Chat record link"
-msgstr "聊天记录链接"
-
-msgid "Get chat record by share link"
-msgstr "通过分享链接获取聊天记录"
-
-msgid "Invalid chat record ids"
-msgstr "无效的聊天记录ID"
-
-msgid "Share link does not exist"
-msgstr "分享链接不存在"
-
-msgid "Chat has been deleted"
-msgstr "聊天记录已被删除"
-
-msgid "cron type requires cron_expression field"
-msgstr "cron 类型需要 cron_expression 字段"
-
-msgid "Invalid cron expression: %s"
-msgstr "Cron 表达式不合法：%s"
-
-msgid "Batch Remove Documents from Tag"
-msgstr "批量删除标签下的文档"
-
-msgid "Document does not belong to current knowledge"
-msgstr "文档不属于当前知识库"
-
-msgid "Move an application"
-msgstr "移动应用程序"
-
-msgid "Batch delete applications"
-msgstr "批量删除应用"
-
-msgid "Batch move applications"
-msgstr "批量移动应用"
-
-msgid "Batch delete knowledge"
-msgstr "批量删除知识库"
-
-msgid "Batch move knowledge"
-msgstr "批量移动知识库"
-
-msgid "Batch delete tools"
-msgstr "批量删除工具"
-
-msgid "Batch move tools"
-msgstr "批量移动工具"
-
-msgid "Model is not allowed to be empty"
-msgstr "模型不能为空"
-
-msgid "Not a valid zip file"
-msgstr "不是有效的 zip 文件"
-
-msgid "Not a valid KB export file, missing knowledge.json"
-msgstr "不是有效的知识库导出文件，缺少 knowledge.json"
-
-msgid "Not a valid KB export file, missing knowledge.xlsx"
-msgstr "不是有效的知识库导出文件，缺少 knowledge.xlsx"
-
-msgid "Tags"
-msgstr "标签"
-
-msgid "Hit handling method"
-msgstr "命中处理方式"
-
-msgid "Directly return similarity"
-msgstr "直接返回相似度"
-
-msgid "Paragraph is active"
-msgstr "分段是否启用"
-
-msgid "Document type"
-msgstr "文档类型"
-
-msgid "Document meta"
-msgstr "文档元数据"
-
-msgid "Export knowledge bundle"
-msgstr "导出知识库"
-
-msgid "Import knowledge bundle"
-msgstr "导入知识库"
-
-msgid "Export system knowledge bundle"
-msgstr "导出系统知识库"
-
-msgid "Export shared knowledge bundle"
-msgstr "导出共享知识库"
-
-msgid "Batch delete"
-msgstr "批量删除"
-
-msgid "Batch move"
-msgstr "批量移动"
-
-msgid "There is a circular dependency in the tool workflow"
-msgstr "工具工作流存在循环依赖"
-
-msgid "model_params_form must be a list"
-msgstr "model_params_form 必须是一个列表"
-
-msgid "The {index}th item in model_params_form must be a dictionary"
-msgstr "model_params_form 中的第 {index} 项必须是一个字典"
-
-msgid "The label field is required for the {index}th item in model_params_form"
-msgstr "model_params_form 中的第 {index} 项的 label 字段是必填项"
-
-msgid "Publish"
-msgstr "发布"
-
-msgid "token is required for EVENT triggers"
-msgstr "事件触发器必须设置 token"
-
-msgid "Home page"
-msgstr "首页"
-
-msgid "Response code"
-msgstr "响应码"
-
-msgid "Response message"
-msgstr "响应消息"
-
-msgid "Total count"
-msgstr "总数量"
-
-msgid "Application data aggregation"
-msgstr "应用数据聚合"
-
-msgid "Knowledge data aggregation"
-msgstr "知识库数据聚合"
-
-msgid "Tool data aggregation"
-msgstr "工具数据聚合"
-
+#: no source
+msgid "lark"
+msgstr "飞书"
+
+#: no source
+msgid "Lark application: "
+msgstr "飞书智能体: "
+
+#: no source
+msgid "Lark callback"
+msgstr "飞书回调"
+
+#: no source
+msgid "Lark configuration not found or not active"
+msgstr "飞书配置未找到或未激活"
+
+#: no source
+msgid "Lark OAuth2 callback"
+msgstr "飞书 OAuth2 回调"
+
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:36
+msgid "Last frame url"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:33
+msgid "Latest flagship model with enhanced reasoning and coding. 204K context window"
+msgstr ""
+
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:48
+msgid "Latest Gemini 1.0 Pro model, updated with Google update"
+msgstr "最新的 Gemini 1.0 Pro 模型，更新了 Google 更新"
+
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:55
+msgid "Latest Gemini 1.0 Pro Vision model, updated with Google update"
+msgstr "最新的Gemini 1.0 Pro Vision模型，随Google更新而更新"
+
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:65
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:72
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:82
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:89
+msgid "Latest Gemini 1.5 Flash model, updated with Google updates"
+msgstr "最新的Gemini 1.5 Flash模型，随Google更新而更新"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:38
+msgid "Latest gpt-4, updated with OpenAI adjustments"
+msgstr "最新的gpt-4，随OpenAI调整而更新"
+
+#: no source
+msgid "LDAP configuration not found or not active"
+msgstr "LDAP 配置未找到或未激活"
+
+#: no source
+msgid "LDAP filter cannot be empty"
+msgstr "LDAP过滤器不能为空"
+
+#: no source
+msgid "Ldap Log in"
+msgstr "LDAP 登录"
+
+#: no source
+msgid "LDAP mapping cannot be empty"
+msgstr "LDAP映射不能为空"
+
+#: no source
+msgid "LDAP server cannot be empty"
+msgstr "LDAP server不能为空"
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:28
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:31
+msgid "Library ID"
+msgstr "工具 ID"
+
+#: no source
+msgid "license details"
+msgstr "license 详情"
+
+#: no source
+msgid "license file"
+msgstr "license 文件"
+
+#: no source
+msgid "License file is required"
+msgstr "license 文件是必需的"
+
+#: no source
+msgid "License usage limit exceeded."
+msgstr "License 使用限制已超出。"
+
+#: no source
+msgid "license version"
+msgstr "license 版本"
+
+#: apps/chat/views/chat_record.py:29
+#: apps/chat/views/chat_record.py:30
+#: apps/chat/views/chat_record.py:31
+msgid "Like, Dislike"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:37
+#: apps/knowledge/serializers/document.py:198
+msgid "limit"
+msgstr "限制"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:43
+msgid "limit reference"
+msgstr ""
+
+#: apps/common/utils/common.py:322
+msgid "Limit {count} exceeded, please contact us (https://fit2cloud.com/)."
+msgstr "超过限制 {count}，请联系我们 (https://fit2cloud.com/)."
+
+#: apps/application/serializers/application_chat_link.py:119
+msgid "Link"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:33
+msgid "List of document ids to exclude"
+msgstr "排除的文档 ID 列表"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:36
+msgid "List of exclusion vector ids"
+msgstr "排除的向量 ID 列表"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:60
+msgid "Llama 2 is a set of pretrained and fine-tuned generative text models ranging in size from 7 billion to 70 billion. This is a repository of 13B pretrained models. Links to other models can be found in the index at the bottom."
+msgstr "Llama 2 是一组经过预训练和微调的生成文本模型，其规模从 70 亿到 700 亿个不等。这是 13B 预训练模型的存储库。其他模型的链接可以在底部的索引中找到。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:64
+msgid "Llama 2 is a set of pretrained and fine-tuned generative text models ranging in size from 7 billion to 70 billion. This is a repository of 70B pretrained models. Links to other models can be found in the index at the bottom."
+msgstr "Llama 2 是一组经过预训练和微调的生成文本模型，其规模从 70 亿到 700 亿个不等。这是 70B 预训练模型的存储库。其他模型的链接可以在底部的索引中找到。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:56
+msgid "Llama 2 is a set of pretrained and fine-tuned generative text models ranging in size from 7 billion to 70 billion. This is a repository of 7B pretrained models. Links to other models can be found in the index at the bottom."
+msgstr "Llama 2 是一组经过预训练和微调的生成文本模型，其规模从 70 亿到 700 亿个不等。这是 7B 预训练模型的存储库。其他模型的链接可以在底部的索引中找到。"
+
+#: no source
+msgid "Llama-2-13b-chat was developed by Meta AI and is open source. It performs well in scenarios such as coding, reasoning and knowledge application. Llama-2-13b-chat is a native open source version with balanced performance and effect, suitable for conversation scenarios."
+msgstr "Llama-2-13b-chat由Meta AI研发并开源，在编码、推理及知识智能体等场景表现优秀，Llama-2-13b-chat是性能与效果均衡的原生开源版本，适用于对话场景。"
+
+#: no source
+msgid "Llama-2-70b-chat was developed by Meta AI and is open source. It performs well in scenarios such as coding, reasoning, and knowledge application. Llama-2-70b-chat is a native open source version with high-precision effects."
+msgstr "Llama-2-70b-chat由Meta AI研发并开源，在编码、推理及知识智能体等场景表现优秀，Llama-2-70b-chat是高精度效果的原生开源版本。"
+
+#: apps/models_provider/base_model_provider.py:147
+msgid "LLM"
+msgstr "大语言模型"
+
+#: no source
+msgid "LOCAL"
+msgstr "账号登录"
+
+#: apps/models_provider/impl/local_model_provider/local_model_provider.py:40
+msgid "local model"
+msgstr "本地模型"
+
+#: apps/users/views/login.py:38
+#: apps/users/views/login.py:39
+#: apps/users/views/login.py:40
+msgid "Log in"
+msgstr "登录"
+
+#: apps/common/constants/permission_constants.py:401
+msgid "Login Auth"
+msgstr "登录认证"
+
+#: apps/common/auth/handle/impl/user_token.py:311
+msgid "Login expired"
+msgstr "登录已过期"
+
+#: apps/users/serializers/login.py:241
+msgid "Login failed %s times, account will be locked, you have %s more chances !"
+msgstr "登录失败 %s 次，账号将被锁定，您还有 %s 次机会！"
+
+#: no source
+msgid "login image"
+msgstr "登录图片"
+
+#: no source
+msgid "login logo"
+msgstr "登录 logo"
+
+#: no source
+msgid "Long Fei"
+msgstr "龙飞"
+
+#: no source
+msgid "Long Jielidou"
+msgstr "龙杰力豆"
+
+#: no source
+msgid "Long Jing"
+msgstr "龙婧"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:31
+msgid "Long Laotie"
+msgstr "龙老铁"
+
+#: no source
+msgid "Long Miao"
+msgstr "龙妙"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:32
+msgid "Long Shu"
+msgstr "龙书"
+
+#: no source
+msgid "Long Shuo"
+msgstr "龙硕"
+
+#: no source
+msgid "Long Tong"
+msgstr "龙彤"
+
+#: no source
+msgid "Long Xiang"
+msgstr "龙祥"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:30
+msgid "Long Xiaobai"
+msgstr "龙小白"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:29
+msgid "Long Xiaochen"
+msgstr "龙小诚"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:27
+msgid "Long Xiaochun"
+msgstr "龙小淳"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:28
+msgid "Long Xiaoxia"
+msgstr "龙小夏"
+
+#: no source
+msgid "Long Yuan"
+msgstr "龙媛"
+
+#: no source
+msgid "Long Yue"
+msgstr "龙悦"
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:20
+msgid "loop_type"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:26
+msgid "Malay language"
+msgstr "马来语"
+
+#: apps/system_manage/views/resource_mapping.py:67
+msgid "Mapping Resource"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:37
+msgid "Maximum length of the knowledge base paragraph"
+msgstr "知识库段落的最大长度"
+
+#: apps/application/serializers/application.py:209
+msgid "Maximum number of quoted characters"
+msgstr "引用字符的最大数量"
+
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:27
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:33
+msgid "Maximum number of words in a quoted segment"
+msgstr "引用段落的最大字数"
+
+#: apps/tools/serializers/tool.py:168
+msgid "MCP configuration is invalid"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:38
+msgid "MCP Server"
+msgstr ""
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:14
+msgid "Mcp server"
+msgstr ""
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:13
+msgid "Mcp servers"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:42
+msgid "MCP Source"
+msgstr ""
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:17
+msgid "Mcp source"
+msgstr ""
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:15
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:16
+msgid "Mcp tool"
+msgstr "Mcp 工具"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:39
+msgid "MCP Tool ID"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:41
+msgid "MCP Tool IDs"
+msgstr ""
+
+#: no source
+msgid "Members"
+msgstr "成员集合"
+
+#: no source
+msgid "menu"
+msgstr "菜单"
+
+#: no source
+msgid "Menu"
+msgstr "菜单"
+
+#: no source
+msgid "menu_label"
+msgstr "菜单标签"
+
+#: no source
+msgid "message"
+msgstr "消息"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:99
+msgid "message type error"
+msgstr "消息类型错误"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:36
+#: apps/common/field/common.py:24
+#: apps/common/field/common.py:37
+msgid "Message type error"
+msgstr "消息类型错误"
+
+#: no source
+msgid "Message types not supported yet"
+msgstr "消息类型暂不支持"
+
+#: apps/tools/serializers/tool.py:1572
+msgid "Messages"
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:76
+msgid "Meta Llama 3: The most capable public product LLM to date. 70 billion parameters."
+msgstr "Meta Llama 3：迄今为止最有能力的公开产品LLM。700亿参数。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:72
+msgid "Meta Llama 3: The most capable public product LLM to date. 8 billion parameters."
+msgstr "Meta Llama 3：迄今为止最有能力的公开产品LLM。80亿参数。"
+
+#: apps/local_model/serializers/model_apply_serializers.py:105
+#: apps/models_provider/serializers/model_apply_serializers.py:42
+msgid "metadata"
+msgstr "元数据"
+
+#: apps/models_provider/api/provide.py:39
+msgid "method"
+msgstr "方法"
+
+#: apps/common/constants/permission_constants.py:368
+msgid "Migrate"
+msgstr "迁移"
+
+#: apps/knowledge/views/document.py:1154
+#: apps/knowledge/views/document.py:1155
+msgid "Migrate documents in batches"
+msgstr "批量迁移文档"
+
+#: apps/knowledge/views/paragraph.py:105
+#: apps/knowledge/views/paragraph.py:106
+msgid "Migrate paragraphs in batches"
+msgstr "批量迁移段落"
+
+#: no source
+msgid "Migrate shared documents in batches"
+msgstr "批量迁移共享文档"
+
+#: no source
+msgid "Migrate shared paragraphs in batches"
+msgstr "批量迁移共享段落"
+
+#: no source
+msgid "Migrate system knowledges in batches"
+msgstr "批量迁移知识库"
+
+#: no source
+msgid "Migrate system paragraphs in batches"
+msgstr "批量迁移段落"
+
+#: apps/application/api/application_chat.py:82
+#: apps/application/serializers/application_chat.py:62
+msgid "Minimum number of clicks"
+msgstr "最小点击数"
+
+#: apps/application/api/application_chat.py:76
+#: apps/application/serializers/application_chat.py:60
+msgid "Minimum number of likes"
+msgstr "最小点赞数"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:95
+msgid "Mixed element visual model"
+msgstr "混元视觉模型"
+
+#: apps/application/serializers/application.py:348
+#: apps/application/serializers/application.py:595
+#: apps/chat/serializers/chat.py:156
+#: apps/common/constants/permission_constants.py:342
+#: apps/common/constants/permission_constants.py:411
+#: apps/common/constants/permission_constants.py:421
+#: apps/common/constants/permission_constants.py:436
+#: apps/models_provider/views/model.py:64
+#: apps/models_provider/views/model.py:86
+#: apps/models_provider/views/model.py:99
+#: apps/models_provider/views/model.py:120
+#: apps/models_provider/views/model.py:143
+#: apps/models_provider/views/model.py:164
+#: apps/models_provider/views/model.py:186
+#: apps/models_provider/views/model.py:207
+#: apps/models_provider/views/model.py:234
+#: apps/models_provider/views/model.py:256
+#: apps/models_provider/views/model.py:301
+#: apps/models_provider/views/model_apply.py:29
+#: apps/models_provider/views/model_apply.py:41
+#: apps/models_provider/views/model_apply.py:53
+#: apps/models_provider/views/provide.py:25
+#: apps/models_provider/views/provide.py:48
+#: apps/models_provider/views/provide.py:62
+#: apps/models_provider/views/provide.py:80
+#: apps/models_provider/views/provide.py:97
+msgid "Model"
+msgstr "模型"
+
+#: no source
+msgid "model"
+msgstr "模型"
+
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:52
+#: apps/models_provider/impl/local_model_provider/credential/embedding/web.py:37
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:64
+#: apps/models_provider/impl/local_model_provider/credential/reranker/web.py:37
+msgid "Model catalog"
+msgstr "模型目录"
+
+#: apps/homepage/views/homepage.py:322
+#: apps/homepage/views/homepage.py:323
 msgid "Model data aggregation"
 msgstr "模型数据聚合"
 
-msgid "Total application count"
-msgstr "应用总数"
+#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:65
+#: apps/application/serializers/application.py:241
+#: apps/application/serializers/application.py:1285
+#: apps/application/serializers/application.py:1291
+#: apps/application/serializers/application.py:1297
+#: apps/application/serializers/application.py:1303
+#: apps/knowledge/serializers/document.py:861
+#: apps/knowledge/serializers/knowledge.py:344
+#: apps/models_provider/serializers/model_serializer.py:140
+#: apps/models_provider/serializers/model_serializer.py:160
+#: apps/models_provider/serializers/model_serializer.py:498
+#: apps/models_provider/tools.py:116
+msgid "Model does not exist"
+msgstr "模型不存在"
 
-msgid "Published application count"
-msgstr "已发布应用数量"
+#: apps/chat/serializers/chat.py:188
+#: apps/tools/serializers/tool.py:1602
+msgid "Model does not exists or is not an LLM model"
+msgstr ""
 
-msgid "Unpublished application count"
-msgstr "未发布应用数量"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:56
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:29
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:19
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:13
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:13
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:14
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:19
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:22
+#: apps/application/flow/step_node/question_node/i_question_node.py:19
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:13
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:14
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:13
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:13
+#: apps/application/serializers/application.py:228
+#: apps/application/serializers/application.py:465
+#: apps/application/serializers/application.py:465
+#: apps/knowledge/serializers/common.py:77
+msgid "Model id"
+msgstr "模型ID"
 
-msgid "Total knowledge count"
-msgstr "知识库总数"
+#: apps/knowledge/serializers/document.py:237
+#: apps/knowledge/serializers/paragraph.py:93
+#: apps/local_model/serializers/model_apply_serializers.py:129
+#: apps/models_provider/api/model.py:105
+#: apps/models_provider/serializers/model_apply_serializers.py:51
+#: apps/models_provider/serializers/model_serializer.py:128
+#: apps/models_provider/serializers/model_serializer.py:481
+msgid "model id"
+msgstr "模型ID"
 
-msgid "Total document count"
-msgstr "文档总数"
+#: apps/tools/serializers/tool.py:1570
+msgid "Model ID"
+msgstr ""
 
-msgid "Failed document count"
-msgstr "失败文档数量"
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:20
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:14
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:14
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:15
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:20
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:23
+#: apps/application/flow/step_node/question_node/i_question_node.py:20
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:14
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:15
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:14
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:14
+msgid "Model id type"
+msgstr ""
 
-msgid "Total tool count"
-msgstr "工具总数"
+#: apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py:205
+#: apps/application/flow/step_node/image_generate_step_node/impl/base_image_generate_node.py:41
+#: apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py:44
+#: apps/application/flow/step_node/image_understand_step_node/impl/base_image_understand_node.py:157
+#: apps/application/flow/step_node/intent_node/impl/base_intent_node.py:67
+#: apps/application/flow/step_node/parameter_extraction_node/impl/base_parameter_extraction_node.py:99
+#: apps/application/flow/step_node/question_node/impl/base_question_node.py:98
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:77
+#: apps/application/flow/step_node/speech_to_text_step_node/impl/base_speech_to_text_node.py:39
+#: apps/application/flow/step_node/text_to_speech_step_node/impl/base_text_to_speech_node.py:63
+#: apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py:44
+#: apps/application/flow/step_node/video_understand_step_node/impl/base_video_understand_node.py:154
+msgid "Model is not allowed to be empty"
+msgstr "模型不能为空"
 
-msgid "Active tool count"
-msgstr "启用工具数量"
+#: apps/models_provider/api/model.py:37
+#: apps/models_provider/api/provide.py:17
+#: apps/models_provider/api/provide.py:23
+#: apps/models_provider/api/provide.py:28
+#: apps/models_provider/api/provide.py:30
+#: apps/models_provider/api/provide.py:82
+#: apps/models_provider/serializers/model_serializer.py:63
+#: apps/models_provider/serializers/model_serializer.py:248
+#: apps/models_provider/serializers/model_serializer.py:285
+#: apps/models_provider/serializers/model_serializer.py:359
+#: apps/models_provider/serializers/model_serializer.py:542
+msgid "model name"
+msgstr "模型名称"
 
-msgid "Inactive tool count"
-msgstr "停用工具数量"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:85
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:33
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:32
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:33
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:32
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:27
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:20
+#: apps/application/flow/step_node/question_node/i_question_node.py:33
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:23
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:23
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:32
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:31
+msgid "Model parameter settings"
+msgstr "模型参数设置"
 
-msgid "Total model count"
-msgstr "模型总数"
+#: apps/application/serializers/application.py:382
+#: apps/application/serializers/application.py:613
+msgid "Model parameters"
+msgstr "模型参数"
 
-msgid "Active model count"
-msgstr "启用模型数量"
+#: apps/tools/serializers/tool.py:1573
+msgid "Model Params Setting"
+msgstr ""
 
-msgid "Inactive model count"
-msgstr "停用模型数量"
+#: apps/models_provider/serializers/model_serializer.py:349
+msgid "Model saving failed"
+msgstr "模型保存失败"
 
-msgid "Top applications by token consumption"
-msgstr "tokens 消耗 TOP 智能体"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:82
+msgid "Model settings"
+msgstr "模型设置"
 
-msgid "Top applications by question count"
-msgstr "提问次数 TOP 智能体"
+#: apps/application/serializers/application.py:608
+msgid "Model setup"
+msgstr "模型设置"
 
-msgid "Top users by token consumption"
-msgstr "tokens 消耗 TOP 用户"
+#: apps/models_provider/api/model.py:44
+#: apps/models_provider/api/provide.py:29
+#: apps/models_provider/api/provide.py:70
+#: apps/models_provider/api/provide.py:98
+#: apps/models_provider/serializers/model_serializer.py:65
+#: apps/models_provider/serializers/model_serializer.py:250
+#: apps/models_provider/serializers/model_serializer.py:287
+#: apps/models_provider/serializers/model_serializer.py:360
+#: apps/models_provider/serializers/model_serializer.py:543
+msgid "model type"
+msgstr "模型类型"
 
-msgid "Application tokens ranking list"
-msgstr "应用 tokens 消耗排行榜列表"
+#: apps/models_provider/base_model_provider.py:60
+msgid "Model type cannot be empty"
+msgstr "模型类型不能为空"
 
-msgid "Application question ranking list"
-msgstr "应用提问次数排行榜列表"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:26
+msgid "Model type error"
+msgstr "模型类型错误"
 
-msgid "User tokens ranking list"
-msgstr "用户 tokens 消耗排行榜列表"
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:34
+msgid "Model type is not supported"
+msgstr ""
 
-msgid "Application name"
-msgstr "应用名称"
+#: no source
+msgid "Models Resource"
+msgstr "模型资源"
 
-msgid "Total consumed tokens"
-msgstr "消耗 tokens 总数"
+#: apps/local_model/serializers/model_apply_serializers.py:114
+msgid "model_name"
+msgstr ""
 
-msgid "Question count"
-msgstr "提问次数"
+#: apps/models_provider/serializers/model_serializer.py:517
+msgid "model_params_form must be a list"
+msgstr "model_params_form 必须是一个列表"
 
-msgid "Chat user ID"
-msgstr "对话用户 ID"
+#: apps/local_model/serializers/model_apply_serializers.py:116
+msgid "model_type"
+msgstr ""
 
-msgid "Chat user type"
-msgstr "对话用户类型"
+#: apps/application/serializers/application.py:470
+#: apps/application/serializers/application.py:470
+msgid "Modification time"
+msgstr "修改时间"
 
-msgid "Asker user information"
-msgstr "提问用户信息"
+#: apps/application/views/application_access_token.py:38
+#: apps/application/views/application_access_token.py:39
+#: apps/application/views/application_access_token.py:40
+msgid "Modify application access restriction information"
+msgstr "修改智能体访问限制信息"
 
-msgid "Termbase"
-msgstr "词库"
+#: no source
+msgid "Modify application access token"
+msgstr "修改智能体程序访问令牌"
 
-msgid "Copy"
-msgstr "复制"
+#: apps/application/views/application_api_key.py:83
+#: apps/application/views/application_api_key.py:84
+#: apps/application/views/application_api_key.py:85
+msgid "Modify application API_KEY"
+msgstr "修改智能体 API 密钥"
 
-msgid "ranking"
-msgstr "排名"
+#: no source
+msgid "Modify Application Settings"
+msgstr "修改智能体设置"
 
-msgid "Token consumption"
-msgstr "Token消耗"
+#: apps/application/views/application_version.py:100
+#: apps/application/views/application_version.py:101
+#: apps/application/views/application_version.py:102
+msgid "Modify application version information"
+msgstr "修改智能体版本信息"
 
-msgid "proportion"
-msgstr "占比"
+#: apps/chat/views/chat_record.py:68
+#: apps/chat/views/chat_record.py:69
+#: apps/chat/views/chat_record.py:70
+msgid "Modify conversation about"
+msgstr ""
 
+#: apps/users/views/user.py:374
+#: apps/users/views/user.py:375
+#: apps/users/views/user.py:376
+msgid "Modify current user password"
+msgstr "修改当前用户密码"
+
+#: apps/knowledge/views/document.py:152
+#: apps/knowledge/views/document.py:153
+#: apps/knowledge/views/document.py:154
+msgid "Modify document"
+msgstr "修改文档"
+
+#: apps/knowledge/views/document.py:287
+#: apps/knowledge/views/document.py:288
+#: apps/knowledge/views/document.py:289
+msgid "Modify document hit processing methods in batches"
+msgstr "批量修改文档命中处理方法"
+
+#: no source
+msgid "Modify knowledge base information"
+msgstr "修改知识库信息"
+
+#: apps/knowledge/views/knowledge_workflow_version.py:110
+#: apps/knowledge/views/knowledge_workflow_version.py:111
+#: apps/knowledge/views/knowledge_workflow_version.py:112
+msgid "Modify knowledge version information"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:175
+#: apps/knowledge/views/paragraph.py:176
+#: apps/knowledge/views/paragraph.py:177
+msgid "Modify paragraph data"
+msgstr "修改段落数据"
+
+#: no source
+msgid "Modify platform information"
+msgstr "修改平台信息"
+
+#: apps/knowledge/views/problem.py:198
+#: apps/knowledge/views/problem.py:199
+#: apps/knowledge/views/problem.py:200
+msgid "Modify question"
+msgstr "修改问题"
+
+#: no source
+msgid "Modify shared document"
+msgstr "修改共享文档"
+
+#: no source
+msgid "Modify shared document hit processing methods in batches"
+msgstr "批量修改文档命中处理方法"
+
+#: no source
+msgid "Modify shared paragraph data"
+msgstr "修改段落数据"
+
+#: no source
+msgid "Modify shared question"
+msgstr "修改问题"
+
+#: no source
+msgid "Modify system document"
+msgstr "修改文档"
+
+#: no source
+msgid "Modify system document hit processing methods in batches"
+msgstr "批量修改文档命中处理方式"
+
+#: no source
+msgid "Modify system paragraph data"
+msgstr "修改段落数据"
+
+#: no source
+msgid "Modify system question"
+msgstr "修改问题"
+
+#: apps/knowledge/views/termbase.py:199
+#: apps/knowledge/views/termbase.py:200
+#: apps/knowledge/views/termbase.py:201
+msgid "Modify termbase"
+msgstr ""
+
+#: apps/application/views/application.py:195
+#: apps/application/views/application.py:196
+#: apps/application/views/application.py:197
+msgid "Modify the application"
+msgstr "修改智能体"
+
+#: apps/system_manage/views/user_resource_permission.py:61
+#: apps/system_manage/views/user_resource_permission.py:62
+msgid "Modify the resource authorization list"
+msgstr "修改资源授权列表"
+
+#: no source
+msgid "Modify the System task source trigger"
+msgstr "修改系统任务来源触发器"
+
+#: apps/trigger/views/trigger.py:342
+#: apps/trigger/views/trigger.py:343
+#: apps/trigger/views/trigger.py:344
+msgid "Modify the task source trigger"
+msgstr "修改任务来源触发器"
+
+#: apps/trigger/views/trigger.py:127
+#: apps/trigger/views/trigger.py:128
+#: apps/trigger/views/trigger.py:129
+msgid "Modify the trigger"
+msgstr "修改触发器"
+
+#: apps/tools/views/tool_workflow_version.py:111
+#: apps/tools/views/tool_workflow_version.py:112
+#: apps/tools/views/tool_workflow_version.py:113
+msgid "Modify tool version information"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:38
+msgid "monster style"
+msgstr "怪兽风格"
+
+#: apps/application/views/application.py:245
+#: apps/application/views/application.py:246
+#: apps/application/views/application.py:247
+msgid "Move an application"
+msgstr "移动应用程序"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:37
+msgid "Multiple dialects, supporting 23 dialects"
+msgstr "多种方言，支持 23 种方言"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:97
+#: apps/tools/serializers/tool_workflow.py:128
+#: apps/users/serializers/user.py:396
+msgid "Name"
+msgstr "用户名"
+
+#: no source
+msgid "Network error or folder token error!"
+msgstr "网络错误或文件夹令牌错误！"
+
+#: no source
+msgid "New chat"
+msgstr "已生成新对话，请重新提问！"
+
+#: apps/knowledge/serializers/paragraph.py:802
+msgid "new_position must be an integer"
+msgstr "new_position 必须是整数"
+
+#: apps/users/serializers/user.py:68
+#: apps/users/serializers/user.py:199
+msgid "Nick name"
+msgstr "姓名"
+
+#: apps/users/serializers/user.py:242
+msgid "Nick Name"
+msgstr ""
+
+#: no source
+msgid "Nickname"
+msgstr "姓名"
+
+#: apps/users/serializers/user.py:419
+msgid "Nickname is already in use"
+msgstr "Nickname已被使用"
+
+#: apps/system_manage/api/user_resource_permission.py:117
+msgid "nick_name"
+msgstr ""
+
+#: apps/application/serializers/application.py:259
+msgid "No citation segmentation prompt"
+msgstr "无引用段落提示"
+
+#: apps/oss/views/file.py:85
+msgid "No permission"
+msgstr ""
+
+#: apps/folders/serializers/folder.py:228
+msgid "No permission for the target folder"
+msgstr "没有目标文件夹的权限"
+
+#: apps/application/serializers/application_chat_record.py:293
+#: apps/application/serializers/application_chat_record.py:430
+#: apps/application/serializers/application_chat_record.py:504
+#: apps/common/auth/authentication.py:139
+msgid "No permission to access"
+msgstr "无权限访问"
+
+#: no source
+msgid "No permission to use this function {name}"
+msgstr "无权限使用此工具 {name}"
+
+#: no source
+msgid "No permission to use this model {model_name}"
+msgstr "无权限使用此模型{model_name}"
+
+#: apps/application/serializers/application.py:137
+#: apps/application/serializers/application.py:788
+msgid "No permission to use tool(s): {tool_ids}"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:77
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:47
+msgid "No reference segment settings"
+msgstr "无参考段设置"
+
+#: apps/application/serializers/application.py:201
+msgid "No reference status"
+msgstr "无参考状态"
+
+#: apps/chat/serializers/chat.py:83
+msgid "Node id"
+msgstr "节点 ID"
+
+#: apps/chat/serializers/chat.py:89
+msgid "Node parameters"
+msgstr "节点参数"
+
+#: apps/application/flow/common.py:267
+msgid "Node {node} is unavailable"
+msgstr "节点 {node} 不可用"
+
+#: no source
+msgid "Non-existent application|knowledge base id["
+msgstr "不存在的智能体|知识库 ID["
+
+#: apps/chat/serializers/chat_record.py:178
+msgid "Non-existent chatID"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:64
+msgid "Non-existent conversation chat_record_id"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:82
+msgid "Non-existent id"
+msgstr "不存在的ID"
+
+#: apps/common/field/common.py:48
+msgid "not a function"
+msgstr "不是函数"
+
+#: apps/knowledge/serializers/knowledge.py:904
+msgid "Not a valid KB export file, missing knowledge.json"
+msgstr "不是有效的知识库导出文件，缺少 knowledge.json"
+
+#: apps/knowledge/serializers/knowledge.py:906
+msgid "Not a valid KB export file, missing knowledge.xlsx"
+msgstr "不是有效的知识库导出文件，缺少 knowledge.xlsx"
+
+#: apps/knowledge/serializers/knowledge.py:899
+msgid "Not a valid zip file"
+msgstr "不是有效的 zip 文件"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:17
+msgid "Not limited to style"
+msgstr "不限于风格"
+
+#: apps/common/auth/authenticate.py:82
+#: apps/common/auth/authenticate.py:108
+#: apps/common/auth/authenticate.py:134
+msgid "Not logged in, please log in first"
+msgstr "未登录，请先登录"
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:24
+msgid "number"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:41
+#: apps/application/serializers/application_stats.py:28
+msgid "Number of conversations"
+msgstr "对话数量"
+
+#: apps/application/serializers/application_chat.py:42
+#: apps/application/serializers/application_stats.py:32
+msgid "Number of Likes"
+msgstr "点赞数量"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:34
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:27
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:23
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:24
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:22
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:25
+#: apps/application/flow/step_node/question_node/i_question_node.py:28
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:23
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:21
+msgid "Number of multi-round conversations"
+msgstr "多轮对话的数量"
+
+#: apps/application/serializers/application_stats.py:29
+msgid "Number of new users"
+msgstr "新用户数量"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:35
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:39
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:20
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:41
+msgid "Number of pictures"
+msgstr "图片数量"
+
+#: apps/homepage/serializers/homepage.py:305
+#: apps/homepage/serializers/homepage.py:490
+#: apps/homepage/serializers/homepage.py:628
 msgid "number of questions"
 msgstr "提问次数"
 
-msgid "active users"
-msgstr "活跃用户数"
+#: apps/application/serializers/application_chat.py:44
+msgid "Number of tags"
+msgstr "标签数量"
 
-msgid "Average tokens per request"
-msgstr "单次请求平均Token数"
+#: apps/application/serializers/application_chat.py:43
+#: apps/application/serializers/application_stats.py:34
+msgid "Number of thumbs-downs"
+msgstr "点踩数量"
 
-msgid "Average Number of Conversation Turns per Person"
-msgstr "人均对话轮次"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:18
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:15
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:24
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:24
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:24
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:24
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:17
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:16
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:22
+msgid "Number of top documents to return after reranking"
+msgstr ""
 
+#: apps/application/flow/step_node/data_source_local_node/i_data_source_local_node.py:21
+msgid "Number of uploaded files"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:29
+msgid "Number of visits"
+msgstr "访问次数"
+
+#: no source
+msgid "OAuth2 Log in"
+msgstr "OAuth2 登录"
+
+#: apps/system_manage/views/user_resource_permission.py:43
+#: apps/system_manage/views/user_resource_permission.py:44
+msgid "Obtain resource authorization list"
+msgstr "获取资源授权列表"
+
+#: apps/system_manage/views/user_resource_permission.py:85
+#: apps/system_manage/views/user_resource_permission.py:86
+#: apps/system_manage/views/user_resource_permission.py:87
+msgid "Obtain resource authorization list by page"
+msgstr "分页获取资源授权列表"
+
+#: no source
+msgid "OIDC Log in"
+msgstr "OIDC 登录"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:20
+msgid "Oil painting 1"
+msgstr "油画1"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:21
+msgid "Oil Painting 2 (Van Gogh)"
+msgstr "油画2（梵高）"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:25
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:55
+msgid "Online TTS"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:288
+msgid "Online Usage"
+msgstr "线上使用"
+
+#: no source
+msgid "Only shared knowledge can be authorized"
+msgstr "仅限共享知识库可以被授权"
+
+#: no source
+msgid "Only shared tools can be authorized"
+msgstr "仅限共享工具可以被授权"
+
+#: no source
+msgid "Only shared tools can be deleted"
+msgstr "仅限共享工具可以被删除"
+
+#: apps/application/serializers/application.py:1013
+#: apps/common/utils/tool_code.py:385
+#: apps/knowledge/serializers/knowledge_workflow.py:666
+#: apps/tools/serializers/tool_workflow.py:396
+msgid "Only support transport=sse or transport=streamable_http"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:65
+msgid "Only supports and|or"
+msgstr "只支持 与|或"
+
+#: no source
+msgid "Only update members to normal users"
+msgstr "只能为普通用户更新成员"
+
+#: apps/chat/views/chat.py:74
+#: apps/chat/views/chat.py:75
+#: apps/chat/views/chat.py:76
+msgid "OpenAI Interface Dialogue"
+msgstr ""
+
+#: apps/application/serializers/application.py:300
+#: apps/application/serializers/application.py:353
+#: apps/application/serializers/application.py:600
+msgid "Opening remarks"
+msgstr "开始提示"
+
+#: no source
+msgid "operate"
+msgstr "操作"
+
+#: no source
+msgid "Operate"
+msgstr "操作"
+
+#: no source
+msgid "Operate Time"
+msgstr "操作时间"
+
+#: no source
+msgid "Operate user"
+msgstr "操作用户"
+
+#: no source
+msgid "operate_label"
+msgstr "操作标签"
+
+#: apps/common/constants/permission_constants.py:337
+msgid "Operation Log"
+msgstr "操作日志"
+
+#: apps/application/serializers/application_api_key.py:39
+#: apps/knowledge/serializers/document.py:483
+msgid "order by"
+msgstr "排序"
+
+#: apps/trigger/serializers/trigger_task.py:131
+msgid "Order field"
+msgstr "排序字段"
+
+#: apps/application/serializers/application_chat.py:174
+#: apps/chat/serializers/chat.py:95
+#: apps/common/constants/permission_constants.py:338
+#: apps/common/constants/permission_constants.py:345
+msgid "Other"
+msgstr "其他"
+
+#: apps/application/serializers/application_chat.py:217
+msgid "Other reason content"
+msgstr "其他反馈理由内容"
+
+#: no source
+msgid "OU cannot be empty"
+msgstr "OU不能为空"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:30
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:29
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:24
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:23
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:26
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:42
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:26
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:24
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:24
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:21
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:29
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:26
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:27
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:26
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:31
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:24
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:24
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:49
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:24
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:24
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:24
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:30
+msgid "Output the maximum Tokens"
+msgstr "输出最大Token数"
+
+#: apps/common/constants/permission_constants.py:395
+#: apps/common/constants/permission_constants.py:408
+#: apps/common/constants/permission_constants.py:439
+msgid "Overview"
+msgstr "概览"
+
+#: apps/knowledge/views/knowledge_workflow.py:140
+#: apps/knowledge/views/knowledge_workflow.py:141
+#: apps/knowledge/views/knowledge_workflow.py:142
+msgid "Page Knowledge workflow action"
+msgstr ""
+
+#: apps/application/api/application_api.py:61
+#: apps/application/api/application_chat.py:117
+#: apps/application/api/application_chat_record.py:81
+#: apps/homepage/api/home_page_api.py:103
+#: apps/system_manage/api/resource_mapping.py:63
+#: apps/system_manage/api/user_resource_permission.py:214
+#: apps/system_manage/api/user_resource_permission.py:280
+#: apps/trigger/api/trigger.py:100
+#: apps/trigger/api/trigger_task.py:109
+msgid "Page size"
+msgstr "每页大小"
+
+#: apps/common/result/api.py:45
+msgid "page size"
+msgstr "每页大小"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:54
+msgid "painting"
+msgstr "油画"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:13
+msgid "painting style"
+msgstr "绘画风格"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:26
+msgid "paper cut style"
+msgstr "剪纸风格"
+
+#: no source
+msgid "Paragraph"
+msgstr "段落"
+
+#: apps/application/serializers/application_chat_record.py:241
+msgid "Paragraph content"
+msgstr "段落内容"
+
+#: apps/knowledge/serializers/paragraph.py:490
+msgid "Paragraph does not exist"
+msgstr "段落不存在"
+
+#: apps/application/api/application_chat_record.py:148
+msgid "Paragraph ID"
+msgstr "段落 ID"
+
+#: apps/application/serializers/application_chat_record.py:480
+msgid "Paragraph id"
+msgstr "段落 ID"
+
+#: apps/knowledge/serializers/paragraph.py:91
+#: apps/knowledge/serializers/paragraph.py:110
+#: apps/knowledge/serializers/paragraph.py:202
+#: apps/knowledge/serializers/paragraph.py:476
+#: apps/knowledge/serializers/paragraph.py:609
+#: apps/knowledge/serializers/paragraph.py:781
+#: apps/knowledge/serializers/problem.py:36
+#: apps/knowledge/serializers/problem.py:51
+msgid "paragraph id"
+msgstr "段落 ID"
+
+#: apps/knowledge/serializers/paragraph.py:125
+#: apps/knowledge/serializers/paragraph.py:221
+msgid "Paragraph id does not exist"
+msgstr "段落 ID 不存在"
+
+#: apps/knowledge/serializers/paragraph.py:91
+#: apps/knowledge/serializers/paragraph.py:608
+msgid "paragraph id list"
+msgstr "段落 ID 列表"
+
+#: apps/knowledge/serializers/knowledge.py:773
+msgid "Paragraph is active"
+msgstr "分段是否启用"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:58
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:29
+msgid "Paragraph List"
+msgstr "段落列表"
+
+#: apps/knowledge/views/paragraph.py:24
+#: apps/knowledge/views/paragraph.py:25
+#: apps/knowledge/views/paragraph.py:26
+msgid "Paragraph list"
+msgstr "段落列表"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:22
+msgid "paragraph title relate problem"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:25
+msgid "paragraph title relate problem reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:18
+msgid "paragraph title relate problem type"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:67
+#: apps/models_provider/serializers/model_serializer.py:289
+msgid "parameter configuration"
+msgstr "参数配置"
+
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:40
+msgid "Parameter value error: The uploaded audio lacks file_id, and the audio upload fails"
+msgstr "参数错误：上传的音频缺少 file_id，音频上传失败"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:81
+msgid "Parameter value error: The uploaded audio lacks file_id, and the audio upload fails."
+msgstr "参数值错误：上传的音频缺少 file_id，音频上传失败"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:62
+msgid "Parameter value error: The uploaded document lacks file_id, and the document upload fails"
+msgstr "参数值错误：上传的文档缺少 file_id，文档上传失败"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:71
+msgid "Parameter value error: The uploaded image lacks file_id, and the image upload fails"
+msgstr "参数值错误：上传的图片缺少 file_id，图片上传失败"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:91
+msgid "Parameter value error: The uploaded video lacks file_id, and the video upload fails."
+msgstr ""
+
+#: apps/folders/models/folder.py:12
+#: apps/folders/models/folder.py:23
+#: apps/folders/serializers/folder.py:131
+msgid "parent id"
+msgstr "父级 ID"
+
+#: apps/system_manage/serializers/email_setting.py:34
+#: apps/users/api/login.py:27
+#: apps/users/api/user.py:93
+#: apps/users/serializers/login.py:33
+#: apps/users/serializers/user.py:66
+#: apps/users/serializers/user.py:185
+#: apps/users/serializers/user.py:429
+#: apps/users/serializers/user.py:977
+#: apps/users/serializers/user.py:1035
+msgid "Password"
+msgstr "密码"
+
+#: no source
+msgid "password"
+msgstr "密码登录"
+
+#: apps/common/constants/exception_code_constants.py:43
+msgid "Password and confirmation password are inconsistent"
+msgstr "密码和确认密码不一致"
+
+#: no source
+msgid "Password cannot be empty"
+msgstr "密码不能为空"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:53
+#: apps/knowledge/serializers/document.py:200
+#: apps/knowledge/serializers/document.py:200
+msgid "patterns"
+msgstr "分割符"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:59
+msgid "patterns reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:56
+msgid "patterns type"
+msgstr ""
+
+#: apps/models_provider/views/model.py:250
+#: apps/models_provider/views/model.py:251
+#: apps/models_provider/views/model.py:252
+msgid "Pause model download"
+msgstr "下载模型暂停"
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:56
+msgid "Peak Performance. Ultimate Value. 204K context window"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:72
+msgid "Perfecting tonal nuances with maximized timbre similarity"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1308
+msgid "period"
+msgstr "句号"
+
+#: apps/system_manage/api/user_resource_permission.py:28
+#: apps/system_manage/api/user_resource_permission.py:119
+#: apps/system_manage/serializers/user_resource_permission.py:53
+#: apps/system_manage/serializers/user_resource_permission.py:64
+#: apps/system_manage/serializers/user_resource_permission.py:104
+#: apps/system_manage/serializers/user_resource_permission.py:302
+#: apps/system_manage/serializers/user_resource_permission.py:308
+msgid "permission"
+msgstr ""
+
+#: no source
+msgid "Permission"
+msgstr "权限"
+
+#: apps/users/serializers/user.py:57
+msgid "permissions"
+msgstr "无权限访问"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:153
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:193
+msgid "Phi-3 Mini is Microsoft's 3.8B parameter, lightweight, state-of-the-art open model."
+msgstr "Phi-3 Mini是Microsoft的3.8B参数，轻量级，最先进的开放模型。"
+
+#: apps/users/serializers/user.py:69
+#: apps/users/serializers/user.py:204
+#: apps/users/serializers/user.py:401
+msgid "Phone"
+msgstr "手机"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:50
+msgid "photography"
+msgstr "摄影"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:54
+#: apps/application/flow/step_node/application_node/i_application_node.py:21
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:29
+#: apps/chat/serializers/chat.py:92
+#: apps/tools/serializers/tool.py:1153
+msgid "picture"
+msgstr "图片"
+
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:27
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:28
+msgid "Picture quality"
+msgstr "图片质量"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:23
+msgid "pixel art"
+msgstr "像素画"
+
+#: no source
+msgid "Platform configuration"
+msgstr "平台配置"
+
+#: no source
+msgid "Platform does not exist"
+msgstr "平台不存在"
+
+#: no source
+msgid "Platform type"
+msgstr "平台类型"
+
+#: apps/application/views/application.py:514
+#: apps/application/views/application.py:515
+#: apps/application/views/application.py:516
+msgid "PlayDemo"
+msgstr ""
+
+#: no source
+msgid "Please analyze the content of the image."
+msgstr "请分析图片内容。"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:23
+msgid "Please enter the Web root address"
+msgstr "请输入 Web 根地址"
+
+#: apps/common/constants/exception_code_constants.py:32
+msgid "Please log in first and bring the user Token"
+msgstr "请先登录并携带用户 Token"
+
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:41
+msgid "Please outline this picture"
+msgstr "请描述这张图片"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:54
+msgid "Please select a system voice supported by Qwen-TTS"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:51
+msgid "Portraits"
+msgstr "人像写真"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:30
+msgid "Portuguese"
+msgstr "葡萄牙语"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:65
+msgid "Post-processor"
+msgstr "后置处理器"
+
+#: apps/application/serializers/application.py:460
+#: apps/application/serializers/application.py:460
+msgid "Primary key id"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:359
+#: apps/common/constants/permission_constants.py:417
+#: apps/common/constants/permission_constants.py:427
+msgid "Problem"
+msgstr "问题"
+
+#: apps/knowledge/api/problem.py:40
+#: apps/knowledge/api/problem.py:53
+#: apps/knowledge/api/termbase.py:39
+#: apps/knowledge/api/termbase.py:46
+#: apps/knowledge/serializers/problem.py:42
+msgid "problem"
+msgstr "问题 ID"
+
+#: apps/application/serializers/application_chat.py:215
+msgid "Problem after optimization"
+msgstr "优化后的问题"
+
+#: apps/knowledge/serializers/paragraph.py:492
+msgid "Problem does not exist"
+msgstr "问题不存在"
+
+#: apps/knowledge/serializers/paragraph.py:474
+#: apps/knowledge/serializers/problem.py:27
+#: apps/knowledge/serializers/problem.py:47
+#: apps/knowledge/serializers/problem.py:57
+#: apps/knowledge/serializers/problem.py:139
+msgid "problem id"
+msgstr "问题 ID"
+
+#: apps/knowledge/serializers/paragraph.py:262
+msgid "Problem id does not exist"
+msgstr "问题 ID 不存在"
+
+#: apps/knowledge/serializers/problem.py:46
+#: apps/knowledge/serializers/problem.py:56
+msgid "problem id list"
+msgstr "问题 ID 列表"
+
+#: apps/knowledge/api/problem.py:39
+#: apps/knowledge/api/problem.py:52
+#: apps/knowledge/api/termbase.py:38
+#: apps/knowledge/api/termbase.py:45
+#: apps/knowledge/serializers/problem.py:41
+msgid "problem list"
+msgstr "问题列表"
+
+#: apps/common/utils/tool_code.py:379
+msgid "Process execution timed out after {} seconds."
+msgstr ""
+
+#: no source
+msgid "product"
+msgstr "产品"
+
+#: no source
+msgid "project url"
+msgstr "项目网址"
+
+#: apps/knowledge/serializers/document.py:238
+#: apps/knowledge/serializers/paragraph.py:95
+msgid "prompt"
+msgstr "提示词"
+
+#: apps/tools/serializers/tool.py:1571
+msgid "Prompt"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:54
+msgid "Prompt template"
+msgstr "提示词模板"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:39
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:25
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:20
+#: apps/application/flow/step_node/question_node/i_question_node.py:25
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:19
+#: apps/application/serializers/application.py:202
+#: apps/application/serializers/application.py:253
+#: apps/knowledge/serializers/common.py:78
+msgid "Prompt word"
+msgstr "提示词"
+
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:19
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:20
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:19
+msgid "Prompt word (negative)"
+msgstr "提示词 (负向)"
+
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:17
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:18
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:17
+msgid "Prompt word (positive)"
+msgstr "提示词 (正向)"
+
+#: apps/homepage/serializers/homepage.py:304
+#: apps/homepage/serializers/homepage.py:491
+#: apps/homepage/serializers/homepage.py:627
+msgid "proportion"
+msgstr "占比"
+
+#: apps/models_provider/api/provide.py:46
+msgid "props info"
+msgstr "props 信息"
+
+#: apps/chat/api/chat_embed_api.py:31
+#: apps/chat/serializers/chat_embed_serializers.py:26
+msgid "protocol"
+msgstr "协议"
+
+#: apps/models_provider/api/model.py:58
+#: apps/models_provider/api/provide.py:18
+#: apps/models_provider/api/provide.py:38
+#: apps/models_provider/api/provide.py:76
+#: apps/models_provider/api/provide.py:104
+#: apps/models_provider/api/provide.py:126
+#: apps/models_provider/serializers/model_serializer.py:64
+#: apps/models_provider/serializers/model_serializer.py:286
+#: apps/models_provider/serializers/model_serializer.py:362
+#: apps/models_provider/serializers/model_serializer.py:545
+msgid "provider"
+msgstr "供应商"
+
+#: apps/common/constants/permission_constants.py:377
+msgid "Public access link"
+msgstr "公共访问链接"
+
+#: no source
+msgid "Public settings"
+msgstr "公共访问连接"
+
+#: apps/common/constants/permission_constants.py:349
+msgid "Publish"
+msgstr "发布"
+
+#: apps/application/api/application_api.py:96
+#: apps/application/serializers/application.py:452
+msgid "Publish status"
+msgstr "发布状态"
+
+#: apps/application/serializers/application.py:453
+msgid "Published"
+msgstr "已发布"
+
+#: apps/homepage/api/home_page_api.py:248
+msgid "Published application count"
+msgstr "已发布应用数量"
+
+#: apps/application/views/application.py:272
+#: apps/application/views/application.py:273
+#: apps/application/views/application.py:274
+msgid "Publishing an application"
+msgstr "发布智能体"
+
+#: apps/knowledge/views/knowledge_workflow.py:253
+#: apps/knowledge/views/knowledge_workflow.py:254
+#: apps/knowledge/views/knowledge_workflow.py:255
+msgid "Publishing an knowledge"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:29
+#: apps/tools/views/tool_workflow.py:30
+#: apps/tools/views/tool_workflow.py:31
+msgid "Publishing an tool"
+msgstr ""
+
+#: apps/local_model/serializers/model_apply_serializers.py:110
+#: apps/models_provider/serializers/model_apply_serializers.py:47
+msgid "query"
+msgstr "查询"
+
+#: apps/models_provider/views/model.py:296
+#: apps/models_provider/views/model.py:297
+#: apps/models_provider/views/model.py:298
+msgid "Query all model list"
+msgstr ""
+
+#: apps/models_provider/views/model.py:159
+#: apps/models_provider/views/model.py:160
+#: apps/models_provider/views/model.py:161
+msgid "Query model details"
+msgstr "查询模型详情"
+
+#: apps/models_provider/views/model.py:94
+#: apps/models_provider/views/model.py:95
+#: apps/models_provider/views/model.py:96
+msgid "Query model list"
+msgstr "查询模型列表"
+
+#: apps/models_provider/views/model.py:226
+#: apps/models_provider/views/model.py:228
+#: apps/models_provider/views/model.py:230
+msgid "Query model meta information, this interface does not carry authentication information"
+msgstr "查询模型元信息，该接口不携带认证信息"
+
+#: apps/knowledge/serializers/knowledge.py:157
+#: apps/knowledge/serializers/knowledge.py:1362
+msgid "query text"
+msgstr "查询文本"
+
+#: apps/common/event/listener_manage.py:114
+msgid "Query vector data: {paragraph_id_list} error {error} {traceback}"
+msgstr "查询向量数据：{paragraph_id_list} 错误：{error} {traceback}"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:26
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:24
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:24
+#: apps/application/serializers/application_chat_record.py:244
+msgid "question"
+msgstr "问题"
+
+#: apps/knowledge/serializers/document.py:936
+#: apps/knowledge/serializers/knowledge.py:768
+msgid "Question (optional, one per line in the cell)"
+msgstr "问题（可选，每个单元格一行）"
+
+#: apps/application/serializers/application.py:366
+#: apps/application/serializers/application.py:610
+msgid "Question completion"
+msgstr "问题完成"
+
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:32
+#: apps/application/serializers/application.py:368
+msgid "Question completion prompt"
+msgstr "问题完成提示"
+
+#: apps/homepage/api/home_page_api.py:195
+#: apps/homepage/api/home_page_api.py:224
+msgid "Question count"
+msgstr "提问次数"
+
+#: apps/knowledge/views/problem.py:23
+#: apps/knowledge/views/problem.py:24
+#: apps/knowledge/views/problem.py:25
+msgid "Question list"
+msgstr "问题列表"
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:31
+msgid "question reference address"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:223
+msgid "Question Time"
+msgstr "提问时间"
+
+#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:46
+msgid "Quickly and accurately generate images based on user text descriptions. Resolution supports 1024x1024"
+msgstr "根据用户文字描述快速、精准生成图像。分辨率支持1024x1024"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:25
+msgid "Qwen-Omni"
+msgstr "多模态"
+
+#: apps/homepage/serializers/homepage.py:301
+#: apps/homepage/serializers/homepage.py:488
+#: apps/homepage/serializers/homepage.py:624
+msgid "ranking"
+msgstr "排名"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:28
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:28
+msgid "Ratio"
+msgstr "比例"
+
+#: apps/users/serializers/user.py:443
+#: apps/users/serializers/user.py:991
+#: apps/users/serializers/user.py:1049
+msgid "Re Password"
+msgstr "确认密码"
+
+#: apps/knowledge/views/knowledge.py:334
+#: apps/knowledge/views/knowledge.py:335
+#: apps/knowledge/views/knowledge.py:336
+msgid "Re-vectorize"
+msgstr "重新向量化"
+
+#: apps/common/constants/permission_constants.py:346
+msgid "Read"
+msgstr "查看"
+
+#: apps/common/constants/permission_constants.py:391
+msgid "Read execute record"
+msgstr "查看执行记录"
+
+#: apps/common/constants/permission_constants.py:387
+msgid "Read Trigger"
+msgstr "查看触发器"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:27
+msgid "Real-time speech recognition - Fun-ASR/Paraformer"
+msgstr "实时语音识别-Fun-ASR/Paraformer"
+
+#: apps/tools/serializers/tool.py:1427
+#: apps/tools/serializers/tool.py:1433
+msgid "record id"
+msgstr ""
+
+#: no source
+msgid "Redirect address cannot be empty"
+msgstr "重定向地址不能为空"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:22
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:22
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:16
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:16
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:17
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:22
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:25
+#: apps/application/flow/step_node/question_node/i_question_node.py:22
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:16
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:17
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:16
+#: apps/application/flow/step_node/variable_assign_node/i_variable_assign_node.py:14
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:16
+msgid "Reference Field"
+msgstr "引用字段"
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:32
+msgid "Reference field cannot be empty"
+msgstr "引用字段不能为空"
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:34
+msgid "Reference field error"
+msgstr "引用字段错误"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:39
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:22
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:25
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:24
+#: apps/application/serializers/application.py:206
+#: apps/application/serializers/application_chat.py:218
+msgid "Reference segment number"
+msgstr "引用分段数"
+
+#: apps/knowledge/views/document.py:363
+#: apps/knowledge/views/document.py:364
+#: apps/knowledge/views/document.py:365
+msgid "Refresh document vector library"
+msgstr "刷新文档向量库"
+
+#: no source
+msgid "Refresh shared document vector library"
+msgstr "刷新共享文档向量库"
+
+#: no source
+msgid "Refresh system knowledge vector library"
+msgstr "刷新文档向量库"
+
+#: apps/chat/serializers/chat.py:213
+msgid "Regenerate"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:26
+msgid "Region Name"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:369
+msgid "Relate"
+msgstr "关联分段"
+
+#: apps/application/serializers/application.py:359
+#: apps/application/serializers/application.py:603
+msgid "Related Knowledge Base"
+msgstr "相关知识库"
+
+#: apps/knowledge/views/paragraph.py:377
+#: apps/knowledge/views/paragraph.py:378
+#: apps/knowledge/views/paragraph.py:379
+msgid "Related questions"
+msgstr "关联问题"
+
+#: no source
+msgid "Related shared questions"
+msgstr "关联问题"
+
+#: no source
+msgid "Related system questions"
+msgstr "关联问题"
+
+#: apps/models_provider/api/provide.py:42
+msgid "relation show field dict"
+msgstr "关系显示字段"
+
+#: apps/models_provider/api/provide.py:43
+msgid "relation trigger field dict"
+msgstr "关系触发字段"
+
+#: no source
+msgid "remark"
+msgstr "备注"
+
+#: apps/common/constants/permission_constants.py:366
+msgid "Remove Member"
+msgstr "移除成员"
+
+#: no source
+msgid "Remove member from chat user group"
+msgstr "从对话用户组移除成员"
+
+#: no source
+msgid "Remove member from system role"
+msgstr "系统角色移除成员"
+
+#: no source
+msgid "Remove member from system workspace"
+msgstr "系统工作空间移除成员"
+
+#: no source
+msgid "Remove member from user group"
+msgstr "从用户组中移除成员"
+
+#: no source
+msgid "Remove member from workspace"
+msgstr "工作空间移除成员"
+
+#: no source
+msgid "Remove member from workspace role"
+msgstr "工作空间角色移除成员"
+
+#: apps/models_provider/views/model_apply.py:49
+#: apps/models_provider/views/model_apply.py:50
+#: apps/models_provider/views/model_apply.py:51
+msgid "Reorder documents"
+msgstr "重新排序文档"
+
+#: apps/common/constants/permission_constants.py:385
+msgid "Replace Original Document"
+msgstr "替换原文档"
+
+#: apps/knowledge/views/document.py:977
+#: apps/knowledge/views/document.py:978
+msgid "Replace source file"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:40
+#: apps/tools/serializers/tool.py:248
+#: apps/tools/serializers/tool.py:274
+msgid "required"
+msgstr "必填"
+
+#: apps/models_provider/base_model_provider.py:153
+msgid "Rerank"
+msgstr "重排模型"
+
+#: apps/application/serializers/application_access_token.py:25
+msgid "Reset Token"
+msgstr "重置令牌"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:20
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:16
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:16
+msgid "Resolution"
+msgstr "分辨率"
+
+#: apps/common/constants/permission_constants.py:446
+msgid "Resource"
+msgstr "资源管理"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:26
+#: apps/system_manage/serializers/resource_mapping_serializers.py:107
+#: apps/system_manage/serializers/user_resource_permission.py:110
+#: apps/system_manage/serializers/user_resource_permission.py:322
+msgid "resource"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:329
+msgid "Resource Application"
+msgstr "资源管理-智能体"
+
+#: apps/common/constants/permission_constants.py:383
+msgid "resource authorization"
+msgstr "资源授权"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:27
+#: apps/system_manage/serializers/resource_mapping_serializers.py:108
+msgid "resource Id"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:321
+msgid "resource id"
+msgstr ""
+
+#: no source
+msgid "Resource id"
+msgstr "资源ID"
+
+#: apps/common/constants/permission_constants.py:330
+msgid "Resource Knowledge"
+msgstr "资源管理-知识库"
+
+#: apps/common/constants/permission_constants.py:332
+msgid "Resource Model"
+msgstr "资源管理-模型"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:28
+#: apps/system_manage/serializers/resource_mapping_serializers.py:110
+msgid "resource Name"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:101
+msgid "resource name"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:333
+msgid "Resource Permission"
+msgstr "资源授权"
+
+#: apps/common/constants/permission_constants.py:331
+msgid "Resource Tool"
+msgstr "资源管理-工具"
+
+#: apps/application/serializers/application.py:467
+#: apps/application/serializers/application.py:467
+msgid "Resource type"
+msgstr "资源类型"
+
+#: apps/system_manage/views/user_resource_permission.py:47
+#: apps/system_manage/views/user_resource_permission.py:66
+#: apps/system_manage/views/user_resource_permission.py:91
+#: apps/system_manage/views/user_resource_permission.py:115
+#: apps/system_manage/views/user_resource_permission.py:148
+#: apps/system_manage/views/user_resource_permission.py:181
+msgid "Resources authorization"
+msgstr "资源授权"
+
+#: apps/system_manage/views/resource_mapping.py:33
+msgid "Resources mapping"
+msgstr "资源映射"
+
+#: apps/common/result/api.py:17
+#: apps/common/result/api.py:17
+#: apps/common/result/api.py:27
+#: apps/common/result/api.py:27
+msgid "response code"
+msgstr "响应码"
+
+#: apps/homepage/api/home_page_api.py:152
+#: apps/homepage/api/home_page_api.py:182
+#: apps/homepage/api/home_page_api.py:209
+#: apps/homepage/api/home_page_api.py:242
+#: apps/homepage/api/home_page_api.py:305
+#: apps/homepage/api/home_page_api.py:342
+#: apps/homepage/api/home_page_api.py:379
+msgid "Response code"
+msgstr "响应码"
+
+#: apps/homepage/api/home_page_api.py:153
+#: apps/homepage/api/home_page_api.py:183
+#: apps/homepage/api/home_page_api.py:210
+#: apps/homepage/api/home_page_api.py:243
+#: apps/homepage/api/home_page_api.py:306
+#: apps/homepage/api/home_page_api.py:343
+#: apps/homepage/api/home_page_api.py:380
+msgid "Response message"
+msgstr "响应消息"
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:21
+msgid "Response Type"
+msgstr "响应类型"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:46
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:31
+#: apps/application/serializers/application.py:220
+msgid "Retrieval Mode"
+msgstr "检索模式"
+
+#: apps/trigger/views/trigger_task.py:53
+#: apps/trigger/views/trigger_task.py:54
+#: apps/trigger/views/trigger_task.py:55
+msgid "Retrieve detailed records of tasks executed by the trigger."
+msgstr "获取由该触发器执行的任务详细记录。"
+
+#: apps/system_manage/views/resource_mapping.py:29
+#: apps/system_manage/views/resource_mapping.py:30
+#: apps/system_manage/views/resource_mapping.py:63
+#: apps/system_manage/views/resource_mapping.py:64
+msgid "Retrieve the pagination list of resource relationships"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:40
+msgid "retro anime"
+msgstr "复古动漫"
+
+#: apps/chat/serializers/chat.py:49
+#: apps/chat/serializers/chat.py:207
+#: apps/common/constants/permission_constants.py:327
+#: apps/common/constants/permission_constants.py:433
+msgid "Role"
+msgstr "角色"
+
+#: no source
+msgid "Role does not exist"
+msgstr "角色不存在"
+
+#: apps/users/api/user.py:26
+msgid "Role ID"
+msgstr "角色 ID"
+
+#: no source
+msgid "Role IDs"
+msgstr "角色 IDs"
+
+#: no source
+msgid "Role IDs cannot be empty"
+msgstr "角色 ID 不能为空"
+
+#: no source
+msgid "Role name"
+msgstr "角色名称"
+
+#: no source
+msgid "Role Name"
+msgstr "角色名称"
+
+#: no source
+msgid "Role name already exists"
+msgstr "角色名称已存在"
+
+#: apps/application/serializers/application.py:256
+msgid "Role prompts"
+msgstr "角色提示"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:24
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:19
+#: apps/application/flow/step_node/question_node/i_question_node.py:24
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:18
+#: apps/users/api/user.py:35
+#: apps/users/api/user.py:102
+msgid "Role Setting"
+msgstr "角色设置"
+
+#: no source
+msgid "Role Setting cannot be empty"
+msgstr "角色设置不能为空"
+
+#: no source
+msgid "Role type"
+msgstr "角色类型"
+
+#: no source
+msgid "Root Directory"
+msgstr "根目录"
+
+#: apps/chat/serializers/chat.py:86
+msgid "Runtime node id"
+msgstr "运行时节点 ID"
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:64
+msgid "Same performance, faster and more agile. 204K context window"
+msgstr ""
+
+#: no source
+msgid "SAML2 Log in"
+msgstr "SAML2 登录"
+
+#: no source
+msgid "SAML2 Metadata"
+msgstr "SAML2 元数据"
+
+#: no source
+msgid "SAML2 SSO"
+msgstr "SAML2 单点登录"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:15
+msgid "Sample Rate"
+msgstr "采样率"
+
+#: apps/models_provider/views/model.py:201
+#: apps/models_provider/views/model.py:202
+#: apps/models_provider/views/model.py:203
+msgid "Save model parameter form"
+msgstr "保存模型参数表单"
+
+#: no source
+msgid "Scan code login type"
+msgstr "扫码登录类型"
+
+#: apps/trigger/serializers/trigger.py:171
+msgid "schedule_type must be one of %s"
+msgstr "schedule_type 必须是以下值之一: %s"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:33
+msgid "science fiction style"
+msgstr "科幻风格"
+
+#: apps/knowledge/serializers/knowledge.py:887
+#: apps/knowledge/serializers/knowledge.py:1137
+#: apps/knowledge/serializers/knowledge_workflow.py:320
+#: apps/tools/serializers/tool.py:345
+#: apps/tools/serializers/tool.py:1690
+msgid "scope"
+msgstr "范围"
+
+#: no source
+msgid "Scope cannot be empty"
+msgstr "范围不能为空"
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:37
+msgid "search condition list"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:34
+msgid "search condition type"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:17
+#: apps/knowledge/serializers/knowledge.py:162
+#: apps/knowledge/serializers/knowledge.py:1367
+msgid "search mode"
+msgstr "搜索模式"
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:20
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:47
+msgid "search scope type"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:28
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:55
+msgid "search scope variable"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:25
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:52
+msgid "search scope variable type"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1700
+#: apps/knowledge/serializers/tag.py:203
+msgid "search value"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:25
+msgid "Secret Access Key"
+msgstr ""
+
+#: no source
+msgid "Secret is required"
+msgstr "Secret 是必填项"
+
+#: apps/common/auth/handle/impl/application_key.py:27
+msgid "Secret key is expired"
+msgstr "密钥已过期"
+
+#: apps/chat/views/chat.py:84
+#: apps/common/auth/handle/impl/application_key.py:23
+#: apps/common/auth/handle/impl/application_key.py:25
+msgid "Secret key is invalid"
+msgstr "密钥无效"
+
+#: apps/knowledge/serializers/document.py:935
+#: apps/knowledge/serializers/knowledge.py:767
+msgid "Section content (required, question answer, no more than 4096 characters)"
+msgstr "章节内容（必填，问答，不超过4096个字符）"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:40
+#: apps/knowledge/serializers/paragraph.py:73
+#: apps/knowledge/serializers/paragraph.py:81
+#: apps/knowledge/serializers/paragraph.py:84
+#: apps/knowledge/serializers/paragraph.py:102
+#: apps/knowledge/serializers/paragraph.py:104
+#: apps/knowledge/serializers/paragraph.py:439
+msgid "section title"
+msgstr "章节标题"
+
+#: apps/application/serializers/application_chat_record.py:240
+msgid "Section title"
+msgstr "章节标题"
+
+#: apps/knowledge/serializers/document.py:934
+#: apps/knowledge/serializers/knowledge.py:766
+msgid "Section title (optional)"
+msgstr "章节标题"
+
+#: apps/application/serializers/application_chat.py:219
+msgid "Section title + content"
+msgstr "分段标题 + 内容"
+
+#: apps/application/serializers/application.py:223
+msgid "Segment settings not referenced"
+msgstr "引用段设置未引用"
+
+#: apps/knowledge/views/document.py:224
+#: apps/knowledge/views/document.py:225
+#: apps/knowledge/views/document.py:226
+msgid "Segmented document"
+msgstr "分段文档"
+
+#: no source
+msgid "Segmented shared document"
+msgstr "分段共享文档"
+
+#: no source
+msgid "Segmented system document"
+msgstr "分段文档"
+
+#: apps/knowledge/serializers/common.py:37
+#: apps/knowledge/serializers/document.py:211
+msgid "selector"
+msgstr "选择器"
+
+#: apps/knowledge/serializers/document.py:1306
+msgid "semicolon"
+msgstr "分号"
+
+#: apps/users/views/user.py:321
+#: apps/users/views/user.py:322
+#: apps/users/views/user.py:323
+msgid "Send email"
+msgstr "发送邮件"
+
+#: apps/users/views/user.py:356
+#: apps/users/views/user.py:357
+#: apps/users/views/user.py:358
+msgid "Send email to current user"
+msgstr "发送邮件给当前用户"
+
+#: apps/system_manage/serializers/email_setting.py:33
+#: apps/system_manage/serializers/email_setting.py:37
+msgid "Sender's email"
+msgstr "发送者邮箱"
+
+#: no source
+msgid "serial number"
+msgstr "序列号"
+
+#: apps/common/constants/permission_constants.py:1346
+#: apps/common/constants/permission_constants.py:1399
+msgid "Set up user groups"
+msgstr "设置用户组"
+
+#: no source
+msgid "Setting"
+msgstr "设置"
+
+#: apps/application/serializers/application_chat_link.py:129
+msgid "Share link does not exist"
+msgstr "分享链接不存在"
+
+#: no source
+msgid "Shared generate related"
+msgstr "生成相关"
+
+#: no source
+msgid "Shared Hit test list"
+msgstr "命中测试列表"
+
+#: apps/common/constants/permission_constants.py:334
+msgid "Shared Knowledge"
+msgstr "共享资源-知识库"
+
+#: no source
+msgid "Shared Knowledge/Document"
+msgstr "共享知识库/文档"
+
+#: no source
+msgid "Shared Knowledge/Documentation"
+msgstr "共享知识库/文档"
+
+#: no source
+msgid "Shared Knowledge/Documentation/Paragraph"
+msgstr "共享知识库/文档/段落"
+
+#: no source
+msgid "Shared Knowledge/Documentation/Paragraph/Question"
+msgstr "知识库/文档/段落/问题"
+
+#: apps/common/constants/permission_constants.py:335
+#: apps/models_provider/views/model.py:278
+msgid "Shared Model"
+msgstr "共享资源-模型"
+
+#: apps/models_provider/serializers/model_serializer.py:142
+msgid "Shared models cannot be deleted or modified"
+msgstr "共享模型不能被删除或修改"
+
+#: no source
+msgid "Shared paragraph list"
+msgstr "共享段落列表"
+
+#: no source
+msgid "Shared question list"
+msgstr "问题列表"
+
+#: no source
+msgid "Shared Re-vectorize"
+msgstr "重新向量化"
+
+#: apps/common/constants/permission_constants.py:336
+msgid "Shared Tool"
+msgstr "共享资源-工具"
+
+#: no source
+msgid "Shared tool is not supported"
+msgstr "不支持共享工具"
+
+#: no source
+msgid "show avatar"
+msgstr "显示头像"
+
+#: no source
+msgid "show exec"
+msgstr "显示执行"
+
+#: no source
+msgid "show forum"
+msgstr "显示论坛"
+
+#: no source
+msgid "show guide"
+msgstr "显示论坛"
+
+#: no source
+msgid "show history"
+msgstr "显示历史"
+
+#: no source
+msgid "show project"
+msgstr "显示项目"
+
+#: no source
+msgid "show source"
+msgstr "显示来源"
+
+#: no source
+msgid "show user avatar"
+msgstr "显示用户头像"
+
+#: no source
+msgid "show user manual"
+msgstr "显示用户手册"
+
+#: apps/users/views/login.py:55
+#: apps/users/views/login.py:56
+#: apps/users/views/login.py:57
+msgid "Sign out"
+msgstr "登出"
+
+#: no source
+msgid "Signature missing"
+msgstr "签名缺失"
+
+#: no source
+msgid "Signing Secret is required"
+msgstr "签名密钥是必填项"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:42
+msgid "Similarity"
+msgstr "相似度"
+
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:27
+#: apps/knowledge/serializers/knowledge.py:159
+#: apps/knowledge/serializers/knowledge.py:1364
+msgid "similarity"
+msgstr "相似度"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:68
+msgid "Since the Chinese alignment of Llama2 itself is weak, we use the Chinese instruction set to fine-tune meta-llama/Llama-2-13b-chat-hf with LoRA so that it has strong Chinese conversation capabilities."
+msgstr "由于Llama2本身的中文对齐较弱，我们采用中文指令集，对meta-llama/Llama-2-13b-chat-hf进行LoRA微调，使其具备较强的中文对话能力。"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:56
+msgid "sketch"
+msgstr "素描"
+
+#: apps/tools/serializers/tool.py:1562
+msgid "Skill file does not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:49
+msgid "Skill IDs"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:296
+msgid "Slack"
+msgstr "Slack 应用"
+
+#: no source
+msgid "Slack application: {user}"
+msgstr "Slack 智能体: {user}"
+
+#: no source
+msgid "slogan"
+msgstr "标语"
+
+#: apps/system_manage/serializers/email_setting.py:31
+msgid "SMTP host"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:32
+msgid "SMTP port"
+msgstr ""
+
+#: no source
+msgid "Some roles do not exist"
+msgstr "部分角色不存在"
+
+#: no source
+msgid "Some user groups do not exist"
+msgstr "某些用户组不存在"
+
+#: no source
+msgid "Some users do not exist"
+msgstr "某些用户不存在"
+
+#: apps/application/models/application_chat.py:120
+msgid "Sorry, no relevant content was found. Please re-describe your problem or provide more information. "
+msgstr "不好意思，没有找到相关内容。请重新描述您的问题或提供更多信息。"
+
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:498
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:661
+msgid "Sorry, the AI model is not configured. Please go to the application to set up the AI model first."
+msgstr "抱歉，AI 模型未配置，请先前往智能体设置 AI 模型。"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:30
+#: apps/application/serializers/application_chat.py:221
+#: apps/folders/serializers/folder.py:136
+#: apps/folders/serializers/folder.py:178
+#: apps/folders/serializers/folder.py:307
+#: apps/tools/serializers/tool.py:262
+#: apps/trigger/serializers/trigger.py:47
+msgid "source"
+msgstr "来源"
+
+#: apps/chat/serializers/chat.py:222
+#: apps/chat/serializers/chat.py:293
+#: apps/chat/serializers/chat.py:538
+#: apps/users/serializers/user.py:70
+#: apps/users/serializers/user.py:211
+#: apps/users/serializers/user.py:257
+msgid "Source"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:141
+msgid "source file id"
+msgstr "源文件 ID"
+
+#: apps/oss/serializers/file.py:72
+#: apps/trigger/serializers/task_source_trigger.py:63
+#: apps/trigger/serializers/task_source_trigger.py:184
+msgid "source id"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1428
+msgid "source name"
+msgstr ""
+
+#: apps/oss/serializers/file.py:75
+#: apps/tools/serializers/tool.py:1429
+#: apps/trigger/serializers/task_source_trigger.py:62
+#: apps/trigger/serializers/task_source_trigger.py:183
+msgid "source type"
+msgstr ""
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:30
+#: apps/system_manage/serializers/resource_mapping_serializers.py:31
+msgid "source Type"
+msgstr ""
+
+#: apps/trigger/serializers/trigger_task.py:130
+msgid "Source type"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:36
+#: apps/knowledge/serializers/knowledge.py:124
+msgid "source url"
+msgstr "来源"
+
+#: apps/trigger/serializers/trigger.py:254
+#: apps/trigger/serializers/trigger.py:276
+msgid "source_id"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1305
+msgid "space"
+msgstr "空格"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:33
+msgid "Spanish"
+msgstr "西班牙语"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:18
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:14
+msgid "Speaker"
+msgstr "发音人"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:18
+msgid "Speaker selection for super-humanoid TTS service"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:15
+msgid "Speaker, optional value: Please go to the console to add a trial or purchase speaker. After adding, the speaker parameter value will be displayed."
+msgstr "发音人，可选值：请到控制台添加试用或购买发音人，添加后即显示发音人参数值"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:37
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:68
+msgid "Speaking speed"
+msgstr "语速"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:77
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:43
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:27
+msgid "speaking speed"
+msgstr "语速"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:31
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:25
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:24
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:27
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:43
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:27
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:25
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:25
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:22
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:27
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:28
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:27
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:32
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:25
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:24
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:25
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:25
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:25
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:25
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:31
+msgid "Specify the maximum number of tokens that the model can generate"
+msgstr "指定模型可以生成的最大 tokens 数"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:30
+msgid "Specify the maximum number of tokens that the model can generate."
+msgstr "指定模型可以生成的最大 tokens 数"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:35
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:39
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:20
+msgid "Specify the number of generated images"
+msgstr "指定生成图片的数量"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:14
+msgid "Specify the size of the generated image, such as: 1024x1024"
+msgstr "指定生成图片的尺寸, 如: 1024x1024"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:22
+msgid "Specify the size of the generated Video, such as: 1024x1024"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:45
+msgid "Specify the style of generated images"
+msgstr "指定生成图片的风格"
+
+#: apps/application/serializers/application.py:394
+#: apps/application/serializers/application.py:625
+msgid "Speech recognition model ID"
+msgstr "语音识别模型 ID"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:77
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:43
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:27
+msgid "Speech speed, optional value: [0-100], default is 50"
+msgstr "语速，可选值：[0-100]，默认为50"
+
+#: apps/application/views/application.py:435
+#: apps/application/views/application.py:436
+#: apps/application/views/application.py:437
+#: apps/application/views/application.py:461
+#: apps/application/views/application.py:462
+#: apps/application/views/application.py:463
+#: apps/chat/views/chat.py:220
+#: apps/chat/views/chat.py:221
+#: apps/chat/views/chat.py:222
+#: apps/knowledge/views/knowledge_workflow.py:458
+#: apps/knowledge/views/knowledge_workflow.py:459
+#: apps/knowledge/views/knowledge_workflow.py:460
+msgid "speech to text"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:149
+msgid "Speech2Text"
+msgstr "语音识别"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:15
+msgid "split strategy"
+msgstr ""
+
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:17
+#: apps/application/flow/step_node/variable_splitting_node/i_variable_splitting_node.py:17
+msgid "Split variables"
+msgstr ""
+
+#: apps/common/job/clean_chat_job.py:23
+msgid "start clean chat log"
+msgstr "开始清理聊天日志"
+
+#: apps/common/job/clean_debug_file_job.py:20
+msgid "start clean debug file"
+msgstr "开始清理调试文件"
+
+#: apps/common/job/client_access_num_job.py:25
+msgid "start reset access_num"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:56
+#: apps/application/serializers/application_stats.py:40
+#: apps/homepage/serializers/homepage.py:91
+#: apps/homepage/serializers/homepage.py:152
+#: apps/homepage/serializers/homepage.py:217
+#: apps/homepage/serializers/homepage.py:390
+#: apps/homepage/serializers/homepage.py:517
+#: apps/homepage/serializers/homepage.py:657
+msgid "Start time"
+msgstr "开始时间"
+
+#: apps/common/event/listener_manage.py:377
+msgid "Start--->Embedding document: {document_id}"
+msgstr "开始--->向量文档: {document_id}"
+
+#: apps/common/event/listener_manage.py:426
+msgid "Start--->Embedding document: {document_list}"
+msgstr "开始--->向量文档: {document_list}"
+
+#: apps/common/event/listener_manage.py:422
+msgid "Start--->Embedding knowledge: {knowledge_id}"
+msgstr "开始--->向量知识库: {knowledge_id}"
+
+#: apps/common/event/listener_manage.py:122
+msgid "Start--->Embedding paragraph: {paragraph_id_list}"
+msgstr "开始--->向量段落: {paragraph_id_list}"
+
+#: apps/common/event/listener_manage.py:157
+msgid "Start--->Embedding paragraph: {paragraph_id}"
+msgstr "开始--->向量段落: {paragraph_id}"
+
+#: apps/knowledge/task/sync.py:26
+#: apps/knowledge/task/sync.py:49
+msgid "Start--->Start synchronization web knowledge base:{knowledge_id}"
+msgstr "开始--->开始同步 web 知识库:{knowledge_id}"
+
+#: apps/common/event/listener_manage.py:535
+msgid "Start--->Tokenize document: {document_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:217
+msgid "Start--->Tokenize paragraph: {paragraph_id}"
+msgstr ""
+
+#: apps/knowledge/task/embedding.py:115
+msgid "Start--->Vectorized knowledge: {knowledge_id}"
+msgstr "开始--->向量知识库: {knowledge_id}"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:98
+#: apps/tools/serializers/tool_workflow.py:129
+msgid "State"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1430
+msgid "state"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:80
+#: apps/knowledge/serializers/document.py:227
+#: apps/knowledge/serializers/document.py:232
+#: apps/knowledge/serializers/document.py:239
+msgid "state list"
+msgstr "状态列表"
+
+#: apps/knowledge/serializers/document.py:482
+msgid "status"
+msgstr "状态"
+
+#: no source
+msgid "Stop"
+msgstr "停止"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:26
+msgid "Strategy"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:70
+#: apps/chat/serializers/chat.py:214
+msgid "Streaming Output"
+msgstr "流式输出"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:45
+msgid "Style"
+msgstr "风格"
+
+#: apps/common/result/result.py:31
+msgid "Success"
+msgstr "成功"
+
+#: apps/application/serializers/application_chat.py:36
+#: apps/application/serializers/application_chat.py:54
+#: apps/application/serializers/application_chat.py:214
+#: apps/application/serializers/application_version.py:23
+#: apps/knowledge/serializers/knowledge_version.py:46
+#: apps/tools/serializers/tool_version.py:36
+msgid "summary"
+msgstr "摘要"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:26
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:56
+msgid "Super Humanoid TTS"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:32
+msgid "Super-humanoid: Grant (EN)"
+msgstr "Grant"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:36
+msgid "Super-humanoid: Huifangnv Pro"
+msgstr "惠芳女"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:33
+msgid "Super-humanoid: Lila (EN)"
+msgstr "Lila"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:38
+msgid "Super-humanoid: Lingfeibo Pro"
+msgstr "聆飞博"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:25
+msgid "Super-humanoid: Lingfeiyi Flow"
+msgstr "聆飞逸"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:34
+msgid "Super-humanoid: Lingwanwan Pro"
+msgstr "聆万万"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:30
+msgid "Super-humanoid: Lingxiaorong Flow"
+msgstr "聆小蓉"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:29
+msgid "Super-humanoid: Lingxiaotang Flow"
+msgstr "聆小糖"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:23
+msgid "Super-humanoid: Lingxiaoxuan Flow"
+msgstr "聆小璇"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:37
+msgid "Super-humanoid: Lingxiaoying Pro"
+msgstr "聆小颖"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:26
+msgid "Super-humanoid: Lingxiaoyue Flow"
+msgstr "聆小玥"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:24
+msgid "Super-humanoid: Lingyuyan Flow"
+msgstr "聆玉言"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:39
+msgid "Super-humanoid: Lingyuyan Pro"
+msgstr "聆玉言"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:28
+msgid "Super-humanoid: Lingyuzhao Flow"
+msgstr "聆玉昭"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:27
+msgid "Super-humanoid: Sun Dasheng Flow"
+msgstr "孙大圣"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:31
+msgid "Super-humanoid: Xinyun Flow"
+msgstr "心云"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:35
+msgid "Super-humanoid: Yiyi Pro"
+msgstr "依依"
+
+#: apps/common/constants/permission_constants.py:1301
+#: apps/users/views/user.py:96
+#: apps/users/views/user.py:97
+#: apps/users/views/user.py:98
+msgid "Switch Language"
+msgstr "切换语言"
+
+#: apps/common/constants/permission_constants.py:363
+msgid "Sync"
+msgstr "同步"
+
+#: no source
+msgid "Sync chat users"
+msgstr "同步对话用户"
+
+#: no source
+msgid "Sync chat users from external source"
+msgstr "从外部源同步对话用户"
+
+#: apps/knowledge/serializers/knowledge.py:1260
+msgid "sync type"
+msgstr "同步类型"
+
+#: no source
+msgid "Sync Type"
+msgstr "同步类型"
+
+#: no source
+msgid "Sync Type: LOCAL or LDAP"
+msgstr "同步类型: LOCAL 或 LDAP"
+
+#: no source
+msgid "Sync users"
+msgstr "同步用户"
+
+#: no source
+msgid "Synchronization is only supported for lark documents"
+msgstr "仅支持飞书文档的同步"
+
+#: apps/knowledge/serializers/document.py:603
+#: apps/knowledge/serializers/knowledge.py:1282
+msgid "Synchronization is only supported for web site types"
+msgstr "仅支持网站类型的同步"
+
+#: no source
+msgid "Synchronize lark document"
+msgstr "同步飞书文档"
+
+#: no source
+msgid "Synchronize shared web site types"
+msgstr "同步共享网站类型"
+
+#: no source
+msgid "Synchronize system web site types"
+msgstr "同步网站类型"
+
+#: apps/knowledge/views/knowledge.py:249
+#: apps/knowledge/views/knowledge.py:250
+#: apps/knowledge/views/knowledge.py:251
+msgid "Synchronize the knowledge base of the website"
+msgstr "同步网站知识库"
+
+#: no source
+msgid "Synchronize the shared knowledge base of the website"
+msgstr "同步共享知识库网站"
+
+#: no source
+msgid "Synchronize the system knowledge base of the website"
+msgstr "同步网站知识库"
+
+#: apps/knowledge/task/sync.py:37
+#: apps/knowledge/task/sync.py:59
+msgid "Synchronize web knowledge base:{knowledge_id} error{error}{traceback}"
+msgstr "同步 web 知识库:{knowledge_id} 错误{error}{traceback}"
+
+#: apps/knowledge/views/document.py:325
+#: apps/knowledge/views/document.py:326
+#: apps/knowledge/views/document.py:327
+msgid "Synchronize web site types"
+msgstr "同步网站类型"
+
+#: no source
+msgid "System"
+msgstr "系统"
+
+#: apps/common/constants/permission_constants.py:403
+#: apps/common/constants/permission_constants.py:1312
+msgid "System API Key"
+msgstr "系统 API Key"
+
+#: no source
+msgid "system API key id"
+msgstr "系统 API 密钥 ID"
+
+#: no source
+msgid "System Application"
+msgstr "系统智能体"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:27
+msgid "System completes question text"
+msgstr "系统完成问题文本"
+
+#: no source
+msgid "System generate related"
+msgstr "生成相关"
+
+#: no source
+msgid "System Hit test list"
+msgstr "命中测试列表"
+
+#: no source
+msgid "System Knowledge"
+msgstr "系统知识库"
+
+#: no source
+msgid "System Knowledge/Documentation"
+msgstr "系统知识库/文档"
+
+#: no source
+msgid "System Knowledge/Documentation/Paragraph"
+msgstr "系统知识库/文档/段落"
+
+#: no source
+msgid "System Knowledge/Documentation/Paragraph/Question"
+msgstr "系统知识库/文档/段落/问题"
+
+#: apps/common/constants/permission_constants.py:339
+msgid "System Management"
+msgstr "系统管理"
+
+#: no source
+msgid "System Model"
+msgstr "系统模型"
+
+#: no source
+msgid "System operate log"
+msgstr "系统操作日志"
+
+#: no source
+msgid "System paragraph list"
+msgstr "段落列表"
+
+#: apps/system_manage/views/system_profile.py:25
+msgid "System parameters"
+msgstr "系统参数"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:41
+msgid "System prompt words (role)"
+msgstr "系统提示词（角色）"
+
+#: no source
+msgid "System question list"
+msgstr "问题列表"
+
+#: no source
+msgid "System Re-vectorize"
+msgstr "重新向量化"
+
+#: no source
+msgid "System resources authorization"
+msgstr "系统资源授权"
+
+#: apps/common/constants/permission_constants.py:325
+msgid "System Setting"
+msgstr "系统设置"
+
+#: no source
+msgid "System Tool"
+msgstr "工具"
+
+#: no source
+msgid "System tools cannot be deleted"
+msgstr "系统工具不能被删除"
+
+#: no source
+msgid "System Trigger"
+msgstr "系统触发器"
+
+#: no source
+msgid "System/Chat user"
+msgstr "系统/对话用户"
+
+#: no source
+msgid "System/User Group"
+msgstr "系统/用户组"
+
+#: apps/common/constants/permission_constants.py:358
+#: apps/common/constants/permission_constants.py:416
+#: apps/common/constants/permission_constants.py:426
+msgid "Tag"
+msgstr "标签管理"
+
+#: apps/knowledge/serializers/document.py:484
+msgid "tag"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1776
+#: apps/knowledge/serializers/document.py:1817
+#: apps/knowledge/serializers/document.py:1844
+msgid "tag id"
+msgstr ""
+
+#: apps/knowledge/serializers/tag.py:95
+msgid "Tag ID"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1859
+#: apps/knowledge/serializers/tag.py:111
+#: apps/knowledge/serializers/tag.py:155
+msgid "Tag id does not exist"
+msgstr "标签 ID 不存在"
+
+#: apps/knowledge/serializers/document.py:1776
+#: apps/knowledge/serializers/document.py:1817
+msgid "tag ids"
+msgstr ""
+
+#: apps/knowledge/serializers/tag.py:169
+msgid "Tag IDs"
+msgstr ""
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:48
+#: apps/knowledge/serializers/tag.py:35
+#: apps/knowledge/serializers/tag.py:40
+msgid "Tag Key"
+msgstr "标签"
+
+#: apps/knowledge/serializers/tag.py:125
+msgid "Tag key already exists"
+msgstr "标签已存在"
+
+#: apps/common/constants/permission_constants.py:384
+msgid "Tag Setting"
+msgstr "标签设置"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:49
+#: apps/knowledge/serializers/tag.py:36
+#: apps/knowledge/serializers/tag.py:41
+msgid "Tag Value"
+msgstr "标签值"
+
+#: apps/knowledge/serializers/tag.py:143
+msgid "Tag value already exists"
+msgstr "标签值已存在"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:56
+#: apps/knowledge/serializers/knowledge.py:769
+#: apps/knowledge/serializers/tag.py:48
+msgid "Tags"
+msgstr "标签"
+
+#: apps/knowledge/serializers/paragraph.py:605
+msgid "target document id"
+msgstr "目标文档 ID"
+
+#: apps/system_manage/serializers/user_resource_permission.py:61
+msgid "target id"
+msgstr "当前 ID"
+
+#: apps/knowledge/serializers/document.py:356
+#: apps/knowledge/serializers/paragraph.py:604
+msgid "target knowledge id"
+msgstr "当前知识库 ID"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:112
+#: apps/system_manage/serializers/resource_mapping_serializers.py:113
+msgid "target Type"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:171
+msgid "Task not found"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:125
+#: apps/knowledge/serializers/document.py:145
+#: apps/knowledge/serializers/document.py:481
+msgid "task type"
+msgstr "任务类型"
+
+#: apps/knowledge/serializers/document.py:133
+#: apps/knowledge/serializers/document.py:153
+msgid "task type not support"
+msgstr "任务类型不支持"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:21
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:16
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:15
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:14
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:13
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:17
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:17
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:15
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:15
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:12
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:20
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:17
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:18
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:17
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:22
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:13
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:15
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:14
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:40
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:15
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:15
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:15
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:21
+msgid "Temperature"
+msgstr "温度"
+
+#: apps/models_provider/impl/tencent_cloud_model_provider/tencent_cloud_model_provider.py:58
+msgid "Tencent Cloud"
+msgstr "腾讯云"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:133
+msgid "Tencent Hunyuan"
+msgstr "腾讯混元"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:85
+msgid "Tencent's Hunyuan Embedding interface can convert text into high-quality vector data. The vector dimension is 1024 dimensions."
+msgstr "腾讯混元 Embedding 接口，可以将文本转化为高质量的向量数据。向量维度为1024维。"
+
+#: apps/common/constants/permission_constants.py:356
+#: apps/common/constants/permission_constants.py:414
+#: apps/common/constants/permission_constants.py:424
+msgid "Termbase"
+msgstr "词库"
+
+#: apps/knowledge/serializers/termbase.py:21
+#: apps/knowledge/serializers/termbase.py:67
+msgid "termbase id"
+msgstr ""
+
+#: apps/knowledge/serializers/termbase.py:28
+msgid "termbase list"
+msgstr ""
+
+#: apps/knowledge/views/termbase.py:28
+#: apps/knowledge/views/termbase.py:29
+#: apps/knowledge/views/termbase.py:30
+msgid "Termbase list"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:48
+msgid "Test"
+msgstr ""
+
+#: apps/system_manage/views/email_setting.py:66
+#: apps/system_manage/views/email_setting.py:67
+msgid "Test email settings"
+msgstr "测试邮箱设置"
+
+#: no source
+msgid "Test LDAP connection"
+msgstr "测试 LDAP 连接"
+
+#: no source
+msgid "Test platform connection"
+msgstr "测试平台连接"
+
+#: apps/tools/views/tool.py:457
+#: apps/tools/views/tool.py:458
+#: apps/tools/views/tool.py:459
+msgid "Test tool connection"
+msgstr ""
+
+#: apps/application/serializers/application.py:972
+msgid "Text"
+msgstr ""
+
+#: apps/local_model/serializers/model_apply_serializers.py:104
+#: apps/models_provider/serializers/model_apply_serializers.py:41
+msgid "text"
+msgstr "文本"
+
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:23
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:21
+msgid "Text content"
+msgstr "文本内容"
+
+#: apps/models_provider/api/provide.py:36
+msgid "text field"
+msgstr "文本字段"
+
+#: apps/application/views/application.py:487
+#: apps/application/views/application.py:488
+#: apps/application/views/application.py:489
+#: apps/chat/views/chat.py:239
+#: apps/chat/views/chat.py:240
+#: apps/chat/views/chat.py:241
+msgid "text to speech"
+msgstr ""
+
+#: apps/application/serializers/application.py:980
+msgid "Text to speech model ID"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:155
+msgid "Text to Video"
+msgstr "文生视频"
+
+#: apps/common/utils/common.py:156
+msgid "Text-to-speech node, the text content cannot be empty"
+msgstr "文本转语音节点，文本内容不能为空"
+
+#: apps/common/utils/common.py:154
+msgid "Text-to-speech node, the text content must be of string type"
+msgstr "文本转语音节点，文本内容必须是字符串类型"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:29
+msgid "Thai"
+msgstr "泰语"
+
+#: no source
+msgid "The app does not enable the speech-to-text function or the speech-to-text function fails."
+msgstr "智能体未开启语音转文字功能或语音转文字功能失败。"
+
+#: apps/application/serializers/common.py:148
+msgid "The application does not exist"
+msgstr ""
+
+#: apps/application/serializers/common.py:153
+#: apps/chat/serializers/chat.py:491
+#: apps/chat/serializers/chat.py:560
+msgid "The application has not been published. Please use it after publishing."
+msgstr "智能体未发布，请发布后使用。"
+
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:21
+msgid "The audio file cannot be empty"
+msgstr "音频文件不能为空"
+
+#: apps/application/flow/common.py:224
+msgid "The branch {branch} of the {node} node needs to be connected"
+msgstr "需要连接 {node} 节点的 {branch} 分支"
+
+#: apps/chat/serializers/chat.py:450
+#: apps/chat/serializers/chat.py:454
+msgid "The chat user is not authorized."
+msgstr ""
+
+#: no source
+msgid "The Chinese enhanced version developed by the Qianfan team based on Llama-2-7b has performed well on Chinese knowledge bases such as CMMLU and C-EVAL."
+msgstr "千帆团队在Llama-2-7b基础上的中文增强版本，在CMMLU、C-EVAL等中文知识库上表现优异。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:55
+msgid "The Claude 3 Haiku is Anthropic's fastest and most compact model, with near-instant responsiveness. The model can answer simple queries and requests quickly. Customers will be able to build seamless AI experiences that mimic human interactions. Claude 3 Haiku can process images and return text output, and provides 200K context windows."
+msgstr "Claude 3 Haiku 是 Anthropic 最快速、最紧凑的模型，具有近乎即时的响应能力。该模型可以快速回答简单的查询和请求。客户将能够构建模仿人类交互的无缝人工智能体验。 Claude 3 Haiku 可以处理图像和返回文本输出，并且提供 200K 上下文窗口。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:62
+msgid "The Claude 3 Sonnet model from Anthropic strikes the ideal balance between intelligence and speed, especially when it comes to handling enterprise workloads. This model offers maximum utility while being priced lower than competing products, and it's been engineered to be a solid choice for deploying AI at scale."
+msgstr "Anthropic 推出的 Claude 3 Sonnet 模型在智能和速度之间取得理想的平衡，尤其是在处理企业工作负载方面。该模型提供最大的效用，同时价格低于竞争产品，并且其经过精心设计，是大规模部署人工智能的可靠选择。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:69
+msgid "The Claude 3.5 Sonnet raises the industry standard for intelligence, outperforming competing models and the Claude 3 Opus in extensive evaluations, with the speed and cost-effectiveness of our mid-range models."
+msgstr "Claude 3.5 Sonnet提高了智能的行业标准，在广泛的评估中超越了竞争对手的型号和Claude 3 Opus，具有我们中端型号的速度和成本效益。"
+
+#: apps/system_manage/serializers/valid_serializers.py:31
+msgid "The community version supports up to 2 users. If you need more users, please contact us (https://fit2cloud.com/)."
+msgstr "社区版支持最多2个用户，如需更多用户，请联系我们（https://fit2cloud.com/）。"
+
+#: apps/system_manage/serializers/valid_serializers.py:28
+msgid "The community version supports up to 5 applications. If you need more applications, please contact us (https://fit2cloud.com/)."
+msgstr "社区版支持最多5个智能体，如需更多智能体，请联系我们（https://fit2cloud.com/）。"
+
+#: apps/system_manage/serializers/valid_serializers.py:25
+msgid "The community version supports up to 50 knowledge bases. If you need more knowledge bases, please contact us (https://fit2cloud.com/)."
+msgstr "社区版支持最多50个知识库，如需更多知识库，请联系我们 (https://fit2cloud.com/)."
+
+#: apps/users/serializers/user.py:447
+#: apps/users/serializers/user.py:995
+#: apps/users/serializers/user.py:1053
+msgid "The confirmation password must be 6-20 characters long and must be a combination of letters, numbers, and special characters."
+msgstr "确认密码必须为6-20个字符，且必须包含字母、数字和特殊字符。"
+
+#: no source
+msgid "The corresponding platform configuration for Slack was not found"
+msgstr "Slack 的对应平台配置未找到"
+
+#: no source
+msgid "The corresponding platform configuration was not found"
+msgstr "未找到对应的平台配置"
+
+#: apps/chat/serializers/chat.py:332
+msgid "The current model is not available"
+msgstr "当前模型不可用"
+
+#: apps/models_provider/base_model_provider.py:92
+msgid "The current platform does not support downloading models"
+msgstr "当前平台不支持下载模型"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:25
+msgid "The default is body, you can enter .classname/#idname/tagname"
+msgstr "默认为 body，可输入 .classname/#idname/tagname"
+
+#: apps/knowledge/serializers/paragraph.py:630
+msgid "The document id does not exist [{document_id}]"
+msgstr "以下文档ID不存在: {error_id_list}"
+
+#: apps/application/serializers/application_chat_record.py:264
+#: apps/application/serializers/application_chat_record.py:400
+#: apps/knowledge/serializers/paragraph.py:349
+msgid "The document id is incorrect"
+msgstr "文档 ID 不正确"
+
+#: apps/knowledge/serializers/paragraph.py:626
+msgid "The document to be migrated is consistent with the target document"
+msgstr "迁移的文档与目标文档一致"
+
+#: apps/common/event/__init__.py:34
+msgid "The download process was interrupted, please try again"
+msgstr "下载过程被中断，请重试"
+
+#: apps/common/constants/exception_code_constants.py:35
+msgid "The email has been registered, please log in directly"
+msgstr "该邮箱已注册，请直接登录"
+
+#: apps/common/constants/exception_code_constants.py:36
+msgid "The email is not registered, please register first"
+msgstr "该邮箱未注册，请先注册"
+
+#: apps/users/serializers/user.py:1134
+msgid "The email service has not been set up. Please contact the administrator to set up the email service in [Email Settings]."
+msgstr "邮箱服务尚未设置，请联系管理员在 [邮箱设置] 中设置邮箱服务。"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:32
+#: apps/tools/serializers/tool.py:265
+#: apps/trigger/serializers/trigger.py:49
+msgid "The field only supports custom|reference"
+msgstr "字段仅支持自定义|引用"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:28
+msgid "The field only supports string|int|dict|array|float"
+msgstr "字段仅支持字符串|整数|字典|数组|浮点数"
+
+#: apps/common/forms/base_field.py:64
+msgid "The field {field_label} is required"
+msgstr "{field_label} 字段是必填项"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:27
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:47
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:46
+msgid "The following fields are required: {keys}"
+msgstr "以下字段是必填项: {keys}"
+
+#: apps/trigger/serializers/trigger.py:43
+msgid "The following id does not exist: %s"
+msgstr "以下 id 不存在: %s"
+
+#: apps/knowledge/serializers/common.py:62
+msgid "The following id does not exist: {error_id_list}"
+msgstr "以下ID不存在: {error_id_list}"
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:39
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:42
+msgid "The function has been deleted"
+msgstr "工具已被删除"
+
+#: apps/application/flow/common.py:276
+msgid "The function library for node {node} is not available"
+msgstr "工具库 {node} 不可用"
+
+#: apps/knowledge/serializers/document.py:1507
+msgid "The hit processing method must be directly_return|optimization"
+msgstr "命中处理方法必须是直接返回|优化"
+
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:15
+msgid "The image generation endpoint allows you to create raw images based on text prompts. "
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:15
+msgid "The image generation endpoint allows you to create raw images based on text prompts. The dimensions of the image can be 1024x1024, 1024x1792, or 1792x1024 pixels."
+msgstr "图像生成端点允许您根据文本提示创建原始图像。图像的尺寸可以为 1024x1024、1024x1792 或 1792x1024 像素。"
+
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:15
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:15
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:15
+msgid "The image generation endpoint allows you to create raw images based on text prompts. When using the DALL·E 3, the image size can be 1024x1024, 1024x1792 or 1792x1024 pixels."
+msgstr "图像生成端点允许您根据文本提示创建原始图像。使用 DALL·E 3 时，图像的尺寸可以为 1024x1024、1024x1792 或 1792x1024 像素。"
+
+#: apps/application/serializers/application.py:248
+msgid "The knowledge base id does not exist"
+msgstr "知识库 ID 不存在"
+
+#: apps/knowledge/serializers/common.py:123
+#: apps/knowledge/serializers/common.py:159
+msgid "The knowledge base is inconsistent with the vector model"
+msgstr "知识库与向量模型不一致"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:42
+msgid "The knowledge base setting is wrong, please reset the knowledge base"
+msgstr "知识库设置错误，请重置知识库"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:214
+msgid "The knowledge base workflow has not been published"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:530
+msgid "The label field is required for the {index}th item in model_params_form"
+msgstr "model_params_form 中的第 {index} 项的 label 字段是必填项"
+
+#: apps/models_provider/impl/docker_ai_model_provider/docker_ai_model_provider.py:73
+msgid "The latest gpt-3.5-turbo, updated with DockerAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:35
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:116
+#: apps/models_provider/impl/regolo_model_provider/regolo_model_provider.py:67
+#: apps/models_provider/impl/siliconCloud_model_provider/siliconCloud_model_provider.py:127
+msgid "The latest gpt-3.5-turbo, updated with OpenAI adjustments"
+msgstr "最新的gpt-3.5-turbo，随OpenAI调整而更新"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:46
+msgid "The latest gpt-4-turbo, updated with OpenAI adjustments"
+msgstr "最新的gpt-4-turbo，随OpenAI调整而更新"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:49
+msgid "The latest gpt-4-turbo-preview, updated with OpenAI adjustments"
+msgstr "最新的gpt-4-turbo-preview，随OpenAI调整而更新"
+
+#: apps/models_provider/impl/docker_ai_model_provider/docker_ai_model_provider.py:49
+msgid "The latest GPT-4o, cheaper and faster than gpt-4-turbo, updated with DockerAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:40
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:99
+msgid "The latest GPT-4o, cheaper and faster than gpt-4-turbo, updated with OpenAI adjustments"
+msgstr "最新的GPT-4o，比gpt-4-turbo更便宜、更快，随OpenAI调整而更新"
+
+#: apps/models_provider/impl/docker_ai_model_provider/docker_ai_model_provider.py:53
+msgid "The latest gpt-4o-mini, cheaper and faster than gpt-4o, updated with DockerAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:43
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:102
+msgid "The latest gpt-4o-mini, cheaper and faster than gpt-4o, updated with OpenAI adjustments"
+msgstr "最新的gpt-4o-mini，比gpt-4o更便宜、更快，随OpenAI调整而更新"
+
+#: apps/application/flow/common.py:273
+msgid "The library ID of node {node} cannot be empty"
+msgstr "工具库 ID {node} 不能为空"
+
+#: no source
+msgid "The license is invalid"
+msgstr "许可证无效"
+
+#: apps/knowledge/serializers/document.py:1223
+msgid "The maximum size of the uploaded file cannot exceed {}MB"
+msgstr "上传文件的最大大小不能超过 {}MB"
+
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:48
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:53
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:50
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:47
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:48
+msgid "The model does not exist, please download the model first"
+msgstr "模型不存在，请先下载模型"
+
+#: apps/models_provider/base_model_provider.py:230
+msgid "The model does not support"
+msgstr "模型不支持"
+
+#: apps/chat/serializers/chat.py:334
+msgid "The model is downloading, please try again later"
+msgstr "下载过程被中断，请重试"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:40
+msgid "The most effective version of the current hybrid model, the trillion-level parameter scale MOE-32K long article model. Reaching the absolute leading level on various benchmarks, with complex instructions and reasoning, complex mathematical capabilities, support for function call, and application focus optimization in fields such as multi-language translation, finance, law, and medical care"
+msgstr "当前混元模型中效果最优版本，万亿级参数规模 MOE-32K 长文模型。在各种 benchmark 上达到绝对领先的水平，复杂指令和推理，具备复杂数学能力，支持 functioncall，在多语言翻译、金融法律医疗等领域智能体重点优化"
+
+#: no source
+msgid "The network is busy, try again later."
+msgstr "网络繁忙，请稍后再试。"
+
+#: apps/common/constants/exception_code_constants.py:44
+msgid "The nickname is already registered"
+msgstr "姓名已注册"
+
+#: apps/application/flow/common.py:257
+msgid "The node {node} model does not exist"
+msgstr "节点 {node} 模型不存在"
+
+#: apps/chat/serializers/chat.py:321
+msgid "The number of visits exceeds today's visits"
+msgstr "今天的访问次数超过限制"
+
+#: apps/application/serializers/application_chat_record.py:517
+msgid "The paragraph id is wrong. The current conversation record does not exist. [{paragraph_id}] paragraph id"
+msgstr "段落 ID 错误。当前对话记录不存在。[{paragraph_id}] 段落 ID"
+
+#: no source
+msgid "The password is incorrect"
+msgstr "密码不正确"
+
+#: apps/users/serializers/user.py:191
+#: apps/users/serializers/user.py:435
+#: apps/users/serializers/user.py:983
+#: apps/users/serializers/user.py:1041
+msgid "The password must be 6-20 characters long and must be a combination of letters, numbers, and special characters."
+msgstr "密码必须为6-20个字符，且必须包含大小写字母、数字和特殊字符。"
+
+#: no source
+msgid "The platform configuration corresponding to {type} was not found"
+msgstr "未找到对应 {type} 的平台配置"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:167
+msgid "The Qwen Audio based end-to-end speech recognition model supports audio recognition within 3 minutes. At present, it mainly supports Chinese and English recognition."
+msgstr "基于Qwen-Audio的端到端语音识别大模型，支持3分钟以内的音频识别，目前主要支持中英文识别。"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:149
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:158
+msgid "The Qwen Omni series model supports inputting multiple modalities of data, including video, audio, images, and text, and outputting audio and text."
+msgstr "Qwen-Omni 系列模型支持输入多种模态的数据，包括视频、音频、图片、文本，并输出音频与文本"
+
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:39
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:45
+msgid "The results are displayed in the knowledge sources"
+msgstr ""
+
+#: apps/application/flow/common.py:244
+msgid "The starting node is required"
+msgstr "开始节点是必需的"
+
+#: apps/application/flow/step_node/application_node/impl/base_application_node.py:194
+msgid "The sub application cannot use the current node"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1264
+msgid "The synchronization type only supports:replace|complete"
+msgstr "同步类型仅支持:replace|complete"
+
+#: apps/knowledge/serializers/paragraph.py:640
+msgid "The target document id does not exist [{document_id}]"
+msgstr "以下目标文档ID不存在: {error_id_list}"
+
+#: apps/knowledge/serializers/paragraph.py:598
+msgid "The task is being executed, please do not send it again."
+msgstr "任务正在执行，请勿重复发送。"
+
+#: apps/knowledge/serializers/document.py:882
+#: apps/knowledge/serializers/document.py:920
+msgid "The task is being executed, please do not send it repeatedly."
+msgstr "任务正在执行，请勿重复发送。"
+
+#: apps/knowledge/serializers/document.py:265
+msgid "The template type only supports excel|csv"
+msgstr "模板类型仅支持 excel|csv"
+
+#: apps/application/serializers/application.py:269
+msgid "The thinking process begins to mark"
+msgstr "思考过程开始标记"
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:191
+msgid "The tool has not been published. Please use it after publishing."
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:45
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:30
+#: apps/application/serializers/application.py:216
+#: apps/knowledge/serializers/knowledge.py:166
+#: apps/knowledge/serializers/knowledge.py:1371
+msgid "The type only supports embedding|keywords|blend"
+msgstr "类型仅支持嵌入|关键字|混合"
+
+#: apps/knowledge/serializers/document.py:166
+#: apps/knowledge/serializers/document.py:256
+msgid "The type only supports optimization|directly_return"
+msgstr "该类型仅支持优化|直接返回"
+
+#: apps/users/serializers/user.py:1091
+#: apps/users/serializers/user.py:1173
+msgid "The type only supports register|reset_password"
+msgstr "类型仅支持 register|reset_password"
+
+#: no source
+msgid "The user does not have permission to access the application"
+msgstr "用户没有访问智能体的权限"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:46
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:51
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:80
+msgid "The user goes to the model inference page of Volcano Ark to create an inference access point. Here, you need to enter ep-xxxxxxxxxx-yyyy to call it."
+msgstr "用户前往火山方舟的模型推理页面创建推理接入点，这里需要输入ep-xxxxxxxxxx-yyyy进行调用"
+
+#: apps/users/serializers/login.py:158
+msgid "The user has been disabled, please contact the administrator!"
+msgstr "用户已被禁用，请联系管理员！"
+
+#: apps/common/constants/exception_code_constants.py:41
+msgid "The username cannot be empty and must be between 6 and 20 characters long."
+msgstr "用户名不能为空，且长度在6到20个字符之间。"
+
+#: apps/common/constants/exception_code_constants.py:39
+msgid "The username has been registered, please log in directly"
+msgstr "用户名已注册，请直接登录"
+
+#: apps/common/constants/exception_code_constants.py:31
+#: apps/users/serializers/login.py:150
+msgid "The username or password is incorrect"
+msgstr "用户名或密码不正确"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:40
+msgid "The vector model of the associated knowledge base is inconsistent and the segmentation cannot be recalled."
+msgstr "关联的知识库的向量模型不一致，无法回调分段。"
+
+#: apps/common/constants/exception_code_constants.py:38
+msgid "The verification code is incorrect or the verification code has expired"
+msgstr "验证码不正确或已过期"
+
+#: apps/common/forms/slider_field.py:62
+msgid "The {field_label} cannot be greater than {max}"
+msgstr "{field_label} 不能大于{max}"
+
+#: apps/common/forms/slider_field.py:56
+msgid "The {field_label} cannot be less than {min}"
+msgstr "{field_label} 不能小于{min}"
+
+#: apps/models_provider/serializers/model_serializer.py:523
+msgid "The {index}th item in model_params_form must be a dictionary"
+msgstr "model_params_form 中的第 {index} 项必须是一个字典"
+
+#: no source
+msgid "theme"
+msgstr "主题"
+
+#: no source
+msgid "theme color"
+msgstr "主题颜色"
+
+#: apps/application/flow/common.py:284
+msgid "There can only be one basic information node"
+msgstr "只能有一个基本信息节点"
+
+#: apps/application/flow/common.py:246
+msgid "There can only be one starting node"
+msgstr "只能有一个开始节点"
+
+#: apps/tools/serializers/tool_workflow.py:287
+msgid "There is a circular dependency in the tool workflow"
+msgstr "工具工作流存在循环依赖"
+
+#: no source
+msgid "Think: "
+msgstr "思考内容: "
+
+#: no source
+msgid "Thinking about 【{question}】...If you want me to continue answering, please reply {trigger_message}"
+msgstr "思考【{question}】...如果你想让我继续回答，请回复 {trigger_message}"
+
+#: apps/application/serializers/application.py:261
+msgid "Thinking process switch"
+msgstr "思考过程开关"
+
+#: no source
+msgid "Thinking, please wait a moment!"
+msgstr "思考中，请稍等！"
+
+#: no source
+msgid "Thinking..."
+msgstr "思考中..."
+
+#: apps/users/serializers/login.py:138
+#: apps/users/serializers/login.py:259
+msgid "This account has been locked for %s minutes, please try again later"
+msgstr "该账号已被锁定 %s 分钟，请稍后再试"
+
+#: apps/common/handle/impl/text/pdf_split_handle.py:381
+msgid "This document has no preface and is treated as ordinary text: {e}"
+msgstr "该文档没有前言，视为普通文本: {e}"
+
+#: apps/folders/serializers/folder.py:276
+msgid "This folder contains resources that you dont have permission"
+msgstr "此文件夹包含您没有权限的资源"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:77
+msgid "This interface is used to recognize short audio files within 60 seconds. Supports Mandarin Chinese, English, Cantonese, Japanese, Vietnamese, Malay, Indonesian, Filipino, Thai, Portuguese, Turkish, Arabic, Hindi, French, German, and 23 Chinese dialects."
+msgstr "本接口用于识别 60 秒之内的短音频文件。支持中文普通话、英语、粤语、日语、越南语、马来语、印度尼西亚语、菲律宾语、泰语、葡萄牙语、土耳其语、阿拉伯语、印地语、法语、德语及 23 种汉语方言。"
+
+#: no source
+msgid "This type of message is not supported yet"
+msgstr "此类型消息暂不支持"
+
+#: no source
+msgid "This workspace contains %s, cannot be deleted."
+msgstr "该工作空间下存在 %s，不能被删除。"
+
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:74
+msgid "Thousand sails large model"
+msgstr "千帆大模型"
+
+#: no source
+msgid "Three-party login"
+msgstr "三方登录"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:21
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:54
+msgid "Timbre"
+msgstr "音色"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:14
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:15
+msgid "timbre"
+msgstr "音色"
+
+#: apps/application/serializers/application_chat.py:222
+msgid "Time consumed (s)"
+msgstr "耗时 (s)"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:128
+msgid "Titan Embed Text is the largest embedding model in the Amazon Titan Embed series and can handle various text embedding tasks, such as text classification, text similarity calculation, etc."
+msgstr "Titan Embed Text 是 Amazon Titan Embed 系列中最大的嵌入模型，可以处理各种文本嵌入任务，如文本分类、文本相似度计算等。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:83
+msgid "Titan Text Premier is the most powerful and advanced model in the Titan Text series, designed to deliver exceptional performance for a variety of enterprise applications. With its cutting-edge features, it delivers greater accuracy and outstanding results, making it an excellent choice for organizations looking for a top-notch text processing solution."
+msgstr "Titan Text Premier 是 Titan Text 系列中功能强大且先进的型号，旨在为各种企业应用程序提供卓越的性能。凭借其尖端功能，它提供了更高的准确性和出色的结果，使其成为寻求一流文本处理解决方案的组织的绝佳选择。"
+
+#: no source
+msgid "title"
+msgstr "标题"
+
+#: no source
+msgid "To be continued, reply \"{trigger_message}\" to continue answering the question"
+msgstr "待续，回复 \"{trigger_message}\" 继续回答问题"
+
+#: apps/chat/api/chat_embed_api.py:38
+#: apps/chat/serializers/chat_embed_serializers.py:27
+#: apps/users/serializers/login.py:48
+msgid "token"
+msgstr "令牌"
+
+#: no source
+msgid "Token"
+msgstr "令牌"
+
+#: no source
+msgid "Token address cannot be empty"
+msgstr "令牌地址不能为空"
+
+#: apps/homepage/serializers/homepage.py:303
+#: apps/homepage/serializers/homepage.py:626
+msgid "Token consumption"
+msgstr "Token消耗"
+
+#: no source
+msgid "token is required"
+msgstr "token 是必填项"
+
+#: no source
+msgid "Token is required"
+msgstr "Token 是必填项"
+
+#: apps/trigger/serializers/trigger.py:248
+msgid "token is required for EVENT triggers"
+msgstr "事件触发器必须设置 token"
+
+#: apps/knowledge/views/document.py:401
+#: apps/knowledge/views/document.py:402
+#: apps/knowledge/views/document.py:403
+msgid "Tokenize document vector library"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:562
+msgid "Tokenize document: {document_id} error {error} {traceback}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:242
+msgid "Tokenize paragraph: {paragraph_id} error {error} {traceback}"
+msgstr ""
+
+#: apps/application/serializers/application_stats.py:33
+msgid "Tokens consumption"
+msgstr "消耗的令牌"
+
+#: apps/homepage/views/homepage.py:58
+#: apps/homepage/views/homepage.py:59
+msgid "Tokens data aggregation"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:184
+msgid "Tongyi Wanxiang - a large image model for text generation, supports bilingual input in Chinese and English, and supports the input of reference pictures for reference content or reference style migration. Key styles include but are not limited to watercolor, oil painting, Chinese painting, sketch, flat illustration, two-dimensional, and 3D. Cartoon."
+msgstr "通义万相-文本生成图像大模型，支持中英文双语输入，支持输入参考图片进行参考内容或者参考风格迁移，重点风格包括但不限于水彩、油画、中国画、素描、扁平插画、二次元、3D卡通。"
+
+#: apps/chat/serializers/chat.py:62
+msgid "Too many messages"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:343
+#: apps/common/constants/permission_constants.py:410
+#: apps/common/constants/permission_constants.py:420
+#: apps/common/constants/permission_constants.py:437
+#: apps/knowledge/views/knowledge.py:321
+#: apps/tools/views/tool.py:50
+#: apps/tools/views/tool.py:73
+#: apps/tools/views/tool.py:104
+#: apps/tools/views/tool.py:127
+#: apps/tools/views/tool.py:154
+#: apps/tools/views/tool.py:180
+#: apps/tools/views/tool.py:211
+#: apps/tools/views/tool.py:249
+#: apps/tools/views/tool.py:287
+#: apps/tools/views/tool.py:318
+#: apps/tools/views/tool.py:351
+#: apps/tools/views/tool.py:379
+#: apps/tools/views/tool.py:409
+#: apps/tools/views/tool.py:434
+#: apps/tools/views/tool.py:462
+#: apps/tools/views/tool.py:487
+#: apps/tools/views/tool.py:506
+#: apps/tools/views/tool.py:534
+#: apps/tools/views/tool.py:553
+#: apps/tools/views/tool.py:583
+#: apps/tools/views/tool.py:616
+#: apps/tools/views/tool.py:645
+#: apps/tools/views/tool.py:674
+#: apps/tools/views/tool_workflow.py:35
+#: apps/tools/views/tool_workflow.py:74
+#: apps/tools/views/tool_workflow.py:105
+#: apps/tools/views/tool_workflow.py:135
+#: apps/tools/views/tool_workflow.py:164
+#: apps/tools/views/tool_workflow.py:198
+msgid "Tool"
+msgstr "工具"
+
+#: apps/tools/serializers/tool.py:287
+#: apps/tools/serializers/tool.py:303
+#: apps/tools/serializers/tool.py:328
+#: apps/tools/serializers/tool.py:551
+msgid "tool content"
+msgstr "工具内容"
+
+#: apps/homepage/views/homepage.py:301
+#: apps/homepage/views/homepage.py:302
+msgid "Tool data aggregation"
+msgstr "工具数据聚合"
+
+#: apps/tools/serializers/tool.py:285
+#: apps/tools/serializers/tool.py:300
+msgid "tool description"
+msgstr "工具描述"
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:118
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:123
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:137
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:142
+#: apps/tools/serializers/tool.py:1220
+#: apps/tools/serializers/tool.py:1387
+#: apps/tools/serializers/tool.py:1559
+msgid "Tool does not exist"
+msgstr "工具不存在"
+
+#: apps/tools/serializers/tool.py:619
+#: apps/tools/serializers/tool.py:1211
+#: apps/tools/serializers/tool.py:1309
+#: apps/tools/serializers/tool.py:1376
+#: apps/tools/serializers/tool.py:1426
+#: apps/tools/serializers/tool.py:1434
+#: apps/tools/serializers/tool.py:1546
+#: apps/tools/serializers/tool_workflow.py:146
+msgid "tool id"
+msgstr "工具 ID"
+
+#: apps/tools/serializers/tool_version.py:34
+#: apps/tools/serializers/tool_version.py:69
+msgid "Tool ID"
+msgstr ""
+
+#: apps/tools/serializers/tool_workflow.py:376
+msgid "Tool id"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:632
+#: apps/tools/serializers/tool.py:641
+#: apps/tools/serializers/tool.py:1162
+#: apps/tools/serializers/tool_version.py:80
+#: apps/tools/serializers/tool_workflow.py:155
+#: apps/tools/serializers/tool_workflow.py:387
+msgid "Tool id does not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:45
+msgid "Tool IDs"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:125
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:144
+msgid "Tool is not active"
+msgstr ""
+
+#: apps/application/serializers/application.py:919
+#: apps/knowledge/serializers/knowledge.py:1419
+#: apps/tools/serializers/tool.py:283
+#: apps/tools/serializers/tool.py:299
+#: apps/tools/serializers/tool.py:318
+#: apps/tools/serializers/tool.py:343
+#: apps/tools/serializers/tool.py:1194
+#: apps/tools/serializers/tool.py:1255
+#: apps/tools/serializers/tool.py:1688
+#: apps/tools/serializers/tool_workflow.py:413
+msgid "tool name"
+msgstr "工具名称"
+
+#: apps/tools/serializers/tool.py:653
+msgid "Tool not found"
+msgstr "工具不存在"
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:18
+msgid "Tool parameters"
+msgstr "工具参数"
+
+#: apps/tools/serializers/tool.py:1465
+msgid "Tool record does not exist"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:346
+#: apps/tools/serializers/tool.py:1691
+msgid "tool type"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1693
+msgid "tool type list"
+msgstr ""
+
+#: apps/tools/serializers/tool_version.py:71
+msgid "Tool version ID"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:130
+#: apps/tools/views/tool_workflow.py:131
+#: apps/tools/views/tool_workflow.py:132
+msgid "tool workflow debug"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:46
+#: apps/tools/views/tool_workflow_version.py:70
+#: apps/tools/views/tool_workflow_version.py:95
+#: apps/tools/views/tool_workflow_version.py:117
+msgid "Tool/Version"
+msgstr ""
+
+#: no source
+msgid "Tools Resource"
+msgstr "工具资源"
+
+#: apps/homepage/views/homepage.py:158
+#: apps/homepage/views/homepage.py:159
+msgid "Top applications by question count"
+msgstr "提问次数 TOP 智能体"
+
+#: apps/homepage/views/homepage.py:133
+#: apps/homepage/views/homepage.py:134
+msgid "Top applications by question count export"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:108
+#: apps/homepage/views/homepage.py:109
+msgid "Top applications by token consumption"
+msgstr "tokens 消耗 TOP 智能体"
+
+#: apps/homepage/views/homepage.py:83
+#: apps/homepage/views/homepage.py:84
+msgid "Top applications by token consumption export"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:17
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:14
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:23
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:23
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:23
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:23
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:16
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:15
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:21
+msgid "Top N"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:158
+#: apps/knowledge/serializers/knowledge.py:1363
+msgid "top number"
+msgstr "Top 数量"
+
+#: apps/homepage/views/homepage.py:207
+#: apps/homepage/views/homepage.py:208
+msgid "Top users by token consumption"
+msgstr "tokens 消耗 TOP 用户"
+
+#: apps/homepage/views/homepage.py:183
+#: apps/homepage/views/homepage.py:184
+msgid "Top users by token consumption export"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:247
+msgid "Total application count"
+msgstr "应用总数"
+
+#: apps/homepage/api/home_page_api.py:165
+#: apps/homepage/api/home_page_api.py:221
+msgid "Total consumed tokens"
+msgstr "消耗 tokens 总数"
+
+#: apps/homepage/api/home_page_api.py:157
+#: apps/homepage/api/home_page_api.py:187
+#: apps/homepage/api/home_page_api.py:212
+msgid "Total count"
+msgstr "总数量"
+
+#: apps/homepage/api/home_page_api.py:311
+msgid "Total document count"
+msgstr "文档总数"
+
+#: apps/homepage/api/home_page_api.py:310
+msgid "Total knowledge count"
+msgstr "知识库总数"
+
+#: apps/homepage/api/home_page_api.py:384
+msgid "Total model count"
+msgstr "模型总数"
+
+#: apps/common/result/api.py:43
+msgid "total number of data"
+msgstr "总数据"
+
+#: apps/application/serializers/application_stats.py:30
+msgid "Total number of users"
+msgstr "总用户数"
+
+#: apps/homepage/api/home_page_api.py:347
+msgid "Total tool count"
+msgstr "工具总数"
+
+#: no source
+msgid "trial listening"
+msgstr "试听"
+
+#: apps/application/serializers/application_chat.py:295
+#: apps/common/constants/permission_constants.py:344
+#: apps/trigger/handler/impl/trigger/event_trigger.py:91
+#: apps/trigger/views/trigger.py:63
+#: apps/trigger/views/trigger.py:84
+#: apps/trigger/views/trigger.py:110
+#: apps/trigger/views/trigger.py:133
+#: apps/trigger/views/trigger.py:155
+#: apps/trigger/views/trigger.py:181
+#: apps/trigger/views/trigger.py:207
+#: apps/trigger/views/trigger.py:232
+#: apps/trigger/views/trigger.py:260
+#: apps/trigger/views/trigger.py:295
+#: apps/trigger/views/trigger.py:323
+#: apps/trigger/views/trigger.py:348
+#: apps/trigger/views/trigger.py:380
+#: apps/trigger/views/trigger_task.py:33
+#: apps/trigger/views/trigger_task.py:58
+#: apps/trigger/views/trigger_task.py:83
+msgid "Trigger"
+msgstr "触发器"
+
+#: apps/trigger/serializers/task_source_trigger.py:31
+#: apps/trigger/serializers/trigger.py:298
+#: apps/trigger/serializers/trigger.py:308
+msgid "trigger description"
+msgstr "触发器描述"
+
+#: apps/trigger/serializers/task_source_trigger.py:60
+#: apps/trigger/serializers/trigger.py:501
+msgid "trigger id"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:306
+#: apps/trigger/serializers/trigger_task.py:42
+#: apps/trigger/serializers/trigger_task.py:66
+#: apps/trigger/serializers/trigger_task.py:126
+msgid "Trigger ID"
+msgstr "触发器ID"
+
+#: apps/trigger/serializers/task_source_trigger.py:72
+#: apps/trigger/serializers/trigger.py:512
+#: apps/trigger/serializers/trigger_task.py:52
+#: apps/trigger/serializers/trigger_task.py:78
+#: apps/trigger/serializers/trigger_task.py:140
+msgid "Trigger id does not exist"
+msgstr "触发器 id 不存在"
+
+#: apps/trigger/serializers/task_source_trigger.py:134
+#: apps/trigger/serializers/task_source_trigger.py:144
+#: apps/trigger/serializers/trigger.py:542
+#: apps/trigger/serializers/trigger.py:562
+msgid "Trigger must have at least one task"
+msgstr "触发器必须至少有一个任务"
+
+#: apps/trigger/serializers/task_source_trigger.py:30
+#: apps/trigger/serializers/trigger.py:297
+#: apps/trigger/serializers/trigger.py:307
+msgid "trigger name"
+msgstr "触发器名称"
+
+#: apps/trigger/serializers/trigger.py:639
+#: apps/trigger/serializers/trigger_task.py:129
+msgid "Trigger name"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:119
+#: apps/trigger/serializers/task_source_trigger.py:167
+#: apps/trigger/serializers/trigger.py:525
+msgid "Trigger not found"
+msgstr "未找到触发器"
+
+#: apps/trigger/serializers/task_source_trigger.py:33
+#: apps/trigger/serializers/trigger.py:300
+#: apps/trigger/serializers/trigger.py:310
+msgid "trigger setting"
+msgstr "触发器设置"
+
+#: apps/trigger/serializers/trigger_task.py:128
+msgid "Trigger state"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:642
+msgid "Trigger task"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:395
+msgid "Trigger task can not be empty"
+msgstr "触发器任务不能为空"
+
+#: apps/trigger/serializers/trigger_task.py:68
+msgid "Trigger task ID"
+msgstr "触发器任务ID"
+
+#: apps/trigger/serializers/task_source_trigger.py:46
+msgid "Trigger task number must be one"
+msgstr "触发器任务数量必须为一个"
+
+#: apps/trigger/serializers/trigger_task.py:69
+msgid "Trigger task record ID"
+msgstr "触发器任务记录ID"
+
+#: apps/trigger/serializers/trigger_task.py:87
+msgid "Trigger task record id does not exist"
+msgstr "触发器任务记录 id 不存在"
+
+#: apps/models_provider/api/provide.py:44
+msgid "trigger type"
+msgstr "触发类型"
+
+#: apps/trigger/serializers/trigger.py:640
+msgid "Trigger type"
+msgstr ""
+
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:16
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:16
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:16
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:16
+msgid "Try out the different sounds (Alloy, Echo, Fable, Onyx, Nova, and Sparkle) to find one that suits your desired tone and audience. The current voiceover is optimized for English."
+msgstr "尝试不同的声音（合金、回声、寓言、缟玛瑙、新星和闪光），找到一种适合您所需的音调和听众的声音。当前的语音针对英语进行了优化。"
+
+#: apps/models_provider/base_model_provider.py:150
+msgid "TTS"
+msgstr "语音合成"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:31
+msgid "Turkish"
+msgstr "土耳其语"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:26
+#: apps/knowledge/serializers/document.py:268
+#: apps/knowledge/serializers/knowledge_workflow.py:299
+#: apps/knowledge/serializers/knowledge_workflow.py:300
+#: apps/system_manage/serializers/valid_serializers.py:37
+#: apps/tools/serializers/tool.py:251
+msgid "type"
+msgstr "类型"
+
+#: apps/users/serializers/user.py:1089
+#: apps/users/serializers/user.py:1170
+msgid "Type"
+msgstr "类型"
+
+#: apps/common/utils/common.py:476
+#: apps/common/utils/common.py:483
+msgid "type error"
+msgstr "类型错误"
+
+#: apps/users/serializers/user.py:486
+msgid "Unable to delete administrator"
+msgstr "无法删除管理员"
+
+#: no source
+msgid "Universal 1.4-Vincent Chart"
+msgstr "通用1.4-文生图"
+
+#: no source
+msgid "Universal 2.0-Vincent Diagram"
+msgstr "通用2.0-文生图"
+
+#: no source
+msgid "Universal 2.0Pro-Vincent Chart"
+msgstr "通用2.0Pro-文生图"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:42
+msgid "Universal realistic style"
+msgstr "通用写实风格"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:98
+msgid "Universal text vector is Tongyi Lab's multi-language text unified vector model based on the LLM base. It provides high-level vector services for multiple mainstream languages around the world and helps developers quickly convert text data into high-quality vector data."
+msgstr "通用文本向量，是通义实验室基于LLM底座的多语言文本统一向量模型，面向全球多个主流语种，提供高水准的向量服务，帮助开发者将文本数据快速转换为高质量的向量数据。"
+
+#: no source
+msgid "Unknown application id {knowledge_id}, cannot be associated"
+msgstr "未知智能体 ID {knowledge_id}，无法关联"
+
+#: apps/common/exception/handle_exception.py:35
+#: apps/common/handle/handle_exception.py:34
+msgid "Unknown exception"
+msgstr "未知错误"
+
+#: apps/application/serializers/application.py:1373
+#: apps/tools/serializers/tool_workflow.py:330
+msgid "Unknown knowledge base id {dataset_id}, unable to associate"
+msgstr "未知知识库 ID {dataset_id}，无法关联"
+
+#: apps/application/serializers/application.py:453
+msgid "Unpublished"
+msgstr "未发布"
+
+#: apps/homepage/api/home_page_api.py:249
+msgid "Unpublished application count"
+msgstr "未发布应用数量"
+
+#: apps/application/serializers/application.py:750
+#: apps/application/serializers/application.py:1401
+#: apps/common/handle/impl/qa/zip_parse_qa_handle.py:56
+#: apps/common/handle/impl/text/zip_split_handle.py:59
+#: apps/knowledge/serializers/document.py:1166
+#: apps/knowledge/serializers/document.py:1188
+#: apps/knowledge/serializers/knowledge_workflow.py:405
+#: apps/tools/serializers/tool.py:1070
+#: apps/tools/serializers/tool.py:1092
+#: apps/tools/serializers/tool.py:1537
+msgid "Unsupported file format"
+msgstr "不支持的文件格式"
+
+#: no source
+msgid "Unsupported platform type"
+msgstr "不支持的平台类型"
+
+#: no source
+msgid "Unsupported sync type"
+msgstr "不支持的同步类型"
+
+#: apps/knowledge/views/tag.py:74
+msgid "Update a knowledge tag"
+msgstr ""
+
+#: no source
+msgid "Update a lark knowledge base"
+msgstr "更新飞书知识库"
+
+#: no source
+msgid "Update appearance settings"
+msgstr "更新外观设置"
+
+#: apps/tools/views/tool.py:577
+#: apps/tools/views/tool.py:578
+#: apps/tools/views/tool.py:579
+msgid "Update Appstore tool"
+msgstr ""
+
+#: no source
+msgid "Update auth setting"
+msgstr "更新认证设置"
+
+#: no source
+msgid "Update chat user information"
+msgstr "更新对话用户信息"
+
+#: apps/folders/views/folder.py:93
+#: apps/folders/views/folder.py:94
+#: apps/folders/views/folder.py:95
+msgid "Update folder"
+msgstr "更新文件夹"
+
+#: apps/knowledge/views/tag.py:73
+msgid "Update Knowledge Tag"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:1296
+msgid "Update License"
+msgstr "更新许可证"
+
+#: no source
+msgid "Update license information"
+msgstr "更新许可证信息"
+
+#: no source
+msgid "Update license information by uploading a new license file"
+msgstr "通过上传新许可证文件更新许可证信息"
+
+#: apps/models_provider/views/model.py:82
+#: apps/models_provider/views/model.py:83
+#: apps/models_provider/views/model.py:114
+#: apps/models_provider/views/model.py:115
+#: apps/models_provider/views/model.py:116
+msgid "Update model"
+msgstr "更新模型"
+
+#: no source
+msgid "Update personal system API_KEY"
+msgstr "更新个人系统 API KEY"
+
+#: no source
+msgid "Update platform configuration"
+msgstr "更新平台配置"
+
+#: no source
+msgid "Update platform status"
+msgstr "更新平台状态"
+
+#: no source
+msgid "Update shared knowledge"
+msgstr "更新共享知识库"
+
+#: no source
+msgid "Update shared tool"
+msgstr "更新共享工具"
+
+#: no source
+msgid "Update system knowledge"
+msgstr "更新系统知识库"
+
+#: no source
+msgid "Update system tool"
+msgstr "更新工具"
+
+#: no source
+msgid "Update SystemAPIKey"
+msgstr "更新系统 API 密钥"
+
+#: apps/tools/views/tool.py:121
+#: apps/tools/views/tool.py:122
+#: apps/tools/views/tool.py:123
+msgid "Update tool"
+msgstr "更新工具"
+
+#: apps/users/views/user.py:230
+#: apps/users/views/user.py:231
+#: apps/users/views/user.py:232
+msgid "Update user information"
+msgstr "更新当前用户信息"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:53
+msgid "Upgraded to MOE structure, the context window is 256k, leading many open source models in multiple evaluation sets such as NLP, code, mathematics, industry, etc."
+msgstr "升级为 MOE 结构，上下文窗口为 256k ，在 NLP，代码，数学，行业等多项评测集上领先众多开源模型"
+
+#: apps/oss/views/file.py:38
+#: apps/oss/views/file.py:39
+#: apps/oss/views/file.py:40
+msgid "Upload file"
+msgstr "上传文件"
+
+#: apps/application/flow/step_node/data_source_local_node/i_data_source_local_node.py:22
+msgid "Upload file size"
+msgstr ""
+
+#: apps/chat/views/chat.py:259
+#: apps/chat/views/chat.py:260
+#: apps/chat/views/chat.py:261
+msgid "Upload files"
+msgstr ""
+
+#: apps/tools/views/tool.py:668
+#: apps/tools/views/tool.py:669
+#: apps/tools/views/tool.py:670
+msgid "Upload skill file"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:44
+msgid "URL error, cannot parse [{source_url}]"
+msgstr "URL 错误，无法解析 [{source_url}]"
+
+#: apps/application/serializers/application_chat.py:220
+msgid "User"
+msgstr "用户"
+
+#: no source
+msgid "USER"
+msgstr "普通用户"
+
+#: no source
+msgid "user"
+msgstr "用户"
+
+#: no source
+msgid "user avatar"
+msgstr "用户头像"
+
+#: no source
+msgid "user avatar url"
+msgstr "用户头像地址"
+
+#: apps/users/serializers/user.py:471
+msgid "User does not exist"
+msgstr "用户不存在"
+
+#: no source
+msgid "User does not have permission to use API Key"
+msgstr "用户没有使用 API Key 的权限"
+
+#: apps/application/serializers/application_chat.py:216
+msgid "User feedback"
+msgstr "用户反馈"
+
+#: apps/common/constants/permission_constants.py:406
+#: apps/common/constants/permission_constants.py:430
+msgid "User Group"
+msgstr "用户组"
+
+#: no source
+msgid "User group"
+msgstr "用户组"
+
+#: no source
+msgid "User group does not exist"
+msgstr "用户组不存在"
+
+#: no source
+msgid "User Group ID"
+msgstr "用户组 ID"
+
+#: no source
+msgid "User group id"
+msgstr "用户组ID"
+
+#: no source
+msgid "User Group IDs"
+msgstr "用户组 IDs"
+
+#: no source
+msgid "User Group IDs cannot be empty"
+msgstr "用户组 IDs 不能为空"
+
+#: no source
+msgid "User group name"
+msgstr "用户名"
+
+#: no source
+msgid "User group name already exists"
+msgstr "用户组名称已存在"
+
+#: no source
+msgid "User Group Names"
+msgstr "用户组名称"
+
+#: no source
+msgid "User group relation IDs"
+msgstr "用户组关系 ID"
+
+#: no source
+msgid "User group relation IDs cannot be empty"
+msgstr "用户组关系 IDs 不能为空"
+
+#: apps/application/api/application_api.py:89
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:30
+#: apps/application/serializers/application.py:227
+#: apps/application/serializers/application.py:455
+#: apps/application/serializers/application.py:475
+#: apps/application/serializers/application.py:632
+#: apps/application/serializers/application.py:918
+#: apps/application/serializers/application.py:994
+#: apps/application/serializers/application_chat_link.py:58
+#: apps/homepage/serializers/homepage.py:90
+#: apps/homepage/serializers/homepage.py:151
+#: apps/homepage/serializers/homepage.py:216
+#: apps/homepage/serializers/homepage.py:388
+#: apps/homepage/serializers/homepage.py:515
+#: apps/homepage/serializers/homepage.py:655
+#: apps/homepage/serializers/homepage.py:737
+#: apps/homepage/serializers/homepage.py:778
+#: apps/homepage/serializers/homepage.py:827
+#: apps/homepage/serializers/homepage.py:874
+#: apps/knowledge/serializers/knowledge.py:1418
+#: apps/knowledge/serializers/knowledge.py:1473
+#: apps/knowledge/serializers/knowledge_workflow.py:647
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:14
+#: apps/models_provider/serializers/model_serializer.py:358
+#: apps/tools/serializers/tool.py:909
+#: apps/tools/serializers/tool.py:1152
+#: apps/tools/serializers/tool.py:1193
+#: apps/tools/serializers/tool.py:1209
+#: apps/tools/serializers/tool.py:1254
+#: apps/tools/serializers/tool.py:1307
+#: apps/tools/serializers/tool.py:1374
+#: apps/tools/serializers/tool.py:1530
+#: apps/tools/serializers/tool.py:1544
+#: apps/tools/serializers/tool_workflow.py:377
+#: apps/tools/serializers/tool_workflow.py:412
+#: apps/trigger/serializers/task_source_trigger.py:40
+#: apps/trigger/serializers/trigger.py:348
+#: apps/trigger/serializers/trigger.py:452
+#: apps/trigger/serializers/trigger.py:502
+#: apps/users/api/user.py:52
+#: apps/users/api/user.py:110
+#: apps/users/api/user.py:126
+#: apps/users/serializers/user.py:463
+msgid "User ID"
+msgstr "用户 ID"
+
+#: apps/folders/serializers/folder.py:135
+#: apps/folders/serializers/folder.py:179
+#: apps/knowledge/serializers/document.py:1003
+#: apps/knowledge/serializers/document.py:1316
+#: apps/knowledge/serializers/knowledge.py:188
+#: apps/knowledge/serializers/knowledge.py:314
+#: apps/knowledge/serializers/knowledge.py:883
+#: apps/knowledge/serializers/knowledge.py:1134
+#: apps/knowledge/serializers/knowledge.py:1257
+#: apps/knowledge/serializers/knowledge.py:1361
+#: apps/knowledge/serializers/knowledge.py:1503
+#: apps/knowledge/serializers/knowledge_workflow.py:317
+#: apps/knowledge/serializers/knowledge_workflow.py:389
+#: apps/knowledge/serializers/knowledge_workflow.py:516
+#: apps/knowledge/serializers/knowledge_workflow.py:566
+#: apps/models_provider/serializers/model_serializer.py:129
+#: apps/models_provider/serializers/model_serializer.py:246
+#: apps/models_provider/serializers/model_serializer.py:284
+#: apps/system_manage/api/user_resource_permission.py:116
+#: apps/system_manage/serializers/user_resource_permission.py:109
+#: apps/tools/serializers/tool.py:344
+#: apps/tools/serializers/tool.py:464
+#: apps/tools/serializers/tool.py:563
+#: apps/tools/serializers/tool.py:1689
+#: apps/tools/serializers/tool_workflow.py:144
+#: apps/users/serializers/user.py:1187
+msgid "user id"
+msgstr "用户ID"
+
+#: apps/users/api/user.py:135
+#: apps/users/serializers/user.py:623
+msgid "User IDs"
+msgstr "用户 ID"
+
+#: apps/users/serializers/user.py:628
+msgid "User IDs cannot be empty"
+msgstr "用户 ID 不能为空"
+
+#: no source
+msgid "User information address cannot be empty"
+msgstr "用户信息地址不能为空"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:20
+msgid "User Input Fields"
+msgstr "用户输入字段"
+
+#: apps/common/constants/permission_constants.py:326
+#: apps/users/views/login.py:41
+#: apps/users/views/login.py:58
+#: apps/users/views/login.py:73
+#: apps/users/views/user.py:71
+#: apps/users/views/user.py:85
+#: apps/users/views/user.py:99
+#: apps/users/views/user.py:118
+#: apps/users/views/user.py:133
+#: apps/users/views/user.py:149
+#: apps/users/views/user.py:164
+#: apps/users/views/user.py:178
+#: apps/users/views/user.py:194
+#: apps/users/views/user.py:209
+#: apps/users/views/user.py:222
+#: apps/users/views/user.py:233
+#: apps/users/views/user.py:252
+#: apps/users/views/user.py:268
+#: apps/users/views/user.py:287
+#: apps/users/views/user.py:303
+#: apps/users/views/user.py:324
+#: apps/users/views/user.py:342
+#: apps/users/views/user.py:359
+#: apps/users/views/user.py:377
+msgid "User Management"
+msgstr "用户管理"
+
+#: no source
+msgid "User management"
+msgstr "用户管理"
+
+#: no source
+msgid "user manual url"
+msgstr "用户手册网址"
+
+#: apps/homepage/serializers/homepage.py:218
+#: apps/homepage/serializers/homepage.py:302
 msgid "User Name"
 msgstr "用户名称"
 
-msgid "New chat"
-msgstr "已生成新对话，请重新提问！"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:62
+#: apps/application/flow/step_node/application_node/i_application_node.py:17
+#: apps/application/serializers/application_chat.py:214
+#: apps/chat/serializers/chat.py:75
+msgid "User Questions"
+msgstr "用户问题"
+
+#: apps/users/serializers/user.py:1146
+msgid "User registration"
+msgstr "用户注册"
+
+#: no source
+msgid "User relation does not exist"
+msgstr "用户关系不存在"
+
+#: no source
+msgid "User relation ID"
+msgstr "用户关系 ID"
+
+#: no source
+msgid "User Relation ID"
+msgstr "用户关系 ID"
+
+#: apps/homepage/api/home_page_api.py:213
+msgid "User tokens ranking list"
+msgstr "用户 tokens 消耗排行榜列表"
+
+#: apps/application/serializers/application_chat.py:55
+#: apps/system_manage/api/user_resource_permission.py:118
+msgid "username"
+msgstr ""
+
+#: apps/users/api/login.py:26
+#: apps/users/api/login.py:26
+#: apps/users/api/user.py:77
+#: apps/users/serializers/login.py:32
+#: apps/users/serializers/login.py:32
+#: apps/users/serializers/user.py:65
+#: apps/users/serializers/user.py:173
+#: apps/users/serializers/user.py:236
+msgid "Username"
+msgstr "用户名"
+
+#: apps/users/serializers/user.py:179
+msgid "Username must be 4-64 characters long"
+msgstr "用户名必须为4-64个字符"
+
+#: no source
+msgid "Username or Nickname"
+msgstr "用户名或姓名"
+
+#: apps/system_manage/api/user_resource_permission.py:343
+#: apps/system_manage/serializers/user_resource_permission.py:323
+msgid "users_permission"
+msgstr "用户权限"
+
+#: no source
+msgid "user_group_id"
+msgstr "用户组ID"
+
+#: apps/system_manage/views/valid.py:28
+msgid "Validation"
+msgstr "验证"
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:20
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:21
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:20
+#: apps/models_provider/api/provide.py:24
+msgid "value"
+msgstr "值"
+
+#: apps/models_provider/api/provide.py:37
+msgid "value field"
+msgstr "值"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:36
+msgid "vaporwave"
+msgstr "蒸汽波"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:15
+msgid "Variable"
+msgstr ""
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:13
+msgid "Variable id"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:24
+msgid "Variable Label"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:23
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:24
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:23
+msgid "Variable Name"
+msgstr "变量名称"
+
+#: apps/tools/serializers/tool.py:247
+#: apps/tools/serializers/tool.py:323
+msgid "variable name"
+msgstr "变量名称"
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:25
+msgid "Variable Source"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:26
+msgid "Variable Type"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:24
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:34
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:27
+#: apps/trigger/serializers/trigger.py:51
+msgid "Variable Value"
+msgstr "变量名称"
+
+#: apps/tools/serializers/tool.py:324
+msgid "variable value"
+msgstr "变量名称"
+
+#: apps/common/constants/permission_constants.py:367
+msgid "Vector"
+msgstr "向量化"
+
+#: apps/local_model/serializers/model_apply_serializers.py:95
+#: apps/local_model/serializers/model_apply_serializers.py:100
+#: apps/models_provider/serializers/model_apply_serializers.py:32
+#: apps/models_provider/serializers/model_apply_serializers.py:37
+msgid "vector text"
+msgstr "向量文本"
+
+#: apps/local_model/serializers/model_apply_serializers.py:96
+#: apps/models_provider/serializers/model_apply_serializers.py:33
+msgid "vector text list"
+msgstr "向量文本列表"
+
+#: apps/models_provider/views/model_apply.py:25
+#: apps/models_provider/views/model_apply.py:26
+#: apps/models_provider/views/model_apply.py:27
+#: apps/models_provider/views/model_apply.py:37
+#: apps/models_provider/views/model_apply.py:38
+#: apps/models_provider/views/model_apply.py:39
+msgid "Vectorization documentation"
+msgstr "向量化文档"
+
+#: apps/common/event/listener_manage.py:404
+msgid "Vectorized document: {document_id} error {error} {traceback}"
+msgstr "向量文档: {document_id} 错误：{error} {traceback}"
+
+#: apps/common/event/listener_manage.py:431
+#: apps/knowledge/task/embedding.py:132
+msgid "Vectorized knowledge: {knowledge_id} error {error} {traceback}"
+msgstr "向量知识库: {knowledge_id} 错误：{error} {traceback}"
+
+#: apps/common/event/listener_manage.py:138
+msgid "Vectorized paragraph: {paragraph_id_list} error {error} {traceback}"
+msgstr "向量段落: {paragraph_id_list} 错误：{error} {traceback}"
+
+#: apps/common/event/listener_manage.py:189
+msgid "Vectorized paragraph: {paragraph_id} error {error} {traceback}"
+msgstr "向量段落: {paragraph_id} 错误：{error} {traceback}"
+
+#: apps/users/serializers/user.py:1167
+msgid "Verification code"
+msgstr "验证码"
+
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:43
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:75
+msgid "Verification failed, please check whether the parameters are correct"
+msgstr "认证失败，请检查参数是否正确"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:57
+msgid "Verification failed, please check whether the parameters are correct: %(error)s"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:76
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:94
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:84
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:81
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:51
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:68
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:59
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:76
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:121
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:134
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:97
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:61
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:63
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:40
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:60
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:59
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:64
+#: apps/models_provider/impl/azure_model_provider/credential/stt.py:39
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:74
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:56
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:61
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:63
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:45
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:56
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:61
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:68
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:37
+#: apps/models_provider/impl/gemini_model_provider/credential/tti.py:44
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:71
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:62
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:42
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:54
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:84
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:86
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:51
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:84
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:60
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:61
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:63
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:45
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:56
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:43
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:62
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:63
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:38
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:58
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:29
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:65
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:55
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:76
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:102
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:61
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:53
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:53
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:49
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:61
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:63
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:50
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:61
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:66
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:80
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:53
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:52
+#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:37
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:49
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:82
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:58
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:58
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:82
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:63
+#: apps/models_provider/impl/xf_model_provider/credential/zh_en_stt.py:45
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:60
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:50
+#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:37
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:75
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:55
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:61
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:62
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:57
+msgid "Verification failed, please check whether the parameters are correct: {error}"
+msgstr "认证失败，请检查参数是否正确：{error}"
+
+#: no source
+msgid "Verification Token is required"
+msgstr "验证令牌是必填项"
+
+#: apps/application/serializers/application_version.py:36
+#: apps/knowledge/serializers/knowledge_version.py:24
+#: apps/tools/serializers/tool_version.py:22
+msgid "Version Name"
+msgstr "版本名称"
+
+#: apps/tools/serializers/tool.py:1380
+msgid "versions"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:52
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:28
+msgid "video"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:24
+msgid "Video"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:22
+msgid "Video size"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:25
+msgid "Vietnamese"
+msgstr "越南语"
+
+#: no source
+msgid "View appearance settings"
+msgstr "查看外观设置"
+
+#: apps/common/constants/permission_constants.py:386
+msgid "View related resources"
+msgstr "查看关联资源"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:56
+msgid "vision"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:151
+msgid "Vision Model"
+msgstr "视觉模型"
+
+#: apps/application/serializers/application.py:390
+#: apps/application/serializers/application.py:621
+msgid "Voice playback autoplay"
+msgstr "自动播放语音"
+
+#: apps/application/serializers/application.py:384
+#: apps/application/serializers/application.py:615
+msgid "Voice playback enabled"
+msgstr "开启语音播放"
+
+#: apps/application/serializers/application.py:386
+#: apps/application/serializers/application.py:617
+msgid "Voice playback model ID"
+msgstr "语音播放模型 ID"
+
+#: apps/application/serializers/application.py:388
+#: apps/application/serializers/application.py:619
+msgid "Voice playback type"
+msgstr "语音播放类型"
+
+#: apps/application/serializers/application.py:396
+#: apps/application/serializers/application.py:627
+msgid "Voice recognition automatic transmission"
+msgstr "语音识别自动播放"
+
+#: apps/application/serializers/application.py:392
+#: apps/application/serializers/application.py:623
+msgid "Voice recognition enabled"
+msgstr "开启语音识别"
+
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:16
+msgid "Voice Setting"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:149
+msgid "volcano engine"
+msgstr "火山引擎"
+
+#: apps/chat/serializers/chat_record.py:31
+msgid "Vote other content"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:28
+msgid "Vote Reason"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:58
+msgid "Voting on the current session minutes, please do not send repeated requests"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:55
+msgid "watercolor"
+msgstr "水彩"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:22
+msgid "watercolor painting"
+msgstr "水彩画"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:33
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:36
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:22
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:22
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:49
+msgid "Watermark"
+msgstr "水印"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:24
+msgid "Web knowledge selector"
+msgstr "选择器"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:22
+msgid "Web source url"
+msgstr "Web 根地址"
+
+#: no source
+msgid "WeChat Official Account: {account}"
+msgstr "微信公众账号: {account}"
+
+#: apps/application/serializers/application_chat.py:291
+msgid "WeChat Public Account"
+msgstr "微信公众号"
+
+#: no source
+msgid "wecom"
+msgstr "企业微信"
+
+#: no source
+msgid "WeCom callback"
+msgstr "企业微信回调"
+
+#: no source
+msgid "WeCom configuration not found or not active"
+msgstr "企业微信配置未找到或未激活"
+
+#: no source
+msgid "WeCom OAuth2 callback"
+msgstr "企业微信 OAuth2 回调"
+
+#: apps/common/constants/permission_constants.py:381
+msgid "Weixin Public Account"
+msgstr ""
+
+#: no source
+msgid "Welcome to subscribe"
+msgstr "欢迎订阅"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:33
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:36
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:22
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:22
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:49
+msgid "Whether to add watermark"
+msgstr "是否添加水印"
+
+#: apps/application/serializers/application_access_token.py:36
+msgid "Whether to display knowledge sources"
+msgstr "是否展示知识来源"
+
+#: no source
+msgid "Whether to enable MCP"
+msgstr "是否启用 MCP"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:50
+msgid "Whether to enable MCP output"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:36
+msgid "Whether to enable SSL"
+msgstr "是否启用 SSL"
+
+#: apps/system_manage/serializers/email_setting.py:35
+msgid "Whether to enable TLS"
+msgstr "是否启用 TLS"
+
+#: apps/application/serializers/application_access_token.py:31
+msgid "Whether to enable whitelist"
+msgstr "是否启用白名单"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:30
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:26
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:29
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:30
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:27
+#: apps/application/flow/step_node/question_node/i_question_node.py:31
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:18
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:19
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:29
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:31
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:48
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:34
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:26
+msgid "Whether to return content"
+msgstr "是否返回内容"
+
+#: apps/application/serializers/application_access_token.py:33
+#: apps/application/serializers/application_access_token.py:34
+msgid "Whitelist"
+msgstr "白名单"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:62
+msgid "with filter"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:68
+msgid "with filter reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:65
+msgid "with filter type"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:71
+msgid "With the GTE-Rerank text sorting series model developed by Alibaba Tongyi Lab, developers can integrate high-quality text retrieval and sorting through the LlamaIndex framework."
+msgstr "阿里巴巴通义实验室开发的GTE-Rerank文本排序系列模型，开发者可以通过LlamaIndex框架进行集成高质量文本检索、排序。"
+
+#: apps/common/constants/permission_constants.py:357
+#: apps/common/constants/permission_constants.py:415
+#: apps/common/constants/permission_constants.py:425
+msgid "Workflow"
+msgstr "工作流"
+
+#: apps/application/api/application_api.py:23
+#: apps/application/serializers/application.py:298
+msgid "Workflow Objects"
+msgstr "工作流对象"
+
+#: apps/application/serializers/application_version.py:91
+#: apps/application/serializers/application_version.py:107
+#: apps/knowledge/serializers/knowledge_version.py:105
+#: apps/knowledge/serializers/knowledge_version.py:123
+#: apps/tools/serializers/tool_version.py:91
+#: apps/tools/serializers/tool_version.py:107
+msgid "Workflow version does not exist"
+msgstr "工作流版本不存在"
+
+#: no source
+msgid "Workflow version id"
+msgstr "工作流版本 ID"
+
+#: apps/common/constants/permission_constants.py:328
+#: apps/common/constants/permission_constants.py:432
+msgid "Workspace"
+msgstr "工作空间"
+
+#: no source
+msgid "Workspace does not exist"
+msgstr "工作空间不存在"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:79
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:47
+#: apps/application/serializers/application.py:474
+#: apps/application/serializers/application.py:995
+#: apps/application/serializers/application.py:1675
+#: apps/application/serializers/application_access_token.py:48
+#: apps/application/serializers/application_api_key.py:37
+#: apps/application/serializers/application_api_key.py:74
+#: apps/application/serializers/application_chat.py:53
+#: apps/application/serializers/application_chat_record.py:46
+#: apps/application/serializers/application_chat_record.py:91
+#: apps/application/serializers/application_chat_record.py:199
+#: apps/application/serializers/application_chat_record.py:248
+#: apps/application/serializers/application_chat_record.py:381
+#: apps/application/serializers/application_chat_record.py:482
+#: apps/application/serializers/application_stats.py:38
+#: apps/application/serializers/application_version.py:40
+#: apps/application/serializers/application_version.py:43
+#: apps/application/serializers/application_version.py:68
+#: apps/chat/serializers/chat.py:155
+#: apps/chat/serializers/chat.py:532
+#: apps/homepage/api/home_page_api.py:71
+#: apps/homepage/api/home_page_api.py:122
+#: apps/homepage/api/home_page_api.py:263
+#: apps/homepage/api/home_page_api.py:277
+#: apps/homepage/api/home_page_api.py:326
+#: apps/homepage/api/home_page_api.py:363
+#: apps/homepage/api/home_page_api.py:400
+#: apps/homepage/serializers/homepage.py:89
+#: apps/homepage/serializers/homepage.py:150
+#: apps/homepage/serializers/homepage.py:215
+#: apps/homepage/serializers/homepage.py:387
+#: apps/homepage/serializers/homepage.py:514
+#: apps/homepage/serializers/homepage.py:654
+#: apps/homepage/serializers/homepage.py:736
+#: apps/homepage/serializers/homepage.py:777
+#: apps/homepage/serializers/homepage.py:826
+#: apps/homepage/serializers/homepage.py:873
+#: apps/knowledge/serializers/knowledge.py:1471
+#: apps/knowledge/serializers/knowledge_version.py:50
+#: apps/knowledge/serializers/knowledge_version.py:53
+#: apps/knowledge/serializers/knowledge_version.py:81
+#: apps/knowledge/serializers/knowledge_workflow.py:648
+#: apps/knowledge/serializers/tag.py:46
+#: apps/knowledge/serializers/tag.py:93
+#: apps/knowledge/serializers/tag.py:167
+#: apps/knowledge/serializers/tag.py:201
+#: apps/tools/serializers/tool.py:1569
+#: apps/tools/serializers/tool_version.py:40
+#: apps/tools/serializers/tool_version.py:43
+#: apps/tools/serializers/tool_version.py:68
+#: apps/tools/serializers/tool_workflow.py:378
+#: apps/trigger/serializers/trigger_task.py:43
+#: apps/trigger/serializers/trigger_task.py:67
+#: apps/trigger/serializers/trigger_task.py:127
+#: apps/users/api/user.py:64
+#: apps/users/api/user.py:170
+msgid "Workspace ID"
+msgstr "工作空间 ID"
+
+#: apps/application/serializers/application.py:631
+#: apps/folders/serializers/folder.py:130
+#: apps/folders/serializers/folder.py:134
+#: apps/folders/serializers/folder.py:177
+#: apps/folders/serializers/folder.py:306
+#: apps/knowledge/serializers/document.py:354
+#: apps/knowledge/serializers/document.py:472
+#: apps/knowledge/serializers/document.py:586
+#: apps/knowledge/serializers/document.py:684
+#: apps/knowledge/serializers/document.py:1001
+#: apps/knowledge/serializers/document.py:1206
+#: apps/knowledge/serializers/document.py:1292
+#: apps/knowledge/serializers/document.py:1314
+#: apps/knowledge/serializers/document.py:1651
+#: apps/knowledge/serializers/document.py:1697
+#: apps/knowledge/serializers/document.py:1772
+#: apps/knowledge/serializers/document.py:1813
+#: apps/knowledge/serializers/document.py:1842
+#: apps/knowledge/serializers/document.py:1878
+#: apps/knowledge/serializers/knowledge.py:315
+#: apps/knowledge/serializers/knowledge.py:884
+#: apps/knowledge/serializers/knowledge.py:1135
+#: apps/knowledge/serializers/knowledge.py:1255
+#: apps/knowledge/serializers/knowledge.py:1359
+#: apps/knowledge/serializers/knowledge.py:1502
+#: apps/knowledge/serializers/knowledge.py:1558
+#: apps/knowledge/serializers/knowledge_workflow.py:113
+#: apps/knowledge/serializers/knowledge_workflow.py:265
+#: apps/knowledge/serializers/knowledge_workflow.py:318
+#: apps/knowledge/serializers/knowledge_workflow.py:390
+#: apps/knowledge/serializers/knowledge_workflow.py:517
+#: apps/knowledge/serializers/knowledge_workflow.py:567
+#: apps/knowledge/serializers/paragraph.py:107
+#: apps/knowledge/serializers/paragraph.py:200
+#: apps/knowledge/serializers/paragraph.py:436
+#: apps/knowledge/serializers/paragraph.py:472
+#: apps/knowledge/serializers/paragraph.py:552
+#: apps/knowledge/serializers/paragraph.py:601
+#: apps/knowledge/serializers/paragraph.py:778
+#: apps/knowledge/serializers/problem.py:63
+#: apps/knowledge/serializers/problem.py:137
+#: apps/knowledge/serializers/problem.py:197
+#: apps/knowledge/serializers/problem.py:234
+#: apps/knowledge/serializers/termbase.py:35
+#: apps/knowledge/serializers/termbase.py:65
+#: apps/knowledge/serializers/termbase.py:103
+#: apps/knowledge/serializers/termbase.py:139
+#: apps/models_provider/api/model.py:30
+#: apps/models_provider/api/model.py:86
+#: apps/models_provider/api/model.py:99
+#: apps/models_provider/serializers/model_serializer.py:130
+#: apps/models_provider/serializers/model_serializer.py:255
+#: apps/models_provider/serializers/model_serializer.py:291
+#: apps/models_provider/serializers/model_serializer.py:364
+#: apps/models_provider/serializers/model_serializer.py:482
+#: apps/models_provider/serializers/model_serializer.py:541
+#: apps/system_manage/serializers/user_resource_permission.py:108
+#: apps/system_manage/serializers/user_resource_permission.py:298
+#: apps/system_manage/serializers/user_resource_permission.py:299
+#: apps/system_manage/serializers/user_resource_permission.py:306
+#: apps/system_manage/serializers/user_resource_permission.py:320
+#: apps/tools/serializers/tool.py:341
+#: apps/tools/serializers/tool.py:465
+#: apps/tools/serializers/tool.py:550
+#: apps/tools/serializers/tool.py:564
+#: apps/tools/serializers/tool.py:620
+#: apps/tools/serializers/tool.py:910
+#: apps/tools/serializers/tool.py:1151
+#: apps/tools/serializers/tool.py:1210
+#: apps/tools/serializers/tool.py:1308
+#: apps/tools/serializers/tool.py:1375
+#: apps/tools/serializers/tool.py:1425
+#: apps/tools/serializers/tool.py:1435
+#: apps/tools/serializers/tool.py:1531
+#: apps/tools/serializers/tool.py:1545
+#: apps/tools/serializers/tool.py:1628
+#: apps/tools/serializers/tool.py:1686
+#: apps/tools/serializers/tool_workflow.py:145
+#: apps/trigger/serializers/task_source_trigger.py:39
+#: apps/trigger/serializers/task_source_trigger.py:61
+#: apps/trigger/serializers/task_source_trigger.py:182
+#: apps/trigger/serializers/trigger.py:347
+#: apps/trigger/serializers/trigger.py:451
+#: apps/trigger/serializers/trigger.py:503
+#: apps/trigger/serializers/trigger.py:644
+msgid "workspace id"
+msgstr "工作空间ID"
+
+#: no source
+msgid "workspace id list"
+msgstr "工作空间ID"
+
+#: apps/users/api/user.py:30
+msgid "Workspace IDs"
+msgstr "工作空间 ID"
+
+#: no source
+msgid "Workspace Name"
+msgstr "工作空间"
+
+#: no source
+msgid "Workspace name already exists"
+msgstr "工作空间名称已存在"
+
+#: no source
+msgid "Workspace Role"
+msgstr "工作空间角色"
+
+#: no source
+msgid "Workspace/Chat user"
+msgstr "工作空间/对话用户"
+
+#: no source
+msgid "Workspace/User Group"
+msgstr "工作空间/用户组"
+
+#: no source
+msgid "workspace_id"
+msgstr "工作空间ID"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:33
+#: apps/system_manage/serializers/resource_mapping_serializers.py:115
+msgid "workspace_ids"
+msgstr ""
+
+#: no source
+msgid "WORKSPACE_MANAGE"
+msgstr "空间管理员"
+
+#: apps/application/serializers/application.py:1157
+msgid "work_flow is a required field"
+msgstr "工作流是必填字段"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:47
+msgid "World"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:42
+msgid "You can request 1 image at a time (requesting more images by making parallel requests), or up to 10 images at a time using the n parameter."
+msgstr "您可以一次请求 1 个图像（通过发出并行请求来请求更多图像），或者使用 n 参数一次最多请求 10 个图像。"
+
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:43
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:43
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:43
+msgid "You can use DALL·E 3 to request 1 image at a time (requesting more images by issuing parallel requests), or use DALL·E 2 with the n parameter to request up to 10 images at a time."
+msgstr "您可以使用 DALL·E 3 一次请求 1 个图像（通过发出并行请求来请求更多图像），或者使用带有 n 参数的 DALL·E 2 一次最多请求 10 个图像。"
+
+#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:75
+msgid "zhipu AI"
+msgstr "智谱 AI"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:30
+msgid "[0.2,3], the default is 1, usually one decimal place is enough"
+msgstr "[0.2,3]，默认为1，通常保留一位小数即可"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:37
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:68
+msgid "[0.5, 2], the default is 1, usually one decimal place is enough"
+msgstr "[0.5,2]，默认为1，通常一位小数就足够了"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:61
+msgid "[Legacy] gpt-3.5-turbo snapshot on June 13, 2023, will be deprecated on June 13, 2024"
+msgstr "[Legacy] 2023年6月13日的gpt-3.5-turbo快照，将于2024年6月13日弃用"
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:33
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:38
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:40
+msgid "{field}, this field is required."
+msgstr "{field_label} 字段是必填项"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:40
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:61
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:87
+msgid "{keys} is required"
+msgstr "{keys} 是必填项"
+
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:47
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:31
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:50
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:63
+#: apps/models_provider/impl/azure_model_provider/credential/stt.py:27
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:62
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:45
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:49
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:49
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:42
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:33
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:44
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:47
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:25
+#: apps/models_provider/impl/gemini_model_provider/credential/tti.py:32
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:30
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:42
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:45
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:46
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:62
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:73
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:49
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:49
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:33
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:44
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:31
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:50
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:49
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:42
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:26
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:46
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:51
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:47
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:39
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:57
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:37
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:47
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:38
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:50
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:55
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:69
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:41
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:61
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:86
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:92
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:38
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:33
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:70
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:46
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:51
+#: apps/models_provider/impl/xf_model_provider/credential/zh_en_stt.py:33
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:40
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:47
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:59
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:39
+#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:26
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:64
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:44
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:47
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:45
+msgid "{key}  is required"
+msgstr "{key} 是必填项"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:62
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:80
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:66
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:67
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:37
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:54
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:45
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:62
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:107
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:120
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:83
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:55
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:57
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:70
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:72
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:70
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:46
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:71
+msgid "{key} is required"
+msgstr "{key} 是必填项"
+
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:33
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:53
+msgid "{model_name} The model does not support"
+msgstr "{model_name} 模型不支持"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:54
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:71
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:58
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:28
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:45
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:36
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:53
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:98
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:111
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:74
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:42
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:20
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:40
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:39
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:45
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/azure_model_provider/credential/stt.py:22
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:57
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:40
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:44
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:44
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:38
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:28
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:42
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:48
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:20
+#: apps/models_provider/impl/gemini_model_provider/credential/tti.py:27
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:48
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:26
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:38
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:61
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:40
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:63
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:34
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:61
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:39
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:44
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:37
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:41
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:44
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:44
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:28
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:45
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:44
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:38
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:21
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:41
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:18
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:47
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:51
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:42
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:38
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:34
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:39
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:32
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:42
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:33
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:45
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:50
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:64
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:29
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:49
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:33
+#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:28
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:41
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:39
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:64
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:46
+#: apps/models_provider/impl/xf_model_provider/credential/zh_en_stt.py:28
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:19
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:42
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:39
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:35
+#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:21
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:59
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:42
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:40
+msgid "{model_type} Model type is not supported"
+msgstr "{model_type} 模型类型不支持"
+
+#: apps/application/flow/common.py:230
+msgid "{node} Nodes cannot be considered as end nodes"
+msgstr "{node} 节点不能被视为结束节点"
+
+#: apps/users/serializers/user.py:1145
+msgid "【Intelligent knowledge base question and answer system-{action}】"
+msgstr "【智能知识库问答系统-{action}】"

--- a/apps/locales/zh_CN/LC_MESSAGES/django.po
+++ b/apps/locales/zh_CN/LC_MESSAGES/django.po
@@ -661,7 +661,7 @@ msgstr "字段仅支持自定义|引用"
 
 #: apps/application/flow/step_node/function_node/i_function_node.py:40
 msgid "{field}, this field is required."
-msgstr "{field_label} 字段是必填项"
+msgstr "{field} 字段是必填项"
 
 #: apps/application/flow/step_node/function_node/i_function_node.py:46
 msgid "function"
@@ -4328,7 +4328,7 @@ msgstr ""
 #: apps/models_provider/impl/openai_model_provider/credential/tti.py:29
 #: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:29
 msgid ""
-"       \n"
+"\n"
 "By default, images are produced in standard quality, but with DALL·E 3 you "
 "can set quality: \"hd\" to enhance detail. Square, standard quality images "
 "are generated fastest.\n"
@@ -4896,7 +4896,7 @@ msgstr "Code Llama 是一个专门用于代码生成的语言模型。"
 
 #: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:44
 msgid ""
-"       \n"
+"\n"
 "Code Llama Instruct is a fine-tuned version of Code Llama's instructions, "
 "designed to perform specific tasks.\n"
 "        "

--- a/apps/locales/zh_Hant/LC_MESSAGES/django.po
+++ b/apps/locales/zh_Hant/LC_MESSAGES/django.po
@@ -661,7 +661,7 @@ msgstr "欄位僅支持自定義|引用"
 
 #: apps/application/flow/step_node/function_node/i_function_node.py:40
 msgid "{field}, this field is required."
-msgstr "{field_label} 欄位是必填項"
+msgstr "{field} 欄位是必填項"
 
 #: apps/application/flow/step_node/function_node/i_function_node.py:46
 msgid "function"
@@ -4328,7 +4328,7 @@ msgstr ""
 #: apps/models_provider/impl/openai_model_provider/credential/tti.py:29
 #: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:29
 msgid ""
-"       \n"
+"\n"
 "By default, images are produced in standard quality, but with DALL·E 3 you "
 "can set quality: \"hd\" to enhance detail. Square, standard quality images "
 "are generated fastest.\n"
@@ -4896,7 +4896,7 @@ msgstr "Code Llama 是一個專門用於代碼生成的語言模型。"
 
 #: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:44
 msgid ""
-"       \n"
+"\n"
 "Code Llama Instruct is a fine-tuned version of Code Llama's instructions, "
 "designed to perform specific tasks.\n"
 "        "
@@ -8628,6 +8628,9 @@ msgstr "API KEY"
 
 msgid "Download"
 msgstr "下載"
+
+msgid "User"
+msgstr "用戶"
 
 msgid "Delete personal system API_KEY"
 msgstr "删除個人系統API KEY"

--- a/apps/locales/zh_Hant/LC_MESSAGES/django.po
+++ b/apps/locales/zh_Hant/LC_MESSAGES/django.po
@@ -16,4850 +16,1422 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: apps/application/api/application_api.py:21
-#: apps/application/serializers/application.py:153
-msgid "Workflow Objects"
-msgstr "工作流對象"
 
-#: apps/application/api/application_api.py:52
-#: apps/application/api/application_chat.py:104
-#: apps/application/api/application_chat_record.py:74
-#: apps/role_setting/api/role_setting.py:171 apps/shared/api/shared_tool.py:79
-#: apps/shared/api/shared_tool.py:119 apps/workspace/api/workspace.py:110
-#: apps/xpack/api/user_group.py:61
-msgid "Current page"
-msgstr "當前頁"
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:39
+msgid "%(key)s is required"
+msgstr ""
 
-#: apps/application/api/application_api.py:59
-#: apps/application/api/application_chat.py:111
-#: apps/application/api/application_chat_record.py:81
-#: apps/role_setting/api/role_setting.py:178 apps/shared/api/shared_tool.py:86
-#: apps/shared/api/shared_tool.py:126 apps/workspace/api/workspace.py:117
-#: apps/xpack/api/user_group.py:68
-msgid "Page size"
-msgstr "每頁大小"
+#: apps/trigger/serializers/trigger.py:446
+msgid "%s id does not exist"
+msgstr "%s id 不存在"
 
-#: apps/application/api/application_api.py:66
-#: apps/application/serializers/application.py:156
-#: apps/application/serializers/application.py:195
-#: apps/application/serializers/application.py:274
-#: apps/folders/serializers/folder.py:97 apps/folders/serializers/folder.py:139
-#: apps/knowledge/serializers/knowledge.py:52
-#: apps/knowledge/serializers/knowledge.py:59
-#: apps/tools/serializers/tool.py:453
-#: apps/xpack/serializers/dataset_lark_serializer.py:55
-msgid "folder id"
-msgstr "文件夾 ID"
+#: apps/knowledge/serializers/knowledge.py:324
+msgid "%s must be a boolean"
+msgstr ""
 
-#: apps/application/api/application_api.py:73
-#: apps/application/serializers/application.py:149
-#: apps/application/serializers/application.py:275
-#: apps/application/serializers/application.py:282
-#: apps/application/serializers/application.py:368
-#| msgid "Application"
-msgid "Application Name"
-msgstr "智能體名稱"
+#: apps/trigger/serializers/trigger.py:69
+#: apps/trigger/serializers/trigger.py:92
+msgid "%s must be a dict"
+msgstr "%s 必須是字典類型"
 
-#: apps/application/api/application_api.py:80
-#: apps/application/serializers/application.py:152
-#: apps/application/serializers/application.py:276
-#: apps/application/serializers/application.py:283
-#: apps/application/serializers/application.py:284
-#: apps/application/serializers/application.py:370
-#| msgid "Application/Version"
-msgid "Application Description"
-msgstr "智能體描述"
+#: apps/trigger/serializers/trigger.py:132
+msgid "%s must be an array"
+msgstr "%s 必須是陣列類型"
 
-#: apps/application/api/application_api.py:87
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:78
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:30
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:47
-#: apps/application/serializers/application.py:99
-#: apps/application/serializers/application.py:277
-#: apps/application/serializers/application.py:295
-#: apps/application/serializers/application.py:413
-#: apps/application/serializers/application.py:540
-#: apps/role_setting/api/role_setting.py:144 apps/tools/serializers/tool.py:357
-#: apps/tools/serializers/tool.py:390 apps/users/api/user.py:52
-#: apps/users/api/user.py:110 apps/users/api/user.py:126
-#: apps/users/serializers/user.py:325 apps/workspace/api/workspace.py:82
-#: apps/workspace/serializers/workspace_serializers.py:270
-#: apps/workspace/serializers/workspace_serializers.py:306
-#: apps/xpack/api/chat_user.py:49 apps/xpack/api/chat_user.py:92
-#: apps/xpack/serializers/chat_user.py:301
-msgid "User ID"
-msgstr "用戶 ID"
+#: apps/trigger/serializers/trigger.py:135
+msgid "%s must not be empty"
+msgstr "%s 不能為空"
 
-#: apps/application/api/application_chat.py:70
-#: apps/application/serializers/application_chat.py:56
-msgid "Minimum number of likes"
-msgstr "最小點讚數"
+#: apps/trigger/serializers/trigger.py:125
+msgid "%s type requires %s field"
+msgstr "%s 類型需要 %s 欄位"
 
-#: apps/application/api/application_chat.py:76
-#: apps/application/serializers/application_chat.py:58
-msgid "Minimum number of clicks"
-msgstr "最小點擊數"
+#: apps/trigger/serializers/trigger.py:146
+msgid "%s values must be between %s and %s"
+msgstr "%s 的值必須在 %s 到 %s 之間"
 
-#: apps/application/api/application_chat.py:82
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:18
-#: apps/application/serializers/application_chat.py:59
-msgid "Comparator"
-msgstr "比較器"
-
-#: apps/application/api/application_chat_record.py:46
-#: apps/application/api/application_chat_record.py:115
-#: apps/application/serializers/application_chat.py:47
-#: apps/application/serializers/application_chat_record.py:76
-#| msgid "Chat"
-msgid "Chat ID"
-msgstr "對話 ID"
-
-#: apps/application/api/application_chat_record.py:53
-#: apps/application/serializers/application_chat_record.py:77
-msgid "Is it in order"
-msgstr "是否有序"
-
-#: apps/application/api/application_chat_record.py:122
-msgid "Chat Record ID"
-msgstr "對話記錄 ID"
-
-#: apps/application/api/application_chat_record.py:129
-#: apps/shared/api/shared_knowledge.py:235
-#: apps/shared/api/shared_knowledge.py:256 apps/xpack/api/knowledge_lark.py:47
-#: apps/xpack/api/knowledge_lark.py:79 apps/xpack/api/knowledge_lark.py:111
-#| msgid "Knowledge"
-msgid "Knowledge ID"
-msgstr "知識庫 ID"
-
-#: apps/application/api/application_chat_record.py:136
-#: apps/shared/api/shared_knowledge.py:263 apps/xpack/api/knowledge_lark.py:86
-#| msgid "Document"
-msgid "Document ID"
-msgstr "文檔 ID"
-
-#: apps/application/api/application_chat_record.py:148
-#| msgid "Paragraph list"
-msgid "Paragraph ID"
-msgstr "段落 ID"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:26
-#| msgid "type error"
-msgid "Model type error"
-msgstr "模型類型錯誤"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:36
-#: apps/common/field/common.py:24 apps/common/field/common.py:37
-#| msgid "type error"
-msgid "Message type error"
-msgstr "消息類型錯誤"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:55
-#| msgid "Question list"
-msgid "Conversation list"
-msgstr "對話列表"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:56
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:29
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:18
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:12
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:13
-#: apps/application/flow/step_node/question_node/i_question_node.py:18
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:12
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:13
-#: apps/application/serializers/application.py:101
-#: apps/application/serializers/application.py:285
-#: apps/knowledge/serializers/common.py:71 apps/shared/api/shared_model.py:76
-#: apps/shared/api/shared_model.py:98
-msgid "Model id"
-msgstr "模型ID"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:58
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:29
-#| msgid "Paragraph list"
-msgid "Paragraph List"
-msgstr "段落列表"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:60
-#: apps/application/serializers/application_chat.py:182
-#: apps/application/serializers/application_chat_record.py:41
-#: apps/application/serializers/application_chat_record.py:140
-#: apps/application/serializers/application_chat_record.py:179
-#: apps/application/serializers/application_chat_record.py:247
-#: apps/application/serializers/application_chat_record.py:312
-#: apps/chat/serializers/chat.py:98 apps/chat/serializers/chat.py:114
-#| msgid "User relation ID"
-msgid "Conversation ID"
-msgstr "對話 ID"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:62
-#: apps/application/flow/step_node/application_node/i_application_node.py:14
-#: apps/application/serializers/application_chat.py:182
-#: apps/chat/serializers/chat.py:40
-#| msgid "Question list"
-msgid "User Questions"
-msgstr "用戶問題"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:65
-msgid "Post-processor"
-msgstr "後置處理器"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:68
-#| msgid "Create question"
-msgid "Completion Question"
-msgstr "完成問題"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:70
-msgid "Streaming Output"
-msgstr "流式輸出"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:71
-#: apps/xpack/serializers/resource_chat_user.py:93
-#| msgid "user id"
-msgid "Chat user id"
-msgstr "對話用戶 ID"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:73
-#| msgid "Create user"
-msgid "Chat user Type"
-msgstr "對話用戶類型"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:76
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:47
-msgid "No reference segment settings"
-msgstr "無參考段設置"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:81
-msgid "Model settings"
-msgstr "模型設置"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:84
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:29
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:29
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:28
-#: apps/application/flow/step_node/question_node/i_question_node.py:29
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:20
-msgid "Model parameter settings"
-msgstr "模型參數設置"
-
-#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:91
-msgid "message type error"
-msgstr "消息類型錯誤"
-
-#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:224
-#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:270
-msgid ""
-"Sorry, the AI model is not configured. Please go to the application to set "
-"up the AI model first."
-msgstr "抱歉，AI 模型未配置，請先前往智能體設置 AI 模型。"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:26
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:24
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:24
-#: apps/application/serializers/application_chat_record.py:172
-msgid "question"
-msgstr "問題"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:32
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:27
-msgid "History Questions"
-msgstr "歷史問題"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:34
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:23
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:20
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:18
-#: apps/application/flow/step_node/question_node/i_question_node.py:24
-msgid "Number of multi-round conversations"
-msgstr "多輪對話的數量"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:37
-msgid "Maximum length of the knowledge base paragraph"
-msgstr "知識庫段落的最大長度"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:39
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:21
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:16
-#: apps/application/flow/step_node/question_node/i_question_node.py:21
-#: apps/application/serializers/application.py:79
-#: apps/application/serializers/application.py:124
-#: apps/knowledge/serializers/common.py:72
-msgid "Prompt word"
-msgstr "提示詞"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:41
-msgid "System prompt words (role)"
-msgstr "系統提示詞（角色）"
-
-#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:44
-msgid "Completion problem"
-msgstr "完成問題"
-
-#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:32
-#: apps/application/serializers/application.py:215
-msgid "Question completion prompt"
-msgstr "問題完成提示"
-
-#: apps/application/chat_pipeline/step/reset_problem_step/impl/base_reset_problem_step.py:20
-#: apps/application/serializers/common.py:87
-#, python-brace-format
-msgid ""
-"() contains the user's question. Answer the guessed user's question based on "
-"the context ({question}) Requirement: Output a complete question and put it "
-"in the <data></data> tag"
+#: apps/application/chat_pipeline/step/reset_problem_step/impl/base_reset_problem_step.py:19
+#: apps/application/serializers/common.py:233
+msgid "() contains the user's question. Answer the guessed user's question based on the context ({question}) Requirement: Output a complete question and put it in the <data></data> tag"
 msgstr " () 包含用戶的問題。根據上下文（{question}）要求：輸出一個完整的問題並提出在<data></data>標籤中"
 
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:27
-msgid "System completes question text"
-msgstr "系統完成問題文本"
+#: no source
+msgid "\n ------------\n[To be continued, reply \"Continue to answer the question]"
+msgstr "\n------------\n[待續，回復 \"繼續回答問題]"
 
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:30
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:39
-msgid "Dataset id list"
-msgstr "知識庫 ID 列表"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:33
-msgid "List of document ids to exclude"
-msgstr "排除的文檔 ID 列表"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:36
-msgid "List of exclusion vector ids"
-msgstr "排除的向量 ID 列表"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:39
-#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:21
-#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:24
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:24
-#: apps/application/serializers/application.py:84
-#: apps/application/serializers/application_chat.py:185
-msgid "Reference segment number"
-msgstr "引用分段數"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:42
-msgid "Similarity"
-msgstr "相似度"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:45
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:30
-#: apps/application/serializers/application.py:91
-#: apps/knowledge/serializers/knowledge.py:100
-#: apps/knowledge/serializers/knowledge.py:643
-msgid "The type only supports embedding|keywords|blend"
-msgstr "類型僅支持嵌入|關鍵字|混合"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:46
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:31
-#: apps/application/serializers/application.py:92
-msgid "Retrieval Mode"
-msgstr "檢索模式"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:31
-#: apps/application/serializers/application.py:113
-#: apps/application/serializers/application.py:657
-#: apps/application/serializers/application.py:664
-#: apps/application/serializers/application.py:671
-#: apps/knowledge/serializers/document.py:643
-#: apps/knowledge/serializers/knowledge.py:220
-#: apps/models_provider/serializers/model_serializer.py:116
-#: apps/models_provider/serializers/model_serializer.py:134
-#: apps/models_provider/serializers/model_serializer.py:370
-#: apps/models_provider/tools.py:111 apps/shared/serializers/shared_model.py:32
-#: apps/shared/serializers/shared_model.py:65
-#: apps/shared/serializers/shared_model.py:82
-msgid "Model does not exist"
-msgstr "模型不存在"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:33
-msgid "No permission to use this model {model_name}"
-msgstr "無權限使用此模型{model_name}"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:42
-msgid ""
-"The vector model of the associated knowledge base is inconsistent and the "
-"segmentation cannot be recalled."
-msgstr "關聯的知識庫的向量模型不一致，無法回調分段。"
-
-#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:44
-msgid "The knowledge base setting is wrong, please reset the knowledge base"
-msgstr "知識庫設置錯誤，請重置知識庫"
-
-#: apps/application/flow/common.py:206
-#, python-brace-format
-msgid "The branch {branch} of the {node} node needs to be connected"
-msgstr "需要連接 {node} 節點的 {branch} 分支"
-
-#: apps/application/flow/common.py:212
-#, python-brace-format
-msgid "{node} Nodes cannot be considered as end nodes"
-msgstr "{node} 節點不能被視為結束節點"
-
-#: apps/application/flow/common.py:226
-msgid "The starting node is required"
-msgstr "開始節點是必需的"
-
-#: apps/application/flow/common.py:228
-msgid "There can only be one starting node"
-msgstr "只能有一個開始節點"
-
-#: apps/application/flow/common.py:236
-msgid "The node {node} model does not exist"
-msgstr "節點 {node} 模型不存在"
-
-#: apps/application/flow/common.py:246
-#, python-brace-format
-msgid "Node {node} is unavailable"
-msgstr "節點 {node} 不可用"
-
-#: apps/application/flow/common.py:252
-#, python-brace-format
-msgid "The library ID of node {node} cannot be empty"
-msgstr "工具庫 ID {node} 不能為空"
-
-#: apps/application/flow/common.py:255
-#, python-brace-format
-msgid "The function library for node {node} is not available"
-msgstr "工具庫 {node} 不可用"
-
-#: apps/application/flow/common.py:261
-msgid "Basic information node is required"
-msgstr "基本信息節點是必需的"
-
-#: apps/application/flow/common.py:263
-msgid "There can only be one basic information node"
-msgstr "只能有一個基本信息節點"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:20
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:15
-#: apps/application/flow/step_node/question_node/i_question_node.py:20
-#: apps/users/api/user.py:35 apps/users/api/user.py:102
-msgid "Role Setting"
-msgstr "角色設置"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:26
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:25
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:30
-#: apps/application/flow/step_node/function_node/i_function_node.py:48
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:26
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:23
-#: apps/application/flow/step_node/question_node/i_question_node.py:27
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:15
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:16
-msgid "Whether to return content"
-msgstr "是否返回內容"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:33
-msgid "Context Type"
-msgstr "上下文類型"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:35
-msgid "Whether to enable MCP"
-msgstr "是否啟用 MCP"
-
-#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:36
-msgid "MCP Server"
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:43
+msgid "1 as default"
 msgstr ""
 
-#: apps/application/flow/step_node/application_node/i_application_node.py:12
-#: apps/application/serializers/application.py:539
-#: apps/application/serializers/application_access_token.py:44
-#: apps/application/serializers/application_chat.py:38
-#: apps/application/serializers/application_chat.py:54
-#: apps/application/serializers/application_chat_record.py:43
-#: apps/application/serializers/application_chat_record.py:75
-#: apps/application/serializers/application_stats.py:35
-#: apps/application/serializers/application_version.py:21
-#: apps/application/serializers/application_version.py:67
-#: apps/chat/serializers/chat.py:118
-#: apps/chat/serializers/chat_authentication.py:80
-#: apps/xpack/api/application_setting.py:31 apps/xpack/api/platform.py:29
-#: apps/xpack/api/platform.py:70
-msgid "Application ID"
-msgstr "智能體 ID"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:15
-msgid "API Input Fields"
-msgstr "API 輸入欄位"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:17
-msgid "User Input Fields"
-msgstr "用戶輸入欄位"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:18
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:25
-#: apps/chat/serializers/chat.py:57 apps/tools/serializers/tool.py:391
-msgid "picture"
-msgstr "圖片"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:19
-#: apps/application/flow/step_node/document_extract_node/i_document_extract_node.py:12
-#: apps/chat/serializers/chat.py:58
-msgid "document"
-msgstr "文檔"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:20
-#: apps/chat/serializers/chat.py:59
-msgid "Audio"
-msgstr "音頻"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:22
-#: apps/chat/serializers/chat.py:62
-msgid "Child Nodes"
-msgstr "子節點"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:23
-#: apps/application/flow/step_node/form_node/i_form_node.py:21
-msgid "Form Data"
-msgstr "表單數據"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:57
-msgid ""
-"Parameter value error: The uploaded document lacks file_id, and the document "
-"upload fails"
-msgstr "參數值錯誤：上傳的文檔缺少 file_id，文檔上傳失敗"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:66
-msgid ""
-"Parameter value error: The uploaded image lacks file_id, and the image "
-"upload fails"
-msgstr "參數值錯誤：上傳的圖片缺少 file_id，圖片上傳失敗"
-
-#: apps/application/flow/step_node/application_node/i_application_node.py:76
-msgid ""
-"Parameter value error: The uploaded audio lacks file_id, and the audio "
-"upload fails."
-msgstr "參數值錯誤：上傳的音頻缺少 file_id，音頻上傳失敗"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:19
-#: apps/models_provider/api/provide.py:24
-msgid "value"
-msgstr "值"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:20
-msgid "Fields"
-msgstr "欄位"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:24
-msgid "Branch id"
-msgstr "分支 ID"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:25
-msgid "Branch Type"
-msgstr "分支類型"
-
-#: apps/application/flow/step_node/condition_node/i_condition_node.py:26
-msgid "Condition or|and"
-msgstr "條件 或|與"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:20
-msgid "Response Type"
-msgstr "響應類型"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:21
-#: apps/application/flow/step_node/variable_assign_node/i_variable_assign_node.py:13
-msgid "Reference Field"
-msgstr "引用欄位"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:23
-msgid "Direct answer content"
-msgstr "直接回答內容"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:31
-msgid "Reference field cannot be empty"
-msgstr "引用欄位不能為空"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:33
-msgid "Reference field error"
-msgstr "引用欄位錯誤"
-
-#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:36
-msgid "Content cannot be empty"
-msgstr "內容不能為空"
-
-#: apps/application/flow/step_node/form_node/i_form_node.py:19
-msgid "Form Configuration"
-msgstr "表單配置"
-
-#: apps/application/flow/step_node/form_node/i_form_node.py:20
-msgid "Form output content"
-msgstr "表單輸出內容"
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:22
-#: apps/application/flow/step_node/function_node/i_function_node.py:24
-msgid "Variable Name"
-msgstr "變量名稱"
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:23
-#: apps/application/flow/step_node/function_node/i_function_node.py:34
-msgid "Variable Value"
-msgstr "變量名稱"
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:27
-msgid "Library ID"
-msgstr "工具 ID"
-
-#: apps/application/flow/step_node/function_lib_node/i_function_lib_node.py:36
-msgid "The function has been deleted"
-msgstr "工具已被刪除"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:43
-msgid "Field: {name} No value set"
-msgstr "欄位：{name} 未設置值"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:59
-msgid "Field: {name} Type: {_type} Value: {value} Unsupported this type"
-msgstr "欄位：{name} 類型：{_type} 值：{value} 不支持該類型"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:63
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:100
-msgid "Field: {name} Type: {_type} Value: {value} Type error"
-msgstr "欄位：{name} 類型：{_type} 值：{value} 類型轉換錯誤"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:91
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:96
-#: apps/tools/serializers/tool.py:254 apps/tools/serializers/tool.py:259
-msgid "type error"
-msgstr "類型錯誤"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:106
-#: apps/tools/serializers/tool.py:398
-msgid "Function does not exist"
-msgstr "工具不存在"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:108
-msgid "No permission to use this function {name}"
-msgstr "無權限使用此工具 {name}"
-
-#: apps/application/flow/step_node/function_lib_node/impl/base_function_lib_node.py:110
-#, python-brace-format
-msgid "Function {name} is unavailable"
-msgstr "工具 {name} 不可用"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:25
-msgid "Is this field required"
-msgstr "{keys} 是必填項"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:26
-#: apps/knowledge/serializers/document.py:203
-#: apps/tools/serializers/tool.py:120
-msgid "type"
-msgstr "類型"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:28
-msgid "The field only supports string|int|dict|array|float"
-msgstr "欄位僅支持字符串|整數|字典|數組|浮點數"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:30
-#: apps/folders/serializers/folder.py:106
-#: apps/folders/serializers/folder.py:141
-#: apps/folders/serializers/folder.py:196 apps/tools/serializers/tool.py:124
-msgid "source"
-msgstr "來源"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:32
-#: apps/tools/serializers/tool.py:126
-msgid "The field only supports custom|reference"
-msgstr "欄位僅支持自定義|引用"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:40
-msgid "{field}, this field is required."
-msgstr "{field} 欄位是必填項"
-
-#: apps/application/flow/step_node/function_node/i_function_node.py:46
-msgid "function"
-msgstr "工具內容"
-
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:14
-msgid "Prompt word (positive)"
-msgstr "提示詞 (正向)"
-
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:16
-msgid "Prompt word (negative)"
-msgstr "提示詞 (負向)"
-
-#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:23
-#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:20
-msgid "Conversation storage type"
-msgstr "對話存儲類型"
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:13
-msgid "Mcp servers"
-msgstr ""
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:16
-msgid "Mcp server"
-msgstr ""
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:18
-msgid "Mcp tool"
-msgstr "Mcp 工具"
-
-#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:21
-msgid "Tool parameters"
-msgstr "工具參數"
-
-#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:26
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:33
-msgid "Maximum number of words in a quoted segment"
-msgstr "引用段落的最大字數"
-
-#: apps/application/flow/step_node/search_dataset_node/i_search_dataset_node.py:27
-#: apps/knowledge/serializers/knowledge.py:97
-#: apps/knowledge/serializers/knowledge.py:640
-msgid "similarity"
-msgstr "相似度"
-
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:18
-msgid "The audio file cannot be empty"
-msgstr "音頻文件不能為空"
-
-#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:33
-msgid ""
-"Parameter value error: The uploaded audio lacks file_id, and the audio "
-"upload fails"
-msgstr "參數錯誤：上傳的音頻缺少 file_id，音頻上傳失敗"
-
-#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:18
-msgid "Text content"
-msgstr "文本內容"
-
-#: apps/application/models/application_chat.py:79
-#: apps/xpack/serializers/channel/chat_manage.py:94
-#: apps/xpack/serializers/channel/chat_manage.py:152
-msgid ""
-"Sorry, no relevant content was found. Please re-describe your problem or "
-"provide more information. "
-msgstr "不好意思，沒有找到相關內容。請重新描述您的問題或提供更多信息。"
-
-#: apps/application/serializers/application.py:78
-msgid "No reference status"
-msgstr "無參考狀態"
-
-#: apps/application/serializers/application.py:86
-msgid "Acquaintance"
-msgstr "相似度"
-
-#: apps/application/serializers/application.py:88
-msgid "Maximum number of quoted characters"
-msgstr "引用字符的最大數量"
-
-#: apps/application/serializers/application.py:95
-msgid "Segment settings not referenced"
-msgstr "引用段設置未引用"
-
-#: apps/application/serializers/application.py:104
-#: apps/application/serializers/application_chat_record.py:176
-#: apps/application/serializers/application_chat_record.py:252
-#: apps/application/serializers/application_chat_record.py:317
-msgid "Knowledge base id"
-msgstr "知識庫"
-
-#: apps/application/serializers/application.py:105
-msgid "Knowledge Base List"
-msgstr "知識庫列表"
-
-#: apps/application/serializers/application.py:119
-msgid "The knowledge base id does not exist"
-msgstr "知識庫 ID 不存在"
-
-#: apps/application/serializers/application.py:126
-msgid "Role prompts"
-msgstr "角色提示"
-
-#: apps/application/serializers/application.py:128
-msgid "No citation segmentation prompt"
-msgstr "無引用段落提示"
-
-#: apps/application/serializers/application.py:130
-msgid "Thinking process switch"
-msgstr "思考過程開關"
-
-#: apps/application/serializers/application.py:134
-msgid "The thinking process begins to mark"
-msgstr "思考過程開始標記"
-
-#: apps/application/serializers/application.py:138
-msgid "End of thinking process marker"
-msgstr "思考過程結束標記"
-
-#: apps/application/serializers/application.py:155
-#: apps/application/serializers/application.py:203
-#: apps/application/serializers/application.py:378
-msgid "Opening remarks"
-msgstr "開始提示"
-
-#: apps/application/serializers/application.py:191
-msgid "application name"
-msgstr "智能體名稱"
-
-#: apps/application/serializers/application.py:194
-msgid "application describe"
-msgstr "智能體描述"
-
-#: apps/application/serializers/application.py:197
-#: apps/application/serializers/application.py:372
-#: apps/common/constants/permission_constants.py:226
-#: apps/common/constants/permission_constants.py:259
-#: apps/common/constants/permission_constants.py:264
-#: apps/models_provider/views/model.py:63
-#: apps/models_provider/views/model.py:95
-#: apps/models_provider/views/model.py:113
-#: apps/models_provider/views/model.py:130
-#: apps/models_provider/views/model.py:145
-#: apps/models_provider/views/model.py:160
-#: apps/models_provider/views/model.py:173
-#: apps/models_provider/views/model.py:194
-#: apps/models_provider/views/model.py:210
-#: apps/models_provider/views/model_apply.py:29
-#: apps/models_provider/views/model_apply.py:41
-#: apps/models_provider/views/model_apply.py:53
-#: apps/models_provider/views/provide.py:25
-#: apps/models_provider/views/provide.py:48
-#: apps/models_provider/views/provide.py:62
-#: apps/models_provider/views/provide.py:80
-#: apps/models_provider/views/provide.py:97
-msgid "Model"
-msgstr "模型"
-
-#: apps/application/serializers/application.py:201
-#: apps/application/serializers/application.py:376
-msgid "Historical chat records"
-msgstr "歷史聊天記錄"
-
-#: apps/application/serializers/application.py:206
-#: apps/application/serializers/application.py:380
-msgid "Related Knowledge Base"
-msgstr "相關知識庫"
-
-#: apps/application/serializers/application.py:213
-#: apps/application/serializers/application.py:390
-msgid "Question completion"
-msgstr "問題完成"
-
-#: apps/application/serializers/application.py:217
-msgid "Application Type"
-msgstr "智能體類型"
-
-#: apps/application/serializers/application.py:221
-msgid "Application type only supports SIMPLE|WORK_FLOW"
-msgstr "智能體類型僅支持 SIMPLE|WORK_FLOW"
-
-#: apps/application/serializers/application.py:226
-#: apps/application/serializers/application.py:394
-msgid "Model parameters"
-msgstr "模型參數"
-
-#: apps/application/serializers/application.py:228
-#: apps/application/serializers/application.py:396
-msgid "Voice playback enabled"
-msgstr "開啟語音播放"
-
-#: apps/application/serializers/application.py:230
-#: apps/application/serializers/application.py:398
-msgid "Voice playback model ID"
-msgstr "語音播放模型 ID"
-
-#: apps/application/serializers/application.py:232
-#: apps/application/serializers/application.py:400
-msgid "Voice playback type"
-msgstr "語音播放類型"
-
-#: apps/application/serializers/application.py:234
-#: apps/application/serializers/application.py:402
-msgid "Voice playback autoplay"
-msgstr "自動播放語音"
-
-#: apps/application/serializers/application.py:236
-#: apps/application/serializers/application.py:404
-msgid "Voice recognition enabled"
-msgstr "開啟語音識別"
-
-#: apps/application/serializers/application.py:238
-#: apps/application/serializers/application.py:406
-msgid "Speech recognition model ID"
-msgstr "語音識別模型 ID"
-
-#: apps/application/serializers/application.py:240
-#: apps/application/serializers/application.py:408
-msgid "Voice recognition automatic transmission"
-msgstr "語音識別自動播放"
-
-#: apps/application/serializers/application.py:281
-msgid "Primary key id"
-msgstr ""
-
-#: apps/application/serializers/application.py:286
-msgid "Application type"
-msgstr "智能體類型"
-
-#: apps/application/serializers/application.py:287
-#: apps/xpack/serializers/resource_chat_user.py:34
-#: apps/xpack/serializers/resource_chat_user.py:110
-#: apps/xpack/serializers/resource_chat_user_group.py:17
-#: apps/xpack/serializers/resource_chat_user_group.py:85
-msgid "Resource type"
-msgstr "資源類型"
-
-#: apps/application/serializers/application.py:288
-msgid "Affiliation user"
-msgstr "關聯用戶"
-
-#: apps/application/serializers/application.py:289
-msgid "Creation time"
-msgstr "創建時間"
-
-#: apps/application/serializers/application.py:290
-msgid "Modification time"
-msgstr "修改時間"
-
-#: apps/application/serializers/application.py:294
-#: apps/application/serializers/application_chat_record.py:42
-#: apps/application/serializers/application_chat_record.py:323
-#: apps/application/serializers/application_version.py:40
-#: apps/chat/serializers/chat.py:318 apps/role_setting/api/role_setting.py:147
-#: apps/users/api/user.py:64 apps/users/api/user.py:170
-#: apps/workspace/api/workspace.py:46 apps/workspace/api/workspace.py:66
-#: apps/workspace/api/workspace.py:85 apps/workspace/api/workspace.py:103
-#: apps/workspace/serializers/workspace_serializers.py:239
-#: apps/xpack/api/application_setting.py:24 apps/xpack/api/knowledge_lark.py:40
-#: apps/xpack/api/knowledge_lark.py:72 apps/xpack/api/knowledge_lark.py:104
-#: apps/xpack/api/platform.py:22 apps/xpack/api/platform.py:63
-msgid "Workspace ID"
-msgstr "工作空間 ID"
-
-#: apps/application/serializers/application.py:363
-#: apps/knowledge/serializers/document.py:157
-#: apps/knowledge/serializers/document.py:162 apps/oss/serializers/file.py:57
-#: apps/tools/serializers/tool.py:356
-msgid "file"
-msgstr "文件"
-
-#: apps/application/serializers/application.py:384
-msgid "Dataset settings"
-msgstr "知識庫設置"
-
-#: apps/application/serializers/application.py:387
-msgid "Model setup"
-msgstr "模型設置"
-
-#: apps/application/serializers/application.py:391
-msgid "Icon"
-msgstr ""
-
-#: apps/application/serializers/application.py:412
-#: apps/application/serializers/application_api_key.py:33
-#: apps/application/serializers/application_api_key.py:64
-#: apps/folders/serializers/folder.py:101
-#: apps/folders/serializers/folder.py:140
-#: apps/folders/serializers/folder.py:195
-#: apps/knowledge/serializers/document.py:253
-#: apps/knowledge/serializers/document.py:347
-#: apps/knowledge/serializers/document.py:408
-#: apps/knowledge/serializers/document.py:502
-#: apps/knowledge/serializers/document.py:736
-#: apps/knowledge/serializers/document.py:888
-#: apps/knowledge/serializers/document.py:963
-#: apps/knowledge/serializers/document.py:983
-#: apps/knowledge/serializers/document.py:1166
-#: apps/knowledge/serializers/knowledge.py:208
-#: apps/knowledge/serializers/knowledge.py:448
-#: apps/knowledge/serializers/knowledge.py:557
-#: apps/knowledge/serializers/knowledge.py:635
-#: apps/knowledge/serializers/paragraph.py:134
-#: apps/knowledge/serializers/paragraph.py:346
-#: apps/knowledge/serializers/paragraph.py:438
-#: apps/knowledge/serializers/paragraph.py:558
-#: apps/knowledge/serializers/problem.py:176
-#: apps/knowledge/serializers/problem.py:204
-#: apps/models_provider/api/model.py:30 apps/models_provider/api/model.py:86
-#: apps/models_provider/api/model.py:99
-#: apps/models_provider/serializers/model_serializer.py:259
-#: apps/models_provider/serializers/model_serializer.py:323
-#: apps/models_provider/serializers/model_serializer.py:392
-#: apps/shared/api/shared_knowledge.py:131
-#: apps/shared/api/shared_knowledge.py:164 apps/shared/api/shared_tool.py:60
-#: apps/shared/api/shared_tool.py:147
-#: apps/shared/serializers/shared_knowledge.py:61
-#: apps/shared/serializers/shared_knowledge.py:109
-#: apps/shared/serializers/shared_knowledge.py:157
-#: apps/shared/serializers/shared_model.py:110
-#: apps/shared/serializers/shared_tool.py:45
-#: apps/shared/serializers/shared_tool.py:86
-#: apps/system_manage/serializers/user_resource_permission.py:74
-#: apps/tools/serializers/tool.py:188 apps/tools/serializers/tool.py:210
-#: apps/tools/serializers/tool.py:268 apps/tools/serializers/tool.py:358
-#: apps/tools/serializers/tool.py:389 apps/tools/serializers/tool.py:425
-#: apps/tools/serializers/tool.py:452
-#: apps/xpack/serializers/dataset_lark_serializer.py:45
-#: apps/xpack/serializers/resource_chat_user.py:33
-#: apps/xpack/serializers/resource_chat_user.py:109
-#: apps/xpack/serializers/resource_chat_user_group.py:16
-#: apps/xpack/serializers/resource_chat_user_group.py:84
-msgid "workspace id"
-msgstr "工作空間ID"
-
-#: apps/application/serializers/application.py:459
-msgid ""
-"The community version supports up to 5 applications. If you need more "
-"applications, please contact us (https://fit2cloud.com/)."
-msgstr ""
-"社區版支持最多5個智能體，如需更多智能體，請聯繫我們（https://fit2cloud.com/）。"
-
-#: apps/application/serializers/application.py:471
-#: apps/common/handle/impl/qa/zip_parse_qa_handle.py:56
-#: apps/common/handle/impl/text/zip_split_handle.py:69
-#: apps/knowledge/serializers/document.py:864
-#: apps/knowledge/serializers/document.py:871
-#: apps/tools/serializers/tool.py:370
-msgid "Unsupported file format"
-msgstr "不支持的文件格式"
-
-#: apps/application/serializers/application.py:545
-msgid "Application id does not exist"
-msgstr "智能體 ID 不存在"
-
-#: apps/application/serializers/application.py:591
-msgid "work_flow is a required field"
-msgstr "工作流是必填欄位"
-
-#: apps/application/serializers/application.py:695
-msgid "Unknown knowledge base id {dataset_id}, unable to associate"
-msgstr "未知知識庫 ID {dataset_id}，無法關聯"
-
-#: apps/application/serializers/application_access_token.py:24
-msgid "Reset Token"
-msgstr "重置令牌"
-
-#: apps/application/serializers/application_access_token.py:25
-msgid "Is it enabled"
-msgstr "是否開啟"
-
-#: apps/application/serializers/application_access_token.py:28
-msgid "Number of visits"
-msgstr "訪問次數"
-
-#: apps/application/serializers/application_access_token.py:30
-msgid "Whether to enable whitelist"
-msgstr "是否啟用白名單"
-
-#: apps/application/serializers/application_access_token.py:32
-#: apps/application/serializers/application_access_token.py:33
-msgid "Whitelist"
-msgstr "白名單"
-
-#: apps/application/serializers/application_access_token.py:35
-msgid "Whether to display knowledge sources"
-msgstr "是否展示知識來源"
-
-#: apps/application/serializers/application_access_token.py:37
-#: apps/users/serializers/user.py:665
-#: apps/xpack/serializers/application_setting_serializer.py:37
-msgid "language"
-msgstr "語言"
-
-#: apps/application/serializers/application_api_key.py:21
-msgid "Availability"
-msgstr "可用"
-
-#: apps/application/serializers/application_api_key.py:24
-msgid "Is cross-domain allowed"
-msgstr "是否允許跨域"
-
-#: apps/application/serializers/application_api_key.py:28
-msgid "Cross-domain address"
-msgstr "跨域地址"
-
-#: apps/application/serializers/application_api_key.py:29
-msgid "Cross-domain list"
-msgstr "跨域列表"
-
-#: apps/application/serializers/application_api_key.py:34
-#: apps/application/serializers/application_api_key.py:65
-#: apps/knowledge/serializers/knowledge.py:72
-#: apps/xpack/serializers/application_setting_serializer.py:77
-#: apps/xpack/serializers/dataset_lark_serializer.py:295
-msgid "application id"
-msgstr "智能體 ID"
-
-#: apps/application/serializers/application_api_key.py:41
-#: apps/chat/serializers/chat.py:277 apps/chat/serializers/chat.py:332
-#: apps/xpack/serializers/application_setting_serializer.py:103
-#: apps/xpack/serializers/platform_serializer.py:81
-#: apps/xpack/serializers/platform_serializer.py:103
-#: apps/xpack/serializers/platform_serializer.py:138
-#: apps/xpack/serializers/platform_serializer.py:149
-msgid "Application does not exist"
-msgstr "智能體不存在"
-
-#: apps/application/serializers/application_api_key.py:66
-msgid "ApiKeyId"
-msgstr "ApiKey ID"
-
-#: apps/application/serializers/application_api_key.py:87
-msgid "APIKey does not exist"
-msgstr "APIKey 不存在"
-
-#: apps/application/serializers/application_chat.py:33
-msgid "chat id"
-msgstr "對話 ID"
-
-#: apps/application/serializers/application_chat.py:34
-#: apps/application/serializers/application_chat.py:51
-#: apps/application/serializers/application_chat.py:182
-#: apps/application/serializers/application_version.py:23
-msgid "summary"
-msgstr "摘要"
-
-#: apps/application/serializers/application_chat.py:35
-msgid "Chat User ID"
-msgstr "對話用戶 ID"
-
-#: apps/application/serializers/application_chat.py:36
-msgid "Chat User Type"
-msgstr "對話用戶類型"
-
-#: apps/application/serializers/application_chat.py:37
-msgid "Is delete"
-msgstr "刪除"
-
-#: apps/application/serializers/application_chat.py:39
-#: apps/application/serializers/application_stats.py:25
-msgid "Number of conversations"
-msgstr "對話數量"
-
-#: apps/application/serializers/application_chat.py:40
-#: apps/application/serializers/application_stats.py:29
-msgid "Number of Likes"
-msgstr "點讚數量"
-
-#: apps/application/serializers/application_chat.py:41
-#: apps/application/serializers/application_stats.py:31
-msgid "Number of thumbs-downs"
-msgstr "點踩數量"
-
-#: apps/application/serializers/application_chat.py:42
-msgid "Number of tags"
-msgstr "標籤數量"
-
-#: apps/application/serializers/application_chat.py:46
-msgid "Chat ID List"
-msgstr "對話 ID 列表"
-
-#: apps/application/serializers/application_chat.py:52
-#: apps/application/serializers/application_stats.py:36
-#: apps/xpack/serializers/operate_log_serializer.py:55
-msgid "Start time"
-msgstr "開始時間"
-
-#: apps/application/serializers/application_chat.py:53
-#: apps/application/serializers/application_stats.py:37
-#: apps/xpack/serializers/operate_log_serializer.py:56
-msgid "End time"
-msgstr "結束時間"
-
-#: apps/application/serializers/application_chat.py:61
-msgid "Only supports and|or"
-msgstr "只支持 與|或"
-
-#: apps/application/serializers/application_chat.py:183
-msgid "Problem after optimization"
-msgstr "優化後的問題"
-
-#: apps/application/serializers/application_chat.py:184
-msgid "answer"
-msgstr "回答"
-
-#: apps/application/serializers/application_chat.py:184
-msgid "User feedback"
-msgstr "用戶反饋"
-
-#: apps/application/serializers/application_chat.py:186
-msgid "Section title + content"
-msgstr "分段標題 + 內容"
-
-#: apps/application/serializers/application_chat.py:187
-#: apps/application/views/application_chat_record.py:139
-#: apps/application/views/application_chat_record.py:140
-#: apps/application/views/application_chat_record.py:141
-#: apps/common/constants/permission_constants.py:248
-msgid "Annotation"
-msgstr "标注"
-
-#: apps/application/serializers/application_chat.py:187
-msgid "Consuming tokens"
-msgstr "消耗的令牌"
-
-#: apps/application/serializers/application_chat.py:188
-msgid "Time consumed (s)"
-msgstr "耗时 (s)"
-
-#: apps/application/serializers/application_chat.py:189
-msgid "Question Time"
-msgstr "提問時間"
-
-#: apps/application/serializers/application_chat_record.py:44
-#: apps/application/serializers/application_chat_record.py:143
-#: apps/application/serializers/application_chat_record.py:250
-#: apps/application/serializers/application_chat_record.py:315
-#: apps/chat/serializers/chat.py:45
-msgid "Conversation record id"
-msgstr "對話記錄 ID"
-
-#: apps/application/serializers/application_chat_record.py:51
-msgid "Application authentication information does not exist"
-msgstr "智能體認證信息不存在"
-
-#: apps/application/serializers/application_chat_record.py:53
-msgid "Displaying knowledge sources is not enabled"
-msgstr "知識庫來源展示未開啟"
-
-#: apps/application/serializers/application_chat_record.py:70
-#: apps/chat/serializers/chat.py:127 apps/chat/serializers/chat.py:274
-msgid "Conversation does not exist"
-msgstr "對話不存在"
-
-#: apps/application/serializers/application_chat_record.py:152
-#: apps/application/serializers/application_chat_record.py:279
-#: apps/application/serializers/application_chat_record.py:336
-#: apps/chat/serializers/chat.py:205
-msgid "Conversation record does not exist"
-msgstr "對話記錄不存在"
-
-#: apps/application/serializers/application_chat_record.py:168
-msgid "Section title"
-msgstr "章節標題"
-
-#: apps/application/serializers/application_chat_record.py:169
-msgid "Paragraph content"
-msgstr "段落內容"
-
-#: apps/application/serializers/application_chat_record.py:177
-#: apps/application/serializers/application_chat_record.py:254
-#: apps/application/serializers/application_chat_record.py:319
-msgid "Document id"
-msgstr "文檔 ID"
-
-#: apps/application/serializers/application_chat_record.py:184
-#: apps/application/serializers/application_chat_record.py:260
-#: apps/knowledge/serializers/paragraph.py:246
-msgid "The document id is incorrect"
-msgstr "文檔 ID 不正確"
-
-#: apps/application/serializers/application_chat_record.py:203
-msgid "Conversation records that do not exist"
-msgstr "對話記錄不存在"
-
-#: apps/application/serializers/application_chat_record.py:321
-msgid "Paragraph id"
-msgstr "段落 ID"
-
-#: apps/application/serializers/application_chat_record.py:340
-#, python-brace-format
-msgid ""
-"The paragraph id is wrong. The current conversation record does not exist. "
-"[{paragraph_id}] paragraph id"
-msgstr "段落 ID 錯誤。當前對話記錄不存在。[{paragraph_id}] 段落 ID"
-
-#: apps/application/serializers/application_stats.py:26
-msgid "Number of new users"
-msgstr "新用戶數量"
-
-#: apps/application/serializers/application_stats.py:27
-msgid "Total number of users"
-msgstr "總用戶數"
-
-#: apps/application/serializers/application_stats.py:28
-msgid "date"
-msgstr "日期"
-
-#: apps/application/serializers/application_stats.py:30
-msgid "Tokens consumption"
-msgstr "消耗的令牌"
-
-#: apps/application/serializers/application_version.py:36
-msgid "Version Name"
-msgstr "版本名稱"
-
-#: apps/application/serializers/application_version.py:69
-msgid "Workflow version id"
-msgstr "工作流版本 ID"
-
-#: apps/application/serializers/application_version.py:79
-#: apps/application/serializers/application_version.py:94
-msgid "Workflow version does not exist"
-msgstr "工作流版本不存在"
-
-#: apps/application/views/application.py:41
-#: apps/application/views/application.py:42
-#: apps/application/views/application.py:43
-msgid "Create an application"
-msgstr "創建一個智能體程式"
-
-#: apps/application/views/application.py:47
-#: apps/application/views/application.py:65
-#: apps/application/views/application.py:82
-#: apps/application/views/application.py:103
-#: apps/application/views/application.py:123
-#: apps/application/views/application.py:145
-#: apps/application/views/application.py:166
-#: apps/application/views/application.py:187
-#: apps/application/views/application.py:206
-#: apps/application/views/application_access_token.py:32
-#: apps/application/views/application_access_token.py:47
-#: apps/application/views/application_chat.py:102
-#: apps/application/views/application_chat.py:122
-#: apps/application/views/application_stats.py:33
-#: apps/common/constants/permission_constants.py:224
-#: apps/common/constants/permission_constants.py:234
-#: apps/xpack/views/application_setting.py:29
-#: apps/xpack/views/application_setting.py:47
-msgid "Application"
-msgstr "智能體"
-
-#: apps/application/views/application.py:60
-#: apps/application/views/application.py:61
-#: apps/application/views/application.py:62
-msgid "Get the application list"
-msgstr "獲取智能體列表"
-
-#: apps/application/views/application.py:77
-#: apps/application/views/application.py:78
-#: apps/application/views/application.py:79
-msgid "Get the application list by page"
-msgstr "分頁獲取智能體列表"
-
-#: apps/application/views/application.py:97
-#: apps/application/views/application.py:98
-#: apps/application/views/application.py:99
-msgid "Import Application"
-msgstr "導入智能體"
-
-#: apps/application/views/application.py:117
-#: apps/application/views/application.py:118
-#: apps/application/views/application.py:119
-msgid "Export application"
-msgstr "導出智能體"
-
-#: apps/application/views/application.py:140
-#: apps/application/views/application.py:141
-#: apps/application/views/application.py:142
-msgid "Deleting application"
-msgstr "刪除智能體"
-
-#: apps/application/views/application.py:160
-#: apps/application/views/application.py:161
-#: apps/application/views/application.py:162
-msgid "Modify the application"
-msgstr "修改智能體"
-
-#: apps/application/views/application.py:181
-#: apps/application/views/application.py:182
-#: apps/application/views/application.py:183
-msgid "Get application details"
-msgstr "獲取智能體詳情"
-
-#: apps/application/views/application.py:200
-#: apps/application/views/application.py:201
-#: apps/application/views/application.py:202
-msgid "Publishing an application"
-msgstr "發布智能體"
-
-#: apps/application/views/application_access_token.py:27
-#: apps/application/views/application_access_token.py:28
-#: apps/application/views/application_access_token.py:29
-msgid "Modify application access restriction information"
-msgstr "修改智能體訪問限制信息"
-
-#: apps/application/views/application_access_token.py:43
-#: apps/application/views/application_access_token.py:44
-#: apps/application/views/application_access_token.py:45
-msgid "Get application access restriction information"
-msgstr "獲取智能體訪問限制信息"
-
-#: apps/application/views/application_api_key.py:31
-#: apps/application/views/application_api_key.py:32
-#: apps/application/views/application_api_key.py:33
-msgid "Create application ApiKey"
-msgstr "創建智能體 API 密鑰"
-
-#: apps/application/views/application_api_key.py:37
-#: apps/application/views/application_api_key.py:57
-#: apps/application/views/application_api_key.py:77
-#: apps/application/views/application_api_key.py:99
-msgid "Application Api Key"
-msgstr "智能體 API 密鑰"
-
-#: apps/application/views/application_api_key.py:52
-msgid "GET application ApiKey List"
-msgstr "獲取智能體的 API 密鑰列表"
-
-#: apps/application/views/application_api_key.py:53
-#: apps/application/views/application_api_key.py:54
-msgid "Create application ApiKey List"
-msgstr "創建智能體 API 密鑰列表"
-
-#: apps/application/views/application_api_key.py:71
-#: apps/application/views/application_api_key.py:72
-#: apps/application/views/application_api_key.py:73
-msgid "Modify application API_KEY"
-msgstr "修改智能體 API 密鑰"
-
-#: apps/application/views/application_api_key.py:93
-#: apps/application/views/application_api_key.py:94
-#: apps/application/views/application_api_key.py:95
-msgid "Delete Application API_KEY"
-msgstr "刪除智能體 API 密鑰"
-
-#: apps/application/views/application_chat.py:35
-#: apps/application/views/application_chat.py:36
-#: apps/application/views/application_chat.py:37
-msgid "Get the conversation list"
-msgstr "獲取對話列表"
-
-#: apps/application/views/application_chat.py:41
-#: apps/application/views/application_chat.py:61
-#: apps/application/views/application_chat.py:82
-#: apps/application/views/application_chat_record.py:37
-#: apps/application/views/application_chat_record.py:58
-#: apps/application/views/application_chat_record.py:82
-#: apps/application/views/application_chat_record.py:106
-#: apps/application/views/application_chat_record.py:125
-#: apps/application/views/application_chat_record.py:145
-#: apps/application/views/application_chat_record.py:171
-msgid "Application/Conversation Log"
-msgstr "智能體/對話日誌"
-
-#: apps/application/views/application_chat.py:55
-#: apps/application/views/application_chat.py:56
-#: apps/application/views/application_chat.py:57
-msgid "Get the conversation list by page"
-msgstr "分頁獲取對話列表"
-
-#: apps/application/views/application_chat.py:76
-#: apps/application/views/application_chat.py:77
-#: apps/application/views/application_chat.py:78
-msgid "Export conversation"
-msgstr "導出對話"
-
-#: apps/application/views/application_chat.py:97
-#: apps/application/views/application_chat.py:98
-#: apps/application/views/application_chat.py:99
-msgid "Get a temporary session id based on the application id"
-msgstr "獲取智能體的臨時會話 ID"
-
-#: apps/application/views/application_chat.py:116
-#: apps/application/views/application_chat.py:117
-#: apps/application/views/application_chat.py:118 apps/chat/views/chat.py:93
-#: apps/chat/views/chat.py:94 apps/chat/views/chat.py:95
-msgid "dialogue"
-msgstr "對話"
-
-#: apps/application/views/application_chat_record.py:31
-#: apps/application/views/application_chat_record.py:32
-#: apps/application/views/application_chat_record.py:33
-msgid "Get the conversation record list"
-msgstr "獲取對話記錄列表"
-
-#: apps/application/views/application_chat_record.py:52
-#: apps/application/views/application_chat_record.py:53
-#: apps/application/views/application_chat_record.py:54
-msgid "Get the conversation record list by page"
-msgstr "分頁獲取對話記錄列表"
-
-#: apps/application/views/application_chat_record.py:76
-#: apps/application/views/application_chat_record.py:77
-#: apps/application/views/application_chat_record.py:78
-msgid "Get conversation record details"
-msgstr "獲取對話記錄詳情"
-
-#: apps/application/views/application_chat_record.py:100
-#: apps/application/views/application_chat_record.py:101
-#: apps/application/views/application_chat_record.py:102
-msgid "Add to Knowledge Base"
-msgstr "添加到知識庫"
-
-#: apps/application/views/application_chat_record.py:119
-#: apps/application/views/application_chat_record.py:120
-#: apps/application/views/application_chat_record.py:121
-msgid "Get the list of marked paragraphs"
-msgstr "獲取標記段落列表"
-
-#: apps/application/views/application_chat_record.py:165
-#: apps/application/views/application_chat_record.py:166
-#: apps/application/views/application_chat_record.py:167
-msgid "Delete a Annotation"
-msgstr "刪除注釋"
-
-#: apps/application/views/application_stats.py:28
-#: apps/application/views/application_stats.py:29
-#: apps/application/views/application_stats.py:30
-msgid "Dialogue-related statistical trends"
-msgstr "與對話有關的統計趨勢"
-
-#: apps/application/views/application_version.py:30
-#: apps/application/views/application_version.py:31
-#: apps/application/views/application_version.py:32
-msgid "Get the application version list"
-msgstr "獲取智能體版本列表"
-
-#: apps/application/views/application_version.py:35
-#: apps/application/views/application_version.py:55
-#: apps/application/views/application_version.py:76
-#: apps/application/views/application_version.py:94
-msgid "Application/Version"
-msgstr "智能體/ 版本"
-
-#: apps/application/views/application_version.py:50
-#: apps/application/views/application_version.py:51
-#: apps/application/views/application_version.py:52
-msgid "Get the list of application versions by page"
-msgstr "分頁獲取智能體版本列表"
-
-#: apps/application/views/application_version.py:71
-#: apps/application/views/application_version.py:72
-#: apps/application/views/application_version.py:73
-msgid "Get application version details"
-msgstr "獲取智能體版本詳情"
-
-#: apps/application/views/application_version.py:88
-#: apps/application/views/application_version.py:89
-#: apps/application/views/application_version.py:90
-msgid "Modify application version information"
-msgstr "修改智能體版本信息"
-
-#: apps/chat/api/chat_authentication_api.py:38
-#: apps/chat/serializers/chat_authentication.py:28
-#: apps/chat/serializers/chat_authentication.py:54
-#: apps/xpack/serializers/chat_auth.py:25
-msgid "access_token"
-msgstr ""
-
-#: apps/chat/api/chat_embed_api.py:24
-msgid "host"
-msgstr ""
-
-#: apps/chat/api/chat_embed_api.py:31
-#: apps/chat/serializers/chat_embed_serializers.py:25
-msgid "protocol"
-msgstr "協議"
-
-#: apps/chat/api/chat_embed_api.py:38
-#: apps/chat/serializers/chat_embed_serializers.py:26
-#: apps/users/serializers/login.py:36
-msgid "token"
-msgstr "令牌"
-
-#: apps/chat/serializers/chat.py:42
-msgid "Is the answer in streaming mode"
-msgstr "是否流式回答"
-
-#: apps/chat/serializers/chat.py:43
-msgid "Do you want to reply again"
-msgstr "是否重新回復"
-
-#: apps/chat/serializers/chat.py:48
-msgid "Node id"
-msgstr "節點 ID"
-
-#: apps/chat/serializers/chat.py:51
-msgid "Runtime node id"
-msgstr "運行時節點 ID"
-
-#: apps/chat/serializers/chat.py:54
-msgid "Node parameters"
-msgstr "節點參數"
-
-#: apps/chat/serializers/chat.py:56
-msgid "Global variables"
-msgstr "全局變量"
-
-#: apps/chat/serializers/chat.py:60
-#: apps/common/constants/permission_constants.py:222
-#: apps/common/constants/permission_constants.py:228
-msgid "Other"
-msgstr "其他"
-
-#: apps/chat/serializers/chat.py:115 apps/chat/serializers/chat.py:320
-msgid "Client id"
-msgstr "客戶端 ID"
-
-#: apps/chat/serializers/chat.py:116 apps/chat/serializers/chat.py:321
-msgid "Client Type"
-msgstr "客戶端類型"
-
-#: apps/chat/serializers/chat.py:119 apps/chat/serializers/chat.py:322
-#: apps/common/constants/permission_constants.py:240
-msgid "Debug"
-msgstr "調試"
-
-#: apps/chat/serializers/chat.py:146
-msgid "The number of visits exceeds today's visits"
-msgstr "今天的訪問次數超過限制"
-
-#: apps/chat/serializers/chat.py:157
-msgid "The current model is not available"
-msgstr "當前模型不可用"
-
-#: apps/chat/serializers/chat.py:159
-msgid "The model is downloading, please try again later"
-msgstr "下載過程被中斷，請重試"
-
-#: apps/chat/serializers/chat.py:306 apps/chat/serializers/chat.py:357
-msgid "The application has not been published. Please use it after publishing."
-msgstr "智能體未發布，請發布後使用。"
-
-#: apps/chat/serializers/chat_authentication.py:50
-#: apps/xpack/serializers/chat_auth.py:53
-msgid "Invalid access_token"
-msgstr "access_token 無效"
-
-#: apps/chat/serializers/chat_authentication.py:89
-msgid "Illegal User"
-msgstr "非法用戶"
-
-#: apps/chat/serializers/chat_embed_serializers.py:24
-msgid "Host"
-msgstr ""
-
-#: apps/chat/views/chat.py:37 apps/chat/views/chat.py:38
-#: apps/chat/views/chat.py:39
-msgid "Application Anonymous Certification"
-msgstr "智能體匿名認證"
-
-#: apps/chat/views/chat.py:42 apps/chat/views/chat.py:64
-#: apps/chat/views/chat.py:81 apps/chat/views/chat.py:99
-#: apps/chat/views/chat.py:120 apps/chat/views/chat_embed.py:27
-#: apps/xpack/views/chat_user_auth.py:419
-msgid "Chat"
-msgstr "聊天"
-
-#: apps/chat/views/chat.py:59 apps/chat/views/chat.py:60
-#: apps/chat/views/chat.py:61
-msgid "Get application related information"
-msgstr "獲取智能體相關信息"
-
-#: apps/chat/views/chat.py:76 apps/chat/views/chat.py:77
-#: apps/chat/views/chat.py:78
-msgid "Get application authentication information"
-msgstr "獲取智能體認證信息"
-
-#: apps/chat/views/chat.py:115 apps/chat/views/chat.py:116
-#: apps/chat/views/chat.py:117
-msgid "Get the session id according to the application id"
-msgstr "根據智能體 ID 獲取會話 ID"
-
-#: apps/chat/views/chat.py:131 apps/chat/views/chat.py:132
-#: apps/chat/views/chat.py:133 apps/users/views/login.py:70
-#: apps/users/views/login.py:71 apps/users/views/login.py:72
-msgid "Get captcha"
-msgstr "獲取驗證碼"
-
-#: apps/chat/views/chat.py:134
-#: apps/common/constants/permission_constants.py:210
-#: apps/users/views/login.py:41 apps/users/views/login.py:58
-#: apps/users/views/login.py:73 apps/users/views/user.py:63
-#: apps/users/views/user.py:77 apps/users/views/user.py:91
-#: apps/users/views/user.py:108 apps/users/views/user.py:123
-#: apps/users/views/user.py:136 apps/users/views/user.py:150
-#: apps/users/views/user.py:164 apps/users/views/user.py:180
-#: apps/users/views/user.py:193 apps/users/views/user.py:206
-#: apps/users/views/user.py:217 apps/users/views/user.py:235
-#: apps/users/views/user.py:251 apps/users/views/user.py:269
-#: apps/users/views/user.py:286 apps/users/views/user.py:303
-#: apps/users/views/user.py:321 apps/users/views/user.py:338
-#: apps/users/views/user.py:356 apps/xpack/views/chat_user_auth.py:206
-msgid "User Management"
-msgstr "用戶管理"
-
-#: apps/chat/views/chat_embed.py:22 apps/chat/views/chat_embed.py:23
-#: apps/chat/views/chat_embed.py:24
-msgid "Get embedded js"
-msgstr "獲取嵌入式 JavaScript"
-
-#: apps/common/auth/authenticate.py:80
-msgid "Not logged in, please log in first"
-msgstr "未登錄，請先登錄"
-
-#: apps/common/auth/authenticate.py:82 apps/common/auth/authenticate.py:89
-#: apps/common/auth/authenticate.py:95
-msgid "Authentication information is incorrect! illegal user"
-msgstr "身份驗證信息不正確！非法用戶"
-
-#: apps/common/auth/authentication.py:98
-msgid "No permission to access"
-msgstr "無權限訪問"
-
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:39
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:41
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:43
-#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:49
-#: apps/xpack/auth/chat_user_token.py:41 apps/xpack/auth/chat_user_token.py:43
-#: apps/xpack/auth/chat_user_token.py:45 apps/xpack/auth/chat_user_token.py:49
-msgid "Authentication information is incorrect"
-msgstr "身份驗證信息不正確"
-
-#: apps/common/auth/handle/impl/user_token.py:265
-msgid "Login expired"
-msgstr "登錄已過期"
-
-#: apps/common/constants/exception_code_constants.py:31
-#: apps/users/serializers/login.py:53
-#: apps/xpack/serializers/chat_user_serializer.py:123
-msgid "The username or password is incorrect"
-msgstr "用戶名或密碼不正確"
-
-#: apps/common/constants/exception_code_constants.py:32
-msgid "Please log in first and bring the user Token"
-msgstr "請先登錄並攜帶用戶 Token"
-
-#: apps/common/constants/exception_code_constants.py:33
-#: apps/users/serializers/user.py:630
-msgid "Email sending failed"
-msgstr "郵件發送失敗"
-
-#: apps/common/constants/exception_code_constants.py:34
-msgid "Email format error"
-msgstr "郵箱格式錯誤"
-
-#: apps/common/constants/exception_code_constants.py:35
-msgid "The email has been registered, please log in directly"
-msgstr "該郵箱已註冊，請直接登錄"
-
-#: apps/common/constants/exception_code_constants.py:36
-msgid "The email is not registered, please register first"
-msgstr "該郵箱未註冊，請先註冊"
-
-#: apps/common/constants/exception_code_constants.py:38
-msgid "The verification code is incorrect or the verification code has expired"
-msgstr "驗證碼不正確或已過期"
-
-#: apps/common/constants/exception_code_constants.py:39
-msgid "The username has been registered, please log in directly"
-msgstr "用戶名已註冊，請直接登錄"
-
-#: apps/common/constants/exception_code_constants.py:41
-msgid ""
-"The username cannot be empty and must be between 6 and 20 characters long."
-msgstr "用戶名不能為空，且長度在6到20個字符之間。"
-
-#: apps/common/constants/exception_code_constants.py:43
-msgid "Password and confirmation password are inconsistent"
-msgstr "密碼和確認密碼不一致"
-
-#: apps/common/constants/exception_code_constants.py:44
-msgid "The nickname is already registered"
-msgstr "暱稱已註冊"
-
-#: apps/common/constants/permission_constants.py:209
-msgid "System Setting"
-msgstr "系統設置"
-
-#: apps/common/constants/permission_constants.py:211
-#: apps/common/constants/permission_constants.py:272
-#: apps/role_setting/views/role_setting.py:44
-#: apps/role_setting/views/role_setting.py:67
-#: apps/role_setting/views/role_setting.py:84
-#: apps/role_setting/views/role_setting.py:103
-#: apps/role_setting/views/role_setting.py:125
-#: apps/role_setting/views/role_setting.py:145
-#: apps/role_setting/views/role_setting.py:167
-#: apps/role_setting/views/role_setting.py:191
-#: apps/role_setting/views/role_setting.py:210
-msgid "Role"
-msgstr "角色"
-
-#: apps/common/constants/permission_constants.py:212
-#: apps/common/constants/permission_constants.py:270
-#: apps/workspace/views/workspace.py:37 apps/workspace/views/workspace.py:49
-#: apps/workspace/views/workspace.py:63 apps/workspace/views/workspace.py:80
-#: apps/workspace/views/workspace.py:101 apps/workspace/views/workspace.py:119
-#: apps/workspace/views/workspace.py:138 apps/workspace/views/workspace.py:155
-#: apps/workspace/views/workspace.py:170 apps/workspace/views/workspace.py:188
-#: apps/workspace/views/workspace.py:207 apps/workspace/views/workspace.py:223
-#: apps/workspace/views/workspace.py:236 apps/workspace/views/workspace.py:250
-msgid "Workspace"
-msgstr "工作空間"
-
-#: apps/common/constants/permission_constants.py:213
-msgid "Resource Application"
-msgstr "資源管理-智能體"
-
-#: apps/common/constants/permission_constants.py:214
-msgid "Resource Knowledge"
-msgstr "資源管理-知識庫"
-
-#: apps/common/constants/permission_constants.py:215
-msgid "Resource Tool"
-msgstr "資源管理-工具"
-
-#: apps/common/constants/permission_constants.py:216
-msgid "Resource Model"
-msgstr "資源管理-模型"
-
-#: apps/common/constants/permission_constants.py:217
-msgid "Resource Permission"
-msgstr "資源授權"
-
-#: apps/common/constants/permission_constants.py:218
-#: apps/shared/views/shared_dataset_lark_views.py:30
-#: apps/shared/views/shared_dataset_lark_views.py:50
-#: apps/shared/views/shared_knowledge.py:33
-#: apps/shared/views/shared_knowledge.py:53
-#: apps/shared/views/shared_knowledge.py:76
-#: apps/shared/views/shared_knowledge.py:91
-#: apps/shared/views/shared_knowledge.py:106
-#: apps/shared/views/shared_knowledge.py:125
-#: apps/shared/views/shared_knowledge.py:151
-#: apps/shared/views/shared_knowledge.py:178
-#: apps/shared/views/shared_knowledge.py:196
-#: apps/shared/views/shared_knowledge.py:214
-#: apps/shared/views/shared_knowledge.py:235
-#: apps/shared/views/shared_knowledge.py:256
-#: apps/shared/views/shared_knowledge.py:276
-#: apps/shared/views/shared_knowledge.py:297
-#: apps/shared/views/shared_knowledge.py:312
-#: apps/shared/views/shared_knowledge.py:331
-#: apps/shared/views/shared_knowledge.py:354
-#: apps/shared/views/shared_knowledge.py:386
-#: apps/shared/views/shared_knowledge.py:407
-msgid "Shared Knowledge"
-msgstr "共享資源-知識庫"
-
-#: apps/common/constants/permission_constants.py:219
-#: apps/models_provider/views/model.py:227 apps/shared/views/shared_model.py:58
-#: apps/shared/views/shared_model.py:89 apps/shared/views/shared_model.py:107
-#: apps/shared/views/shared_model.py:124 apps/shared/views/shared_model.py:138
-#: apps/shared/views/shared_model.py:153 apps/shared/views/shared_model.py:166
-#: apps/shared/views/shared_model.py:186 apps/shared/views/shared_model.py:202
-#: apps/shared/views/shared_model.py:219 apps/shared/views/shared_model.py:234
-#: apps/shared/views/shared_model.py:253 apps/shared/views/shared_model.py:270
-msgid "Shared Model"
-msgstr "共享資源-模型"
-
-#: apps/common/constants/permission_constants.py:220
-#: apps/shared/views/shared_tool.py:30 apps/shared/views/shared_tool.py:49
-#: apps/shared/views/shared_tool.py:68 apps/shared/views/shared_tool.py:83
-#: apps/shared/views/shared_tool.py:98 apps/shared/views/shared_tool.py:116
-#: apps/shared/views/shared_tool.py:139 apps/shared/views/shared_tool.py:157
-#: apps/shared/views/shared_tool.py:175 apps/shared/views/shared_tool.py:194
-#: apps/shared/views/shared_tool.py:218 apps/shared/views/shared_tool.py:239
-#: apps/shared/views/shared_tool.py:254 apps/shared/views/shared_tool.py:273
-#: apps/shared/views/shared_tool.py:294
-msgid "Shared Tool"
-msgstr "共享資源-工具"
-
-#: apps/common/constants/permission_constants.py:221
-msgid "Operation Log"
-msgstr "操作日誌"
-
-#: apps/common/constants/permission_constants.py:223
-msgid "System Management"
-msgstr "系統管理"
-
-#: apps/common/constants/permission_constants.py:225
-#: apps/common/constants/permission_constants.py:235
-#: apps/common/constants/permission_constants.py:260
-#: apps/common/constants/permission_constants.py:265
-msgid "Knowledge"
-msgstr "知識庫"
-
-#: apps/common/constants/permission_constants.py:227
-#: apps/common/constants/permission_constants.py:258
-#: apps/common/constants/permission_constants.py:263
-#: apps/tools/views/tool.py:39 apps/tools/views/tool.py:61
-#: apps/tools/views/tool.py:82 apps/tools/views/tool.py:104
-#: apps/tools/views/tool.py:127 apps/tools/views/tool.py:146
-#: apps/tools/views/tool.py:172 apps/tools/views/tool.py:201
-#: apps/tools/views/tool.py:223 apps/tools/views/tool.py:250
-#: apps/tools/views/tool.py:274
-msgid "Tool"
-msgstr "工具"
-
-#: apps/common/constants/permission_constants.py:229
-msgid "Read"
-msgstr "查看"
-
-#: apps/common/constants/permission_constants.py:230
-msgid "Edit"
-msgstr "編輯"
-
-#: apps/common/constants/permission_constants.py:231
-msgid "Create"
-msgstr "創建"
-
-#: apps/common/constants/permission_constants.py:232
-msgid "Delete"
-msgstr "刪除"
-
-#: apps/common/constants/permission_constants.py:233
-msgid "Email Setting"
-msgstr "郵箱設置"
-
-#: apps/common/constants/permission_constants.py:236
-#: apps/common/constants/permission_constants.py:261
-#: apps/common/constants/permission_constants.py:266
-msgid "Document"
-msgstr "文檔"
-
-#: apps/common/constants/permission_constants.py:237
-#: apps/common/constants/permission_constants.py:262
-#: apps/common/constants/permission_constants.py:267
-msgid "Problem"
-msgstr "問題"
-
-#: apps/common/constants/permission_constants.py:238
-msgid "Import"
-msgstr "導入"
-
-#: apps/common/constants/permission_constants.py:239
-msgid "Export"
-msgstr "導出"
-
-#: apps/common/constants/permission_constants.py:241
-msgid "Sync"
-msgstr "同步"
-
-#: apps/common/constants/permission_constants.py:242
-msgid "Generate"
-msgstr "生成問題"
-
-#: apps/common/constants/permission_constants.py:243
-msgid "Add Member"
-msgstr "添加成員"
-
-#: apps/common/constants/permission_constants.py:244
-msgid "Remove Member"
-msgstr "移除成員"
-
-#: apps/common/constants/permission_constants.py:245
-msgid "Vector"
-msgstr "向量化"
-
-#: apps/common/constants/permission_constants.py:246
-msgid "Migrate"
-msgstr "遷移"
-
-#: apps/common/constants/permission_constants.py:247
-msgid "Relate"
-msgstr "關聯分段"
-
-#: apps/common/constants/permission_constants.py:249
-msgid "Clear Policy"
-msgstr "清除策略"
-
-#: apps/common/constants/permission_constants.py:250
-msgid "Login Auth"
-msgstr "登錄認證"
-
-#: apps/common/constants/permission_constants.py:251
-msgid "Display Settings"
-msgstr "顯示設置"
-
-#: apps/common/constants/permission_constants.py:252
-#: apps/common/constants/permission_constants.py:720
-#: apps/xpack/views/system_api_key.py:23 apps/xpack/views/system_api_key.py:38
-#: apps/xpack/views/system_api_key.py:56 apps/xpack/views/system_api_key.py:71
-msgid "System API Key"
-msgstr "系統 API Key"
-
-#: apps/common/constants/permission_constants.py:253
-#: apps/xpack/views/system_params.py:26 apps/xpack/views/system_params.py:42
-msgid "Appearance Settings"
-msgstr "外觀設置"
-
-#: apps/common/constants/permission_constants.py:254
-#: apps/common/constants/permission_constants.py:269
-#: apps/xpack/views/system_chat_user.py:339
-#: apps/xpack/views/system_chat_user.py:362
-msgid "Chat User"
-msgstr "對話用戶"
-
-#: apps/common/constants/permission_constants.py:255
-#: apps/common/constants/permission_constants.py:268
-msgid "User Group"
-msgstr "用戶組"
-
-#: apps/common/constants/permission_constants.py:256
-msgid "Chat User Auth"
-msgstr "對話用戶認證"
-
-#: apps/common/constants/permission_constants.py:257
-msgid "Overview"
-msgstr "概覽"
-
-#: apps/common/constants/permission_constants.py:271
-#: apps/common/constants/permission_constants.py:671
-#: apps/common/constants/permission_constants.py:677
-#: apps/common/constants/permission_constants.py:683
-#: apps/common/constants/permission_constants.py:689
-msgid "Dialogue log"
-msgstr "對話日誌"
-
-#: apps/common/constants/permission_constants.py:641
-msgid "Embed third party"
-msgstr "嵌入第三方"
-
-#: apps/common/constants/permission_constants.py:647
-msgid "Access restrictions"
-msgstr "訪問限制"
-
-#: apps/common/constants/permission_constants.py:653
-msgid "Display settings"
-msgstr "顯示設置"
-
-#: apps/common/constants/permission_constants.py:659
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:44
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:16
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:75
-msgid "API Key"
-msgstr ""
-
-#: apps/common/constants/permission_constants.py:665
-msgid "Public settings"
-msgstr "公共訪問連接"
-
-#: apps/common/constants/permission_constants.py:704
-msgid "About"
-msgstr "關於"
-
-#: apps/common/constants/permission_constants.py:709
-#: apps/users/views/user.py:88 apps/users/views/user.py:89
-#: apps/users/views/user.py:90
-msgid "Switch Language"
-msgstr "切換語言"
-
-#: apps/common/constants/permission_constants.py:714
-msgid "Change Password"
-msgstr "修改密碼"
-
-#: apps/common/constants/permission_constants.py:734
-msgid "Sync users"
-msgstr "同步用戶"
-
-#: apps/common/constants/permission_constants.py:755
-#: apps/common/constants/permission_constants.py:808
-msgid "Set up user groups"
-msgstr "設置用戶組"
-
-#: apps/common/event/__init__.py:27
-msgid "The download process was interrupted, please try again"
-msgstr "下載過程被中斷，請重試"
-
-#: apps/common/event/listener_manage.py:90
-#, python-brace-format
-msgid "Query vector data: {paragraph_id_list} error {error} {traceback}"
-msgstr "查詢向量數據：{paragraph_id_list} 錯誤：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:95
-#, python-brace-format
-msgid "Start--->Embedding paragraph: {paragraph_id_list}"
-msgstr "開始--->向量段落: {paragraph_id_list}"
-
-#: apps/common/event/listener_manage.py:107
-#, python-brace-format
-msgid "Vectorized paragraph: {paragraph_id_list} error {error} {traceback}"
-msgstr "向量段落: {paragraph_id_list} 錯誤：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:113
-#, python-brace-format
-msgid "End--->Embedding paragraph: {paragraph_id_list}"
-msgstr "結束--->向量段落: {paragraph_id_list}"
-
-#: apps/common/event/listener_manage.py:122
-#, python-brace-format
-msgid "Start--->Embedding paragraph: {paragraph_id}"
-msgstr "開始--->向量段落: {paragraph_id}"
-
-#: apps/common/event/listener_manage.py:147
-#, python-brace-format
-msgid "Vectorized paragraph: {paragraph_id} error {error} {traceback}"
-msgstr "向量段落: {paragraph_id} 錯誤：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:152
-#, python-brace-format
-msgid "End--->Embedding paragraph: {paragraph_id}"
-msgstr "結束--->向量段落: {paragraph_id}"
-
-#: apps/common/event/listener_manage.py:268
-#, python-brace-format
-msgid "Start--->Embedding document: {document_id}"
-msgstr "開始--->向量文檔: {document_id}"
-
-#: apps/common/event/listener_manage.py:288
-#, python-brace-format
-msgid "Vectorized document: {document_id} error {error} {traceback}"
-msgstr "向量文檔: {document_id} 錯誤：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:293
-#, python-brace-format
-msgid "End--->Embedding document: {document_id}"
-msgstr "結束--->向量文檔: {document_id}"
-
-#: apps/common/event/listener_manage.py:304
-#, python-brace-format
-msgid "Start--->Embedding knowledge: {knowledge_id}"
-msgstr "開始--->向量知識庫: {knowledge_id}"
-
-#: apps/common/event/listener_manage.py:308
-#, python-brace-format
-msgid "Start--->Embedding document: {document_list}"
-msgstr "開始--->向量文檔: {document_list}"
-
-#: apps/common/event/listener_manage.py:312
-#: apps/knowledge/task/embedding.py:116
-#, python-brace-format
-msgid "Vectorized knowledge: {knowledge_id} error {error} {traceback}"
-msgstr "向量知識庫: {knowledge_id} 錯誤：{error} {traceback}"
-
-#: apps/common/event/listener_manage.py:315
-#, python-brace-format
-msgid "End--->Embedding knowledge: {knowledge_id}"
-msgstr "結束--->向量知識庫: {knowledge_id}"
-
-#: apps/common/exception/handle_exception.py:32
-#: apps/common/handle/handle_exception.py:33
-msgid "Unknown exception"
-msgstr "未知錯誤"
-
-#: apps/common/field/common.py:48
-msgid "not a function"
-msgstr "不是函數"
-
-#: apps/common/forms/base_field.py:64
-#, python-brace-format
-msgid "The field {field_label} is required"
-msgstr "{field_label} 欄位是必填項"
-
-#: apps/common/forms/slider_field.py:56
-#, python-brace-format
-msgid "The {field_label} cannot be less than {min}"
-msgstr "{field_label} 不能小於{min}"
-
-#: apps/common/forms/slider_field.py:62
-#, python-brace-format
-msgid "The {field_label} cannot be greater than {max}"
-msgstr "{field_label} 不能大於{max}"
-
-#: apps/common/handle/impl/text/pdf_split_handle.py:281
-#, python-brace-format
-msgid "This document has no preface and is treated as ordinary text: {e}"
-msgstr "該文檔沒有前言，視為普通文本: {e}"
-
-#: apps/common/job/clean_chat_job.py:23
-msgid "start clean chat log"
-msgstr "開始清理聊天日誌"
-
-#: apps/common/job/clean_chat_job.py:69
-msgid "end clean chat log"
-msgstr "結束清理聊天日誌"
-
-#: apps/common/job/clean_debug_file_job.py:21
-msgid "start clean debug file"
-msgstr "開始清理調試文件"
-
-#: apps/common/job/clean_debug_file_job.py:25
-msgid "end clean debug file"
-msgstr "結束清理調試文件"
-
-#: apps/common/result/api.py:17 apps/common/result/api.py:27
-msgid "response code"
-msgstr "響應碼"
-
-#: apps/common/result/api.py:18 apps/common/result/api.py:19
-#: apps/common/result/api.py:28 apps/common/result/api.py:29
-msgid "error prompt"
-msgstr "錯誤提示"
-
-#: apps/common/result/api.py:43
-msgid "total number of data"
-msgstr "總數據"
-
-#: apps/common/result/api.py:44
-msgid "current page"
-msgstr "當前頁"
-
-#: apps/common/result/api.py:45
-msgid "page size"
-msgstr "每頁大小"
-
-#: apps/common/result/result.py:31
-#: apps/xpack/serializers/operate_log_serializer.py:134
-msgid "Success"
-msgstr "成功"
-
-#: apps/common/utils/common.py:91
-msgid "Text-to-speech node, the text content must be of string type"
-msgstr "文本轉語音節點，文本內容必須是字符串類型"
-
-#: apps/common/utils/common.py:93
-msgid "Text-to-speech node, the text content cannot be empty"
-msgstr "文本轉語音節點，文本內容不能為空"
-
-#: apps/common/utils/common.py:246
-#, python-brace-format
-msgid "Limit {count} exceeded, please contact us (https://fit2cloud.com/)."
-msgstr "超過限制 {count}，請聯繫我們 (https://fit2cloud.com/)."
-
-#: apps/folders/models/folder.py:6 apps/folders/models/folder.py:17
-#: apps/folders/serializers/folder.py:98
-msgid "folder name"
-msgstr "文件夾名稱"
-
-#: apps/folders/models/folder.py:8 apps/folders/models/folder.py:19
-#: apps/folders/serializers/folder.py:99
-msgid "folder description"
-msgstr "文件夾描述"
-
-#: apps/folders/models/folder.py:12 apps/folders/models/folder.py:23
-#: apps/folders/serializers/folder.py:102
-msgid "parent id"
-msgstr "父級 ID"
-
-#: apps/folders/serializers/folder.py:75
-msgid "Folder depth cannot exceed 5 levels"
-msgstr "文件夾深度不能超過5級"
-
-#: apps/folders/serializers/folder.py:100
-msgid "folder user id"
-msgstr "文件夾用戶 ID"
-
-#: apps/folders/serializers/folder.py:105
-#: apps/knowledge/serializers/knowledge.py:112
-#: apps/knowledge/serializers/knowledge.py:207
-#: apps/knowledge/serializers/knowledge.py:447
-#: apps/knowledge/serializers/knowledge.py:559
-#: apps/knowledge/serializers/knowledge.py:637
-#: apps/models_provider/serializers/model_serializer.py:108
-#: apps/models_provider/serializers/model_serializer.py:212
-#: apps/models_provider/serializers/model_serializer.py:252
-#: apps/shared/serializers/shared_knowledge.py:107
-#: apps/shared/serializers/shared_knowledge.py:156
-#: apps/shared/serializers/shared_tool.py:84
-#: apps/system_manage/serializers/user_resource_permission.py:75
-#: apps/tools/serializers/tool.py:187 apps/tools/serializers/tool.py:209
-#: apps/tools/serializers/tool.py:455 apps/users/serializers/user.py:664
-#: apps/xpack/serializers/dataset_lark_serializer.py:46
-#: apps/xpack/serializers/dataset_lark_serializer.py:285
-#: apps/xpack/serializers/system_api_key.py:23
-msgid "user id"
-msgstr "用戶ID"
-
-#: apps/folders/serializers/folder.py:123
-msgid "Folder name already exists"
-msgstr "文件夾名稱已存在"
-
-#: apps/folders/serializers/folder.py:150
-#: apps/folders/serializers/folder.py:182
-msgid "Folder does not exist"
-msgstr "文件夾不存在"
-
-#: apps/folders/serializers/folder.py:184
-msgid "Cannot delete root folder"
-msgstr "無法刪除根文件夾"
-
-#: apps/folders/views/folder.py:31 apps/folders/views/folder.py:32
-#: apps/folders/views/folder.py:33
-msgid "Create folder"
-msgstr "創建文件夾"
-
-#: apps/folders/views/folder.py:37 apps/folders/views/folder.py:63
-#: apps/folders/views/folder.py:86 apps/folders/views/folder.py:110
-#: apps/folders/views/folder.py:129
-msgid "Folder"
-msgstr "文件夾"
-
-#: apps/folders/views/folder.py:58 apps/folders/views/folder.py:59
-#: apps/folders/views/folder.py:60
-msgid "Get folder tree"
-msgstr "獲取文件夾樹"
-
-#: apps/folders/views/folder.py:80 apps/folders/views/folder.py:81
-#: apps/folders/views/folder.py:82
-msgid "Update folder"
-msgstr "更新文件夾"
-
-#: apps/folders/views/folder.py:105 apps/folders/views/folder.py:106
-#: apps/folders/views/folder.py:107
-msgid "Get folder"
-msgstr "獲取文件夾"
-
-#: apps/folders/views/folder.py:124 apps/folders/views/folder.py:125
-#: apps/folders/views/folder.py:126
-msgid "Delete folder"
-msgstr "刪除文件夾"
-
-#: apps/knowledge/api/problem.py:39 apps/knowledge/api/problem.py:52
-#: apps/knowledge/serializers/problem.py:40
-msgid "problem list"
-msgstr "問題列表"
-
-#: apps/knowledge/api/problem.py:40 apps/knowledge/api/problem.py:53
-#: apps/knowledge/serializers/problem.py:41
-msgid "problem"
-msgstr "問題 ID"
-
-#: apps/knowledge/serializers/common.py:32
-#: apps/knowledge/serializers/knowledge.py:62
-#: apps/shared/serializers/shared_knowledge.py:29
-msgid "source url"
-msgstr "來源"
-
-#: apps/knowledge/serializers/common.py:33
-#: apps/knowledge/serializers/document.py:152
-msgid "selector"
-msgstr "選擇器"
-
-#: apps/knowledge/serializers/common.py:40
-#, python-brace-format
-msgid "URL error, cannot parse [{source_url}]"
-msgstr "URL 錯誤，無法解析 [{source_url}]"
-
-#: apps/knowledge/serializers/common.py:48
-#: apps/knowledge/serializers/document.py:78
-#: apps/knowledge/serializers/document.py:170
-#: apps/knowledge/serializers/document.py:186
-msgid "id list"
-msgstr "ID 列表"
-
-#: apps/knowledge/serializers/common.py:58
-#, python-brace-format
-msgid "The following id does not exist: {error_id_list}"
-msgstr "以下ID不存在: {error_id_list}"
-
-#: apps/knowledge/serializers/common.py:74
-#: apps/knowledge/serializers/document.py:166
-#: apps/knowledge/serializers/document.py:171
-#: apps/knowledge/serializers/document.py:178
-msgid "state list"
-msgstr "狀態列表"
-
-#: apps/knowledge/serializers/common.py:117
-#: apps/knowledge/serializers/common.py:141
-msgid "The knowledge base is inconsistent with the vector model"
-msgstr "知識庫與向量模型不一致"
-
-#: apps/knowledge/serializers/common.py:119
-#: apps/knowledge/serializers/common.py:143
-msgid "Knowledge base setting error, please reset the knowledge base"
-msgstr "知識庫設置錯誤，請重置知識庫"
-
-#: apps/knowledge/serializers/document.py:79
-#: apps/knowledge/serializers/document.py:97
-#: apps/knowledge/serializers/document.py:353
-msgid "task type"
-msgstr "任務類型"
-
-#: apps/knowledge/serializers/document.py:87
-#: apps/knowledge/serializers/document.py:105
-msgid "task type not support"
-msgstr "任務類型不支持"
-
-#: apps/knowledge/serializers/document.py:91
-#: apps/knowledge/serializers/document.py:110
-#: apps/knowledge/serializers/document.py:350
-msgid "document name"
-msgstr "文檔名稱"
-
-#: apps/knowledge/serializers/document.py:93
-msgid "source file id"
-msgstr "源文件 ID"
-
-#: apps/knowledge/serializers/document.py:113
-#: apps/knowledge/serializers/document.py:194
-msgid "The type only supports optimization|directly_return"
-msgstr "該類型僅支持優化|直接返回"
-
-#: apps/knowledge/serializers/document.py:115
-#: apps/knowledge/serializers/document.py:187
-#: apps/knowledge/serializers/document.py:351
-msgid "hit handling method"
-msgstr "命中處理方法"
-
-#: apps/knowledge/serializers/document.py:118
-#: apps/knowledge/serializers/document.py:189
-msgid "directly return similarity"
-msgstr "直接返回相似度"
-
-#: apps/knowledge/serializers/document.py:120
-#: apps/knowledge/serializers/document.py:352
-msgid "document is active"
-msgstr "文檔已激活"
-
-#: apps/knowledge/serializers/document.py:139
-#: apps/knowledge/serializers/document.py:156
-#: apps/knowledge/serializers/document.py:161
-msgid "file list"
-msgstr "文件 列表"
-
-#: apps/knowledge/serializers/document.py:140
-msgid "limit"
-msgstr "限制"
-
-#: apps/knowledge/serializers/document.py:143
-#: apps/knowledge/serializers/document.py:144
-msgid "patterns"
-msgstr "分割符"
-
-#: apps/knowledge/serializers/document.py:146
-msgid "Auto Clean"
-msgstr "自動清理"
-
-#: apps/knowledge/serializers/document.py:150
-#: apps/knowledge/serializers/document.py:151
-msgid "document url list"
-msgstr "文檔 URL 列表"
-
-#: apps/knowledge/serializers/document.py:175
-#: apps/knowledge/serializers/document.py:182
-msgid "document id list"
-msgstr "文檔 ID 列表"
-
-#: apps/knowledge/serializers/document.py:176
-#: apps/knowledge/serializers/paragraph.py:58
-#: apps/models_provider/api/model.py:105
-#: apps/models_provider/serializers/model_apply_serializers.py:51
-#: apps/models_provider/serializers/model_serializer.py:107
-#: apps/models_provider/serializers/model_serializer.py:364
-#: apps/shared/api/shared_model.py:61
-#: apps/shared/serializers/shared_model.py:54
-msgid "model id"
-msgstr "模型ID"
-
-#: apps/knowledge/serializers/document.py:177
-#: apps/knowledge/serializers/paragraph.py:59
-msgid "prompt"
-msgstr "提示詞"
-
-#: apps/knowledge/serializers/document.py:201
-msgid "The template type only supports excel|csv"
-msgstr "模板類型僅支持 excel|csv"
-
-#: apps/knowledge/serializers/document.py:254
-#: apps/knowledge/serializers/document.py:348
-#: apps/knowledge/serializers/document.py:409
-#: apps/knowledge/serializers/document.py:504
-#: apps/knowledge/serializers/document.py:889
-#: apps/knowledge/serializers/document.py:964
-#: apps/knowledge/serializers/document.py:984
-#: apps/knowledge/serializers/document.py:1167
-#: apps/knowledge/serializers/knowledge.py:209
-#: apps/knowledge/serializers/knowledge.py:558
-#: apps/knowledge/serializers/paragraph.py:70
-#: apps/knowledge/serializers/paragraph.py:138
-#: apps/knowledge/serializers/paragraph.py:239
-#: apps/knowledge/serializers/paragraph.py:321
-#: apps/knowledge/serializers/paragraph.py:347
-#: apps/knowledge/serializers/paragraph.py:398
-#: apps/knowledge/serializers/paragraph.py:439
-#: apps/knowledge/serializers/paragraph.py:559
-#: apps/knowledge/serializers/problem.py:62
-#: apps/knowledge/serializers/problem.py:126
-#: apps/knowledge/serializers/problem.py:177
-#: apps/knowledge/serializers/problem.py:205
-#: apps/shared/api/shared_knowledge.py:196
-#: apps/shared/api/shared_knowledge.py:218
-#: apps/shared/serializers/shared_knowledge.py:158
-#: apps/shared/serializers/shared_knowledge.py:205
-#: apps/xpack/serializers/dataset_lark_serializer.py:104
-#: apps/xpack/serializers/dataset_lark_serializer.py:263
-#: apps/xpack/serializers/dataset_lark_serializer.py:284
-msgid "knowledge id"
-msgstr "知識庫 ID"
-
-#: apps/knowledge/serializers/document.py:255
-#: apps/knowledge/serializers/paragraph.py:441
-msgid "target knowledge id"
-msgstr "當前知識庫 ID"
-
-#: apps/knowledge/serializers/document.py:256
-msgid "document list"
-msgstr "文檔列表"
-
-#: apps/knowledge/serializers/document.py:257
-#: apps/knowledge/serializers/document.py:410
-#: apps/knowledge/serializers/document.py:503
-#: apps/knowledge/serializers/document.py:737
-#: apps/knowledge/serializers/paragraph.py:61
-#: apps/knowledge/serializers/paragraph.py:71
-#: apps/knowledge/serializers/paragraph.py:140
-#: apps/knowledge/serializers/paragraph.py:240
-#: apps/knowledge/serializers/paragraph.py:322
-#: apps/knowledge/serializers/paragraph.py:349
-#: apps/knowledge/serializers/paragraph.py:399
-#: apps/knowledge/serializers/paragraph.py:440
-#: apps/knowledge/serializers/paragraph.py:560
-#: apps/knowledge/serializers/problem.py:36
-#: apps/knowledge/serializers/problem.py:51
-#: apps/xpack/serializers/dataset_lark_serializer.py:160
-msgid "document id"
-msgstr "文檔 ID"
-
-#: apps/knowledge/serializers/document.py:354 apps/xpack/api/license.py:25
-#: apps/xpack/serializers/operate_log_serializer.py:60
-#: apps/xpack/serializers/operate_log_serializer.py:174
-msgid "status"
-msgstr "狀態"
-
-#: apps/knowledge/serializers/document.py:355
-msgid "order by"
-msgstr "排序"
-
-#: apps/knowledge/serializers/document.py:417
-#: apps/knowledge/serializers/document.py:510
-#: apps/xpack/serializers/dataset_lark_serializer.py:167
-#: apps/xpack/serializers/dataset_lark_serializer.py:189
-msgid "document id not exist"
-msgstr "文檔 ID 不存在"
-
-#: apps/knowledge/serializers/document.py:419
-#: apps/knowledge/serializers/knowledge.py:570
-msgid "Synchronization is only supported for web site types"
-msgstr "僅支持網站類型的同步"
-
-#: apps/knowledge/serializers/document.py:661
-msgid "The task is being executed, please do not send it repeatedly."
-msgstr "任務正在執行，請勿重複發送。"
-
-#: apps/knowledge/serializers/document.py:674
-msgid "Section title (optional)"
-msgstr "章節標題"
-
-#: apps/knowledge/serializers/document.py:675
-msgid ""
-"Section content (required, question answer, no more than 4096 characters)"
-msgstr "章節內容（必填，問答，不超過4096個字符）"
-
-#: apps/knowledge/serializers/document.py:676
-msgid "Question (optional, one per line in the cell)"
-msgstr "問題（可選，每個單元格一行）"
-
-#: apps/knowledge/serializers/document.py:742
-msgid "knowledge id not exist"
-msgstr "知識庫 ID 不存在"
-
-#: apps/knowledge/serializers/document.py:898
-msgid "The maximum size of the uploaded file cannot exceed {}MB"
-msgstr "上傳文件的最大大小不能超過 {}MB"
-
-#: apps/knowledge/serializers/document.py:976
-msgid "space"
-msgstr "空格"
-
-#: apps/knowledge/serializers/document.py:977
-msgid "semicolon"
-msgstr "分號"
-
-#: apps/knowledge/serializers/document.py:977
-msgid "comma"
-msgstr "逗號"
-
-#: apps/knowledge/serializers/document.py:978
-msgid "period"
-msgstr "句號"
-
-#: apps/knowledge/serializers/document.py:978
-msgid "enter"
-msgstr "回車"
-
-#: apps/knowledge/serializers/document.py:979
-msgid "blank line"
-msgstr "空行"
-
-#: apps/knowledge/serializers/document.py:1140
-msgid "Hit handling method is required"
-msgstr "命中處理方法是必需的"
-
-#: apps/knowledge/serializers/document.py:1142
-msgid "The hit processing method must be directly_return|optimization"
-msgstr "命中處理方法必須是直接返回|優化"
-
-#: apps/knowledge/serializers/knowledge.py:51
-#: apps/knowledge/serializers/knowledge.py:58
-#: apps/knowledge/serializers/knowledge.py:67
-#: apps/knowledge/serializers/knowledge.py:108
-#: apps/shared/api/shared_knowledge.py:117
-#: apps/shared/api/shared_knowledge.py:150
-#: apps/shared/serializers/shared_knowledge.py:20
-#: apps/shared/serializers/shared_knowledge.py:26
-#: apps/shared/serializers/shared_knowledge.py:59
-#: apps/shared/serializers/shared_knowledge.py:106
-#: apps/xpack/serializers/dataset_lark_serializer.py:51
-#: apps/xpack/serializers/dataset_lark_serializer.py:289
-msgid "knowledge name"
-msgstr "知識庫名稱"
-
-#: apps/knowledge/serializers/knowledge.py:53
-#: apps/knowledge/serializers/knowledge.py:60
-#: apps/knowledge/serializers/knowledge.py:68
-#: apps/knowledge/serializers/knowledge.py:110
-#: apps/shared/api/shared_knowledge.py:124
-#: apps/shared/api/shared_knowledge.py:157
-#: apps/shared/serializers/shared_knowledge.py:21
-#: apps/shared/serializers/shared_knowledge.py:27
-#: apps/shared/serializers/shared_knowledge.py:60
-#: apps/shared/serializers/shared_knowledge.py:108
-#: apps/xpack/serializers/dataset_lark_serializer.py:53
-#: apps/xpack/serializers/dataset_lark_serializer.py:291
-msgid "knowledge description"
-msgstr "知識庫描述"
-
-#: apps/knowledge/serializers/knowledge.py:54
-#: apps/knowledge/serializers/knowledge.py:61
-#: apps/shared/serializers/shared_knowledge.py:22
-#: apps/shared/serializers/shared_knowledge.py:28
-msgid "knowledge embedding"
-msgstr "知識庫向量"
-
-#: apps/knowledge/serializers/knowledge.py:63
-#: apps/shared/serializers/shared_knowledge.py:30
-msgid "knowledge selector"
-msgstr "知識庫選擇器"
-
-#: apps/knowledge/serializers/knowledge.py:73
-#: apps/xpack/serializers/dataset_lark_serializer.py:296
-msgid "application id list"
-msgstr "智能體 ID 列表"
-
-#: apps/knowledge/serializers/knowledge.py:75
-msgid "file size limit"
-msgstr "文件大小限制"
-
-#: apps/knowledge/serializers/knowledge.py:76
-msgid "file count limit"
-msgstr "文件數量限制"
-
-#: apps/knowledge/serializers/knowledge.py:95
-#: apps/knowledge/serializers/knowledge.py:638
-msgid "query text"
-msgstr "查詢文本"
-
-#: apps/knowledge/serializers/knowledge.py:96
-#: apps/knowledge/serializers/knowledge.py:639
-msgid "top number"
-msgstr "Top 數量"
-
-#: apps/knowledge/serializers/knowledge.py:98
-#: apps/knowledge/serializers/knowledge.py:641
-msgid "search mode"
-msgstr "搜索模式"
-
-#: apps/knowledge/serializers/knowledge.py:113
-msgid "knowledge scope"
-msgstr "知識庫範圍"
-
-#: apps/knowledge/serializers/knowledge.py:169
-#: apps/tools/serializers/tool.py:434 apps/tools/serializers/tool.py:464
-msgid "Folder not found"
-msgstr "文件夾不存在"
-
-#: apps/knowledge/serializers/knowledge.py:236
-#: apps/knowledge/serializers/knowledge.py:265
-msgid "Failed to send the vectorization task, please try again later!"
-msgstr "發送向量化任務失敗，請稍後再試！"
-
-#: apps/knowledge/serializers/knowledge.py:315
-#: apps/knowledge/serializers/knowledge.py:471
-#: apps/knowledge/serializers/knowledge.py:533
-#: apps/xpack/serializers/dataset_lark_serializer.py:82
-#: apps/xpack/serializers/dataset_lark_serializer.py:340
-msgid "Knowledge base name duplicate!"
-msgstr "知識庫名稱重複！"
-
-#: apps/knowledge/serializers/knowledge.py:341
-#: apps/xpack/serializers/dataset_lark_serializer.py:359
-#, python-brace-format
-msgid "Unknown application id {knowledge_id}, cannot be associated"
-msgstr "未知智能體 ID {knowledge_id}，無法關聯"
-
-#: apps/knowledge/serializers/knowledge.py:449
-#: apps/shared/serializers/shared_knowledge.py:62
-#: apps/shared/serializers/shared_knowledge.py:110
-#: apps/shared/serializers/shared_tool.py:46
-#: apps/shared/serializers/shared_tool.py:87 apps/tools/serializers/tool.py:456
-#: apps/xpack/serializers/dataset_lark_serializer.py:47
-msgid "scope"
-msgstr "範圍"
-
-#: apps/knowledge/serializers/knowledge.py:460
-msgid ""
-"The community version supports up to 50 knowledge bases. If you need more "
-"knowledge bases, please contact us (https://fit2cloud.com/)."
-msgstr ""
-"社區版支持最多50個知識庫，如需更多知識庫，請聯繫我們 (https://"
-"fit2cloud.com/)."
-
-#: apps/knowledge/serializers/knowledge.py:560
-msgid "sync type"
-msgstr "同步類型"
-
-#: apps/knowledge/serializers/knowledge.py:562
-msgid "The synchronization type only supports:replace|complete"
-msgstr "同步類型僅支持:replace|complete"
-
-#: apps/knowledge/serializers/knowledge.py:568
-#: apps/knowledge/serializers/knowledge.py:649
-msgid "id does not exist"
-msgstr "知識庫 ID 不存在"
-
-#: apps/knowledge/serializers/knowledge.py:636 apps/users/api/user.py:76
-msgid "id"
-msgstr "ID"
-
-#: apps/knowledge/serializers/paragraph.py:39
-#: apps/knowledge/serializers/problem.py:27
-#: apps/knowledge/serializers/problem.py:31
-#: apps/knowledge/serializers/problem.py:206
-msgid "content"
-msgstr "內容"
-
-#: apps/knowledge/serializers/paragraph.py:41
-#: apps/knowledge/serializers/paragraph.py:48
-#: apps/knowledge/serializers/paragraph.py:51
-#: apps/knowledge/serializers/paragraph.py:65
-#: apps/knowledge/serializers/paragraph.py:67
-#: apps/knowledge/serializers/paragraph.py:323
-msgid "section title"
-msgstr "章節標題"
-
-#: apps/knowledge/serializers/paragraph.py:44
-#: apps/tools/serializers/tool.py:152 apps/tools/serializers/tool.py:164
-#: apps/xpack/serializers/system_api_key.py:11
-msgid "Is active"
-msgstr "是否啟用"
-
-#: apps/knowledge/serializers/paragraph.py:56
-#: apps/knowledge/serializers/paragraph.py:443
-msgid "paragraph id list"
-msgstr "段落 ID 列表"
-
-#: apps/knowledge/serializers/paragraph.py:57
-#: apps/knowledge/serializers/paragraph.py:72
-#: apps/knowledge/serializers/paragraph.py:136
-#: apps/knowledge/serializers/paragraph.py:350
-#: apps/knowledge/serializers/paragraph.py:444
-#: apps/knowledge/serializers/paragraph.py:561
-#: apps/knowledge/serializers/problem.py:35
-#: apps/knowledge/serializers/problem.py:50
-msgid "paragraph id"
-msgstr "段落 ID"
-
-#: apps/knowledge/serializers/paragraph.py:77
-#: apps/knowledge/serializers/paragraph.py:145
-msgid "Paragraph id does not exist"
-msgstr "段落 ID 不存在"
-
-#: apps/knowledge/serializers/paragraph.py:108
-msgid "Already associated, please do not associate again"
-msgstr "已關聯，請勿再次關聯"
-
-#: apps/knowledge/serializers/paragraph.py:181
-msgid "Problem id does not exist"
-msgstr "問題 ID 不存在"
-
-#: apps/knowledge/serializers/paragraph.py:348
-#: apps/knowledge/serializers/problem.py:26
-#: apps/knowledge/serializers/problem.py:46
-#: apps/knowledge/serializers/problem.py:56
-#: apps/knowledge/serializers/problem.py:127
-msgid "problem id"
-msgstr "問題 ID"
-
-#: apps/knowledge/serializers/paragraph.py:358
-msgid "Paragraph does not exist"
-msgstr "段落不存在"
-
-#: apps/knowledge/serializers/paragraph.py:360
-msgid "Problem does not exist"
-msgstr "問題不存在"
-
-#: apps/knowledge/serializers/paragraph.py:435
-msgid "The task is being executed, please do not send it again."
-msgstr "任務正在執行，請勿重複發送。"
-
-#: apps/knowledge/serializers/paragraph.py:442
-msgid "target document id"
-msgstr "目標文檔 ID"
-
-#: apps/knowledge/serializers/paragraph.py:453
-msgid "The document to be migrated is consistent with the target document"
-msgstr "遷移的文檔與目標文檔一致"
-
-#: apps/knowledge/serializers/paragraph.py:455
-msgid "The document id does not exist [{document_id}]"
-msgstr "以下文檔ID不存在: {error_id_list}"
-
-#: apps/knowledge/serializers/paragraph.py:459
-msgid "The target document id does not exist [{document_id}]"
-msgstr "以下目標文檔ID不存在: {error_id_list}"
-
-#: apps/knowledge/serializers/paragraph.py:573
-msgid "new_position must be an integer"
-msgstr "new_position 必須是整數"
-
-#: apps/knowledge/serializers/problem.py:45
-#: apps/knowledge/serializers/problem.py:55
-msgid "problem id list"
-msgstr "問題 ID 列表"
-
-#: apps/knowledge/task/embedding.py:24 apps/knowledge/task/embedding.py:74
-#, python-brace-format
-msgid "Failed to obtain vector model: {error} {traceback}"
-msgstr "向量模型獲取失敗: {error} {traceback}"
-
-#: apps/knowledge/task/embedding.py:103
-#, python-brace-format
-msgid "Start--->Vectorized knowledge: {knowledge_id}"
-msgstr "開始--->向量知識庫: {knowledge_id}"
-
-#: apps/knowledge/task/embedding.py:107
-#, python-brace-format
-msgid "Knowledge documentation: {document_names}"
-msgstr "知識庫文檔: {document_names}"
-
-#: apps/knowledge/task/embedding.py:120
-#, python-brace-format
-msgid "End--->Vectorized knowledge: {knowledge_id}"
-msgstr "結束--->向量知識庫: {knowledge_id}"
-
-#: apps/knowledge/task/generate.py:106
-#, python-brace-format
-msgid ""
-"Generate issue based on document: {document_id} error {error}{traceback}"
-msgstr "生成問題基於文檔: {document_id} 錯誤 {error}{traceback}"
-
-#: apps/knowledge/task/generate.py:110
-#, python-brace-format
-msgid "End--->Generate problem: {document_id}"
-msgstr "結束--->生成問題: {document_id}"
-
-#: apps/knowledge/task/handler.py:121
-#, python-brace-format
-msgid "Association problem failed {error}"
-msgstr "關聯問題失敗 {error}"
-
-#: apps/knowledge/task/sync.py:30 apps/knowledge/task/sync.py:47
-#, python-brace-format
-msgid "Start--->Start synchronization web knowledge base:{knowledge_id}"
-msgstr "開始--->開始同步 web 知識庫:{knowledge_id}"
-
-#: apps/knowledge/task/sync.py:35 apps/knowledge/task/sync.py:51
-#, python-brace-format
-msgid "End--->End synchronization web knowledge base:{knowledge_id}"
-msgstr "結束--->結束同步 web 知識庫:{knowledge_id}"
-
-#: apps/knowledge/task/sync.py:37 apps/knowledge/task/sync.py:53
-#, python-brace-format
-msgid "Synchronize web knowledge base:{knowledge_id} error{error}{traceback}"
-msgstr "同步 web 知識庫:{knowledge_id} 錯誤{error}{traceback}"
-
-#: apps/knowledge/views/document.py:28 apps/knowledge/views/document.py:29
-#: apps/knowledge/views/document.py:30
-msgid "Create document"
-msgstr "創建文檔"
-
-#: apps/knowledge/views/document.py:34 apps/knowledge/views/document.py:57
-#: apps/knowledge/views/document.py:84 apps/knowledge/views/document.py:104
-#: apps/knowledge/views/document.py:128 apps/knowledge/views/document.py:160
-#: apps/knowledge/views/document.py:191 apps/knowledge/views/document.py:209
-#: apps/knowledge/views/document.py:238 apps/knowledge/views/document.py:267
-#: apps/knowledge/views/document.py:295 apps/knowledge/views/document.py:323
-#: apps/knowledge/views/document.py:352 apps/knowledge/views/document.py:382
-#: apps/knowledge/views/document.py:412 apps/knowledge/views/document.py:441
-#: apps/knowledge/views/document.py:472 apps/knowledge/views/document.py:501
-#: apps/knowledge/views/document.py:527 apps/knowledge/views/document.py:553
-#: apps/knowledge/views/document.py:579 apps/knowledge/views/document.py:599
-#: apps/knowledge/views/document.py:633 apps/knowledge/views/document.py:664
-#: apps/knowledge/views/document.py:695 apps/knowledge/views/document.py:723
-#: apps/knowledge/views/document.py:737
-#: apps/xpack/views/dataset_lark_views.py:72
-#: apps/xpack/views/dataset_lark_views.py:91
-#: apps/xpack/views/dataset_lark_views.py:111
-#: apps/xpack/views/dataset_lark_views.py:132
-msgid "Knowledge Base/Documentation"
-msgstr "知識庫/文檔"
-
-#: apps/knowledge/views/document.py:52 apps/knowledge/views/document.py:53
-#: apps/knowledge/views/document.py:54
-msgid "Get document"
-msgstr "獲取文檔"
-
-#: apps/knowledge/views/document.py:79 apps/knowledge/views/document.py:80
-#: apps/knowledge/views/document.py:81
-msgid "Get document details"
-msgstr "文檔文檔詳情"
-
-#: apps/knowledge/views/document.py:98 apps/knowledge/views/document.py:99
-#: apps/knowledge/views/document.py:100
-msgid "Modify document"
-msgstr "修改文檔"
-
-#: apps/knowledge/views/document.py:123 apps/knowledge/views/document.py:124
-#: apps/knowledge/views/document.py:125
-msgid "Delete document"
-msgstr "刪除文檔"
-
-#: apps/knowledge/views/document.py:154 apps/knowledge/views/document.py:155
-#: apps/knowledge/views/document.py:156
-msgid "Segmented document"
-msgstr "分段文檔"
-
-#: apps/knowledge/views/document.py:186 apps/knowledge/views/document.py:187
-#: apps/knowledge/views/document.py:188
-msgid "Get a list of segment IDs"
-msgstr "獲取分段列表"
-
-#: apps/knowledge/views/document.py:203 apps/knowledge/views/document.py:204
-#: apps/knowledge/views/document.py:205
-msgid "Modify document hit processing methods in batches"
-msgstr "批量修改文檔命中處理方法"
-
-#: apps/knowledge/views/document.py:232 apps/knowledge/views/document.py:233
-#: apps/knowledge/views/document.py:234
-msgid "Synchronize web site types"
-msgstr "同步網站類型"
-
-#: apps/knowledge/views/document.py:261 apps/knowledge/views/document.py:262
-#: apps/knowledge/views/document.py:263
-msgid "Refresh document vector library"
-msgstr "刷新文檔向量庫"
-
-#: apps/knowledge/views/document.py:289 apps/knowledge/views/document.py:290
-#: apps/knowledge/views/document.py:291
-msgid "Cancel task"
-msgstr "取消任務"
-
-#: apps/knowledge/views/document.py:317 apps/knowledge/views/document.py:318
-#: apps/knowledge/views/document.py:319
-msgid "Cancel tasks in batches"
-msgstr "批量取消任務"
-
-#: apps/knowledge/views/document.py:346 apps/knowledge/views/document.py:347
-#: apps/knowledge/views/document.py:348
-msgid "Create documents in batches"
-msgstr "批量創建文檔"
-
-#: apps/knowledge/views/document.py:376 apps/knowledge/views/document.py:377
-#: apps/knowledge/views/document.py:378
-msgid "Batch sync documents"
-msgstr "批量同步文檔"
-
-#: apps/knowledge/views/document.py:406 apps/knowledge/views/document.py:407
-#: apps/knowledge/views/document.py:408
-msgid "Delete documents in batches"
-msgstr "批量刪除文檔"
-
-#: apps/knowledge/views/document.py:436 apps/knowledge/views/document.py:437
-msgid "Batch refresh document vector library"
-msgstr "批量刷新文檔向量庫"
-
-#: apps/knowledge/views/document.py:466 apps/knowledge/views/document.py:467
-#: apps/knowledge/views/document.py:468
-msgid "Batch generate related problems"
-msgstr "批量生成相關問題"
-
-#: apps/knowledge/views/document.py:496 apps/knowledge/views/document.py:497
-#: apps/knowledge/views/document.py:498
-msgid "Get document by pagination"
-msgstr "分頁獲取文檔"
-
-#: apps/knowledge/views/document.py:523 apps/knowledge/views/document.py:524
-msgid "Export document"
-msgstr "導出文檔"
-
-#: apps/knowledge/views/document.py:549 apps/knowledge/views/document.py:550
-msgid "Export Zip document"
-msgstr "導出 Zip 文檔"
-
-#: apps/knowledge/views/document.py:575 apps/knowledge/views/document.py:576
-msgid "Download source file"
-msgstr "下載源文件"
-
-#: apps/knowledge/views/document.py:594 apps/knowledge/views/document.py:595
-msgid "Migrate documents in batches"
-msgstr "批量遷移文檔"
-
-#: apps/knowledge/views/document.py:627 apps/knowledge/views/document.py:628
-#: apps/knowledge/views/document.py:629
-#: apps/shared/views/shared_document.py:570
-msgid "Create Web site documents"
-msgstr "創建網站文檔"
-
-#: apps/knowledge/views/document.py:658 apps/knowledge/views/document.py:659
-#: apps/knowledge/views/document.py:660
-msgid "Import QA and create documentation"
-msgstr "導入問答並創建文檔"
-
-#: apps/knowledge/views/document.py:689 apps/knowledge/views/document.py:690
-#: apps/knowledge/views/document.py:691
-msgid "Import tables and create documents"
-msgstr "導入表格並創建文檔"
-
-#: apps/knowledge/views/document.py:719 apps/knowledge/views/document.py:720
-msgid "Get QA template"
-msgstr "獲取問答模板"
-
-#: apps/knowledge/views/document.py:733 apps/knowledge/views/document.py:734
-msgid "Get form template"
-msgstr "獲取表格模板"
-
-#: apps/knowledge/views/knowledge.py:25 apps/knowledge/views/knowledge.py:26
-#: apps/knowledge/views/knowledge.py:27
-msgid "Get knowledge by folder"
-msgstr "根據文件夾獲取知識庫"
-
-#: apps/knowledge/views/knowledge.py:30 apps/knowledge/views/knowledge.py:59
-#: apps/knowledge/views/knowledge.py:83 apps/knowledge/views/knowledge.py:106
-#: apps/knowledge/views/knowledge.py:127 apps/knowledge/views/knowledge.py:156
-#: apps/knowledge/views/knowledge.py:188 apps/knowledge/views/knowledge.py:218
-#: apps/knowledge/views/knowledge.py:242 apps/knowledge/views/knowledge.py:266
-#: apps/knowledge/views/knowledge.py:293 apps/knowledge/views/knowledge.py:319
-#: apps/knowledge/views/knowledge.py:343 apps/knowledge/views/knowledge.py:369
-#: apps/knowledge/views/knowledge.py:397
-#: apps/xpack/views/dataset_lark_views.py:29
-#: apps/xpack/views/dataset_lark_views.py:50
-msgid "Knowledge Base"
-msgstr "知識庫"
-
-#: apps/knowledge/views/knowledge.py:53 apps/knowledge/views/knowledge.py:54
-#: apps/knowledge/views/knowledge.py:55
-msgid "Edit knowledge"
-msgstr "修改知識庫"
-
-#: apps/knowledge/views/knowledge.py:77 apps/knowledge/views/knowledge.py:78
-#: apps/knowledge/views/knowledge.py:79
-msgid "Delete knowledge"
-msgstr "刪除知識庫"
-
-#: apps/knowledge/views/knowledge.py:101 apps/knowledge/views/knowledge.py:102
-#: apps/knowledge/views/knowledge.py:103
-msgid "Get knowledge"
-msgstr "獲取知識庫"
-
-#: apps/knowledge/views/knowledge.py:122 apps/knowledge/views/knowledge.py:123
-#: apps/knowledge/views/knowledge.py:124
-msgid "Get the knowledge base paginated list"
-msgstr "獲取知識庫分頁列表"
-
-#: apps/knowledge/views/knowledge.py:150 apps/knowledge/views/knowledge.py:151
-#: apps/knowledge/views/knowledge.py:152
-msgid "Synchronize the knowledge base of the website"
-msgstr "同步網站知識庫"
-
-#: apps/knowledge/views/knowledge.py:182 apps/knowledge/views/knowledge.py:183
-#: apps/knowledge/views/knowledge.py:184
-msgid "Hit test list"
-msgstr "命中測試列表"
-
-#: apps/knowledge/views/knowledge.py:212 apps/knowledge/views/knowledge.py:213
-#: apps/knowledge/views/knowledge.py:214
-msgid "Re-vectorize"
-msgstr "重新向量化"
-
-#: apps/knowledge/views/knowledge.py:238 apps/knowledge/views/knowledge.py:239
-msgid "Export knowledge base"
-msgstr "導出知識庫"
-
-#: apps/knowledge/views/knowledge.py:262 apps/knowledge/views/knowledge.py:263
-msgid "Export knowledge base containing images"
-msgstr "導出包含圖片的知識庫"
-
-#: apps/knowledge/views/knowledge.py:287 apps/knowledge/views/knowledge.py:288
-#: apps/knowledge/views/knowledge.py:289
-msgid "Generate related"
-msgstr "生成相關"
-
-#: apps/knowledge/views/knowledge.py:314 apps/knowledge/views/knowledge.py:315
-#: apps/knowledge/views/knowledge.py:316
-msgid "Get model for knowledge base"
-msgstr "獲取知識庫模型"
-
-#: apps/knowledge/views/knowledge.py:338 apps/knowledge/views/knowledge.py:339
-#: apps/knowledge/views/knowledge.py:340
-msgid "Get embedding model for knowledge base"
-msgstr "獲取知識庫向量模型"
-
-#: apps/knowledge/views/knowledge.py:363 apps/knowledge/views/knowledge.py:364
-#: apps/knowledge/views/knowledge.py:365
-msgid "Create base knowledge"
-msgstr "創建知識庫"
-
-#: apps/knowledge/views/knowledge.py:391 apps/knowledge/views/knowledge.py:392
-#: apps/knowledge/views/knowledge.py:393
-msgid "Create web knowledge"
-msgstr "創建 web 知識庫"
-
-#: apps/knowledge/views/paragraph.py:24 apps/knowledge/views/paragraph.py:25
-#: apps/knowledge/views/paragraph.py:26
-msgid "Paragraph list"
-msgstr "段落列表"
-
-#: apps/knowledge/views/paragraph.py:29 apps/knowledge/views/paragraph.py:53
-#: apps/knowledge/views/paragraph.py:82 apps/knowledge/views/paragraph.py:102
-#: apps/knowledge/views/paragraph.py:138 apps/knowledge/views/paragraph.py:167
-#: apps/knowledge/views/paragraph.py:199 apps/knowledge/views/paragraph.py:224
-#: apps/knowledge/views/paragraph.py:259 apps/knowledge/views/paragraph.py:289
-#: apps/knowledge/views/paragraph.py:316 apps/knowledge/views/paragraph.py:351
-#: apps/knowledge/views/paragraph.py:385 apps/knowledge/views/paragraph.py:415
-msgid "Knowledge Base/Documentation/Paragraph"
-msgstr "知識庫/文檔/段落"
-
-#: apps/knowledge/views/paragraph.py:48 apps/knowledge/views/paragraph.py:49
-msgid "Create Paragraph"
-msgstr "創建段落"
-
-#: apps/knowledge/views/paragraph.py:76 apps/knowledge/views/paragraph.py:77
-#: apps/knowledge/views/paragraph.py:78
-msgid "Batch Paragraph"
-msgstr "批量段落"
-
-#: apps/knowledge/views/paragraph.py:97 apps/knowledge/views/paragraph.py:98
-msgid "Migrate paragraphs in batches"
-msgstr "批量遷移段落"
-
-#: apps/knowledge/views/paragraph.py:132 apps/knowledge/views/paragraph.py:133
-#: apps/knowledge/views/paragraph.py:134
-msgid "Batch Generate Related"
-msgstr "批量生成相關"
-
-#: apps/knowledge/views/paragraph.py:161 apps/knowledge/views/paragraph.py:162
-#: apps/knowledge/views/paragraph.py:163
-msgid "Modify paragraph data"
-msgstr "修改段落數據"
-
-#: apps/knowledge/views/paragraph.py:194 apps/knowledge/views/paragraph.py:195
-#: apps/knowledge/views/paragraph.py:196
-msgid "Get paragraph details"
-msgstr "獲取段落詳情"
-
-#: apps/knowledge/views/paragraph.py:219 apps/knowledge/views/paragraph.py:220
-#: apps/knowledge/views/paragraph.py:221
-msgid "Delete paragraph"
-msgstr "刪除段落"
-
-#: apps/knowledge/views/paragraph.py:253 apps/knowledge/views/paragraph.py:254
-#: apps/knowledge/views/paragraph.py:255
-msgid "Add associated questions"
-msgstr "添加關聯問題"
-
-#: apps/knowledge/views/paragraph.py:284 apps/knowledge/views/paragraph.py:285
-#: apps/knowledge/views/paragraph.py:286
-msgid "Get a list of paragraph questions"
-msgstr "獲取段落問題列表"
-
-#: apps/knowledge/views/paragraph.py:310 apps/knowledge/views/paragraph.py:311
-#: apps/knowledge/views/paragraph.py:312
-msgid "Disassociation issue"
-msgstr "取消關聯問題"
-
-#: apps/knowledge/views/paragraph.py:345 apps/knowledge/views/paragraph.py:346
-#: apps/knowledge/views/paragraph.py:347
-msgid "Related questions"
-msgstr "關聯問題"
-
-#: apps/knowledge/views/paragraph.py:380 apps/knowledge/views/paragraph.py:381
-#: apps/knowledge/views/paragraph.py:382
-msgid "Get paragraph list by pagination"
-msgstr "獲取段落列表"
-
-#: apps/knowledge/views/paragraph.py:409 apps/knowledge/views/paragraph.py:410
-#: apps/knowledge/views/paragraph.py:411
-#: apps/resource_manage/views/paragraph.py:364
-#: apps/resource_manage/views/paragraph.py:365
-#: apps/resource_manage/views/paragraph.py:366
-#: apps/shared/views/shared_paragraph.py:365
-#: apps/shared/views/shared_paragraph.py:366
-#: apps/shared/views/shared_paragraph.py:367
-msgid "Adjust paragraph position"
-msgstr "調整段落位置"
-
-#: apps/knowledge/views/problem.py:23 apps/knowledge/views/problem.py:24
-#: apps/knowledge/views/problem.py:25
-msgid "Question list"
-msgstr "問題列表"
-
-#: apps/knowledge/views/problem.py:28 apps/knowledge/views/problem.py:53
-#: apps/knowledge/views/problem.py:78 apps/knowledge/views/problem.py:104
-#: apps/knowledge/views/problem.py:131 apps/knowledge/views/problem.py:157
-#: apps/knowledge/views/problem.py:186 apps/knowledge/views/problem.py:216
-msgid "Knowledge Base/Documentation/Paragraph/Question"
-msgstr "知識庫/文檔/段落/問題"
-
-#: apps/knowledge/views/problem.py:47 apps/knowledge/views/problem.py:48
-#: apps/knowledge/views/problem.py:49
-msgid "Create question"
-msgstr "創建問題"
-
-#: apps/knowledge/views/problem.py:73 apps/knowledge/views/problem.py:74
-#: apps/knowledge/views/problem.py:75
-msgid "Get a list of associated paragraphs"
-msgstr "獲取關聯段落列表"
-
-#: apps/knowledge/views/problem.py:98 apps/knowledge/views/problem.py:99
-#: apps/knowledge/views/problem.py:100
-msgid "Batch associated paragraphs"
-msgstr "批量關聯段落"
-
-#: apps/knowledge/views/problem.py:125 apps/knowledge/views/problem.py:126
-#: apps/knowledge/views/problem.py:127
-msgid "Batch deletion issues"
-msgstr "批量刪除問題"
-
-#: apps/knowledge/views/problem.py:152 apps/knowledge/views/problem.py:153
-#: apps/knowledge/views/problem.py:154
-msgid "Delete question"
-msgstr "刪除問題"
-
-#: apps/knowledge/views/problem.py:180 apps/knowledge/views/problem.py:181
-#: apps/knowledge/views/problem.py:182
-msgid "Modify question"
-msgstr "修改問題"
-
-#: apps/knowledge/views/problem.py:211 apps/knowledge/views/problem.py:212
-#: apps/knowledge/views/problem.py:213
-msgid "Get the list of questions by page"
-msgstr "分頁獲取問題列表"
-
-#: apps/maxkb/settings/base.py:101
-msgid "Intelligent customer service platform"
-msgstr "强大易用的企業級智能體平臺"
-
-#: apps/models_provider/api/model.py:37 apps/models_provider/api/provide.py:17
-#: apps/models_provider/api/provide.py:23
-#: apps/models_provider/api/provide.py:28
-#: apps/models_provider/api/provide.py:30
-#: apps/models_provider/api/provide.py:82
-#: apps/models_provider/serializers/model_serializer.py:40
-#: apps/models_provider/serializers/model_serializer.py:215
-#: apps/models_provider/serializers/model_serializer.py:253
-#: apps/models_provider/serializers/model_serializer.py:318
-#: apps/models_provider/serializers/model_serializer.py:393
-#: apps/shared/api/shared_model.py:18
-#: apps/shared/serializers/shared_model.py:111
-msgid "model name"
-msgstr "模型名稱"
-
-#: apps/models_provider/api/model.py:44 apps/models_provider/api/provide.py:29
-#: apps/models_provider/api/provide.py:70
-#: apps/models_provider/api/provide.py:98
-#: apps/models_provider/serializers/model_serializer.py:42
-#: apps/models_provider/serializers/model_serializer.py:217
-#: apps/models_provider/serializers/model_serializer.py:255
-#: apps/models_provider/serializers/model_serializer.py:319
-#: apps/models_provider/serializers/model_serializer.py:394
-#: apps/shared/api/shared_model.py:25
-#: apps/shared/serializers/shared_model.py:112
-msgid "model type"
-msgstr "模型類型"
-
-#: apps/models_provider/api/model.py:51
-#: apps/models_provider/serializers/model_serializer.py:43
-#: apps/models_provider/serializers/model_serializer.py:219
-#: apps/models_provider/serializers/model_serializer.py:256
-#: apps/models_provider/serializers/model_serializer.py:320
-#: apps/models_provider/serializers/model_serializer.py:395
-#: apps/shared/api/shared_model.py:32
-#: apps/shared/serializers/shared_model.py:113
-msgid "base model"
-msgstr "基礎模型"
-
-#: apps/models_provider/api/model.py:58 apps/models_provider/api/provide.py:18
-#: apps/models_provider/api/provide.py:38
-#: apps/models_provider/api/provide.py:76
-#: apps/models_provider/api/provide.py:104
-#: apps/models_provider/api/provide.py:126
-#: apps/models_provider/serializers/model_serializer.py:41
-#: apps/models_provider/serializers/model_serializer.py:254
-#: apps/models_provider/serializers/model_serializer.py:321
-#: apps/models_provider/serializers/model_serializer.py:396
-#: apps/shared/api/shared_model.py:39
-#: apps/shared/serializers/shared_model.py:114
-msgid "provider"
-msgstr "供應商"
-
-#: apps/models_provider/api/model.py:65
-#: apps/models_provider/serializers/model_serializer.py:322
-#: apps/models_provider/serializers/model_serializer.py:397
-#: apps/shared/api/shared_model.py:46
-#: apps/shared/serializers/shared_model.py:115
-msgid "create user"
-msgstr "創建用戶"
-
-#: apps/models_provider/api/provide.py:19
-#: apps/xpack/serializers/application_setting_serializer.py:41
-#: apps/xpack/serializers/system_params.py:21
-msgid "icon"
-msgstr "圖標"
-
-#: apps/models_provider/api/provide.py:34 apps/tools/serializers/tool.py:134
-msgid "input type"
-msgstr "輸入類型"
-
-#: apps/models_provider/api/provide.py:35
-msgid "label"
-msgstr "標籤"
-
-#: apps/models_provider/api/provide.py:36
-msgid "text field"
-msgstr "文本欄位"
-
-#: apps/models_provider/api/provide.py:37
-msgid "value field"
-msgstr "值"
-
-#: apps/models_provider/api/provide.py:39
-msgid "method"
-msgstr "方法"
-
-#: apps/models_provider/api/provide.py:40 apps/tools/serializers/tool.py:119
-#: apps/tools/serializers/tool.py:133
-msgid "required"
-msgstr "必填"
-
-#: apps/models_provider/api/provide.py:41
-msgid "default value"
-msgstr "默認值"
-
-#: apps/models_provider/api/provide.py:42
-msgid "relation show field dict"
-msgstr "關係顯示欄位"
-
-#: apps/models_provider/api/provide.py:43
-msgid "relation trigger field dict"
-msgstr "關係觸發欄位"
-
-#: apps/models_provider/api/provide.py:44
-msgid "trigger type"
-msgstr "觸發類型"
-
-#: apps/models_provider/api/provide.py:45
-msgid "attrs"
-msgstr "屬性"
-
-#: apps/models_provider/api/provide.py:46
-msgid "props info"
-msgstr "props 信息"
-
-#: apps/models_provider/base_model_provider.py:60
-msgid "Model type cannot be empty"
-msgstr "模型類型不能為空"
-
-#: apps/models_provider/base_model_provider.py:85
-msgid "The current platform does not support downloading models"
-msgstr "當前平臺不支持下載模型"
-
-#: apps/models_provider/base_model_provider.py:143
-msgid "LLM"
-msgstr "大語言模型"
-
-#: apps/models_provider/base_model_provider.py:144
-msgid "Embedding Model"
-msgstr "向量模型"
-
-#: apps/models_provider/base_model_provider.py:145
-msgid "Speech2Text"
-msgstr "語音識別"
-
-#: apps/models_provider/base_model_provider.py:146
-msgid "TTS"
-msgstr "語音合成"
-
-#: apps/models_provider/base_model_provider.py:147
-msgid "Vision Model"
-msgstr "視覺模型"
-
-#: apps/models_provider/base_model_provider.py:148
-msgid "Image Generation"
-msgstr "圖片生成"
-
-#: apps/models_provider/base_model_provider.py:149
-msgid "Rerank"
-msgstr "重排模型"
-
-#: apps/models_provider/base_model_provider.py:223
-msgid "The model does not support"
-msgstr "模型不支持"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:42
-msgid ""
-"With the GTE-Rerank text sorting series model developed by Alibaba Tongyi "
-"Lab, developers can integrate high-quality text retrieval and sorting "
-"through the LlamaIndex framework."
-msgstr ""
-"阿里巴巴通義實驗室開發的GTE-Rerank文本排序系列模型，開發者可以通過LlamaIndex"
-"框架進行集成高質量文本檢索、排序。"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:45
-msgid ""
-"Chinese (including various dialects such as Cantonese), English, Japanese, "
-"and Korean support free switching between multiple languages."
-msgstr "中文（含粵語等各種方言）、英文、日語、韓語支持多個語種自由切換"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:48
-msgid ""
-"CosyVoice is based on a new generation of large generative speech models, "
-"which can predict emotions, intonation, rhythm, etc. based on context, and "
-"has better anthropomorphic effects."
-msgstr ""
-"CosyVoice基於新一代生成式語音大模型，能根據上下文預測情緒、語調、韻律等，具有"
-"更好的擬人效果"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:51
-msgid ""
-"Universal text vector is Tongyi Lab's multi-language text unified vector "
-"model based on the LLM base. It provides high-level vector services for "
-"multiple mainstream languages around the world and helps developers quickly "
-"convert text data into high-quality vector data."
-msgstr ""
-"通用文本向量，是通義實驗室基於LLM底座的多語言文本統一向量模型，面向全球多個主"
-"流語種，提供高水準的向量服務，幫助開發者將文本數據快速轉換為高質量的向量數"
-"據。"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:69
-msgid ""
-"Tongyi Wanxiang - a large image model for text generation, supports "
-"bilingual input in Chinese and English, and supports the input of reference "
-"pictures for reference content or reference style migration. Key styles "
-"include but are not limited to watercolor, oil painting, Chinese painting, "
-"sketch, flat illustration, two-dimensional, and 3D. Cartoon."
-msgstr ""
-"通義萬相-文本生成圖像大模型，支持中英文雙語輸入，支持輸入參考圖片進行參考內容"
-"或者參考風格遷移，重點風格包括但不限於水彩、油畫、中國畫、素描、扁平插畫、二"
-"次元、3D卡通。"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:95
-msgid "Alibaba Cloud Bailian"
-msgstr "阿里雲百鍊"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:53
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:50
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:74
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:77
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:61
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tti.py:43
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py:37
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:33
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:34
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:53
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:37
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:40
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:69
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:32
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/gemini_model_provider/model/stt.py:43
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:37
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:37
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:44
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:35
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:35
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:58
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:37
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:58
-#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:23
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:37
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:51
-#: apps/models_provider/impl/tencent_model_provider/model/tti.py:54
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:50
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:36
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:32
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/volcanic_engine_model_provider/model/tts.py:77
-#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:60
-#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:76
-#: apps/models_provider/impl/xf_model_provider/model/tts.py:101
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:32
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:50
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:34
-#: apps/models_provider/impl/xinference_model_provider/model/tts.py:44
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:31
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:56
-#: apps/models_provider/impl/zhipu_model_provider/model/tti.py:49
-msgid "Hello"
-msgstr "你好"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:36
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:46
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt.py:44
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:96
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:89
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:23
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:21
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:40
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:30
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/azure_model_provider/credential/stt.py:23
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:58
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:41
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:22
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:21
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:28
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/ollama_model_provider/credential/image.py:19
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:44
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:27
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:31
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:25
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:48
-#: apps/models_provider/impl/openai_model_provider/credential/stt.py:22
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:61
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:40
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:25
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:28
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:22
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:61
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:22
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:19
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:28
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:78
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/vllm_model_provider/credential/image.py:22
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:39
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:26
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:22
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:25
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:41
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:51
-#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:46
-#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:27
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:29
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/xf_model_provider/credential/stt.py:24
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:47
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:19
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:22
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:39
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:25
-#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:21
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:59
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:39
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:21
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:40
-#, python-brace-format
-msgid "{model_type} Model type is not supported"
-msgstr "{model_type} 模型類型不支持"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:44
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:67
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:55
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt.py:53
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:105
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:98
-#, python-brace-format
-msgid "{key} is required"
-msgstr "{key} 是必填項"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:60
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:85
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:69
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt.py:67
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:121
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:113
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:43
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:65
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:42
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:61
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:50
-#: apps/models_provider/impl/azure_model_provider/credential/stt.py:40
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:77
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:58
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:65
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:42
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:38
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:64
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:44
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:45
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:51
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:45
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:67
-#: apps/models_provider/impl/openai_model_provider/credential/stt.py:39
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:80
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:58
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:45
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:44
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:39
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:80
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:40
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:30
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:47
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:57
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:104
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/vllm_model_provider/credential/image.py:42
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:55
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:43
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:42
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:66
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:42
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:58
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:68
-#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:38
-#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:38
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:50
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:84
-#: apps/models_provider/impl/xf_model_provider/credential/stt.py:41
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:65
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:41
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:40
-#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:37
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:77
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:56
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:41
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:64
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:59
-#, python-brace-format
-msgid ""
-"Verification failed, please check whether the parameters are correct: {error}"
-msgstr "認證失敗，請檢查參數是否正確：{error}"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:17
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:14
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:20
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:14
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:22
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:41
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:22
-msgid "Temperature"
-msgstr "溫度"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:18
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:21
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:15
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:16
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:42
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:16
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:23
-msgid ""
-"Higher values make the output more random, while lower values make it more "
-"focused and deterministic"
-msgstr "較高的數值會使輸出更加隨機，而較低的數值會使其更加集中和確定"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:30
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:23
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:43
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:29
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:50
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:31
-msgid "Output the maximum Tokens"
-msgstr "輸出最大Token數"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:31
-msgid "Specify the maximum number of tokens that the model can generate."
-msgstr "指定模型可以生成的最大 tokens 數"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:43
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:15
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:74
-msgid "API URL"
-msgstr ""
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:15
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:14
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:15
-msgid "Image size"
-msgstr "图片尺寸"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:15
-msgid "Specify the size of the generated image, such as: 1024x1024"
-msgstr "指定生成圖片的尺寸, 如: 1024x1024"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:34
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:40
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:43
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:43
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:41
-msgid "Number of pictures"
-msgstr "圖片數量"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:34
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:40
-msgid "Specify the number of generated images"
-msgstr "指定生成圖片的數量"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:44
-msgid "Style"
-msgstr "風格"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:44
-msgid "Specify the style of generated images"
-msgstr "指定生成圖片的風格"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:48
-msgid "Default value, the image style is randomly output by the model"
-msgstr "默認值，圖片風格由模型隨機輸出"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:49
-msgid "photography"
-msgstr "攝影"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:50
-msgid "Portraits"
-msgstr "人像寫真"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:51
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:52
 msgid "3D cartoon"
 msgstr "3D卡通"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:52
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:102
+msgid "7B dense converter for rapid deployment and easy customization. Small in size yet powerful in a variety of use cases. Supports English and code, as well as 32k context windows."
+msgstr "7B 密集型轉換器，可快速部署，易於定製。體積雖小，但功能強大，適用於各種用例。支持英語和代碼，以及 32k 的上下文窗口。"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:47
+msgid "A better routing strategy is adopted to simultaneously alleviate the problems of load balancing and expert convergence. For long articles, the needle-in-a-haystack index reaches 99.9%"
+msgstr "採用更優的路由策略，同時緩解了負載均衡和專家趨同的問題。長文方面，大海撈針指標達到99.9%"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:76
+msgid "A faster, more affordable but still very powerful model that can handle a range of tasks including casual conversation, text analysis, summarization and document question answering."
+msgstr "一種更快速、更實惠但仍然非常強大的模型，它可以處理一系列任務，包括隨意對話、文本分析、摘要和文檔問題回答。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:162
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:197
+msgid "A high-performance open embedding model with a large token context window."
+msgstr "一個具有大 tokens上下文窗口的高性能開放嵌入模型。"
+
+#: apps/common/constants/permission_constants.py:1291
+msgid "About"
+msgstr "關於"
+
+#: apps/chat/serializers/chat_record.py:122
+msgid "Abstract"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:24
+msgid "accent"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:24
+msgid "Access Key ID"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:374
+msgid "Access restrictions"
+msgstr "訪問限制"
+
+#: apps/oss/serializers/file.py:198
+msgid "Access to internal IP addresses is blocked"
+msgstr ""
+
+#: apps/chat/api/chat_authentication_api.py:45
+#: apps/chat/serializers/chat_authentication.py:27
+#: apps/chat/serializers/chat_authentication.py:53
+msgid "access_token"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:172
+msgid "accurate"
+msgstr "內容準確"
+
+#: apps/application/serializers/application.py:207
+msgid "Acquaintance"
+msgstr "相似度"
+
+#: apps/trigger/views/trigger.py:201
+#: apps/trigger/views/trigger.py:202
+#: apps/trigger/views/trigger.py:203
+msgid "Activate trigger in batches"
+msgstr "批次啟用/停用觸發器"
+
+#: apps/homepage/api/home_page_api.py:385
+msgid "Active model count"
+msgstr "啟用模型數量"
+
+#: apps/homepage/api/home_page_api.py:348
+msgid "Active tool count"
+msgstr "啟用工具數量"
+
+#: apps/homepage/serializers/homepage.py:492
+#: apps/homepage/serializers/homepage.py:629
+msgid "active users"
+msgstr "活躍用戶數"
+
+#: no source
+msgid "Add ApiKey"
+msgstr "添加 API KEY"
+
+#: apps/tools/views/tool.py:547
+#: apps/tools/views/tool.py:548
+#: apps/tools/views/tool.py:549
+msgid "Add Appstore tool"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:276
+#: apps/knowledge/views/paragraph.py:277
+#: apps/knowledge/views/paragraph.py:278
+msgid "Add associated questions"
+msgstr "添加關聯問題"
+
+#: apps/knowledge/views/document.py:1039
+#: apps/knowledge/views/document.py:1040
+#: apps/knowledge/views/document.py:1041
+msgid "Add document tags"
+msgstr ""
+
+#: apps/tools/views/tool.py:500
+#: apps/tools/views/tool.py:501
+#: apps/tools/views/tool.py:502
+msgid "Add internal tool"
+msgstr "添加内置工具"
+
+#: apps/common/constants/permission_constants.py:365
+msgid "Add Member"
+msgstr "添加成員"
+
+#: no source
+msgid "Add member to chat user group"
+msgstr "添加成員到對話用戶組"
+
+#: no source
+msgid "Add member to system role"
+msgstr "系統角色添加成員"
+
+#: no source
+msgid "Add member to system workspace"
+msgstr "系統工作空間添加成員"
+
+#: no source
+msgid "Add member to user group"
+msgstr "添加成員到用戶組"
+
+#: no source
+msgid "Add member to workspace"
+msgstr "工作空間添加成員"
+
+#: no source
+msgid "Add member to workspace role"
+msgstr "工作空間角色添加成員"
+
+#: no source
+msgid "Add or modify authentication configuration"
+msgstr "添加或修改認證配置"
+
+#: no source
+msgid "Add or modify Chat/Authentication Configuration"
+msgstr "添加或修改對話/認證配置"
+
+#: no source
+msgid "Add personal system API_KEY"
+msgstr "添加個人系統API KEY"
+
+#: no source
+msgid "Add shared associated questions"
+msgstr "添加關聯問題"
+
+#: no source
+msgid "Add system associated questions"
+msgstr "添加關聯問題"
+
+#: apps/application/views/application_chat_record.py:116
+#: apps/application/views/application_chat_record.py:117
+#: apps/application/views/application_chat_record.py:118
+#: apps/common/constants/permission_constants.py:382
+msgid "Add to Knowledge Base"
+msgstr "添加到知識庫"
+
+#: no source
+msgid "Add user"
+msgstr "添加用戶"
+
+#: apps/knowledge/views/paragraph.py:446
+#: apps/knowledge/views/paragraph.py:447
+#: apps/knowledge/views/paragraph.py:448
+msgid "Adjust paragraph position"
+msgstr "調整段落位置"
+
+#: no source
+msgid "ADMIN"
+msgstr "系統管理員"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:108
+msgid "Advanced Mistral AI large-scale language model capable of handling any language task, including complex multilingual reasoning, text understanding, transformation, and code generation."
+msgstr "先進的 Mistral AI 大型語言模型，能夠處理任何語言任務，包括複雜的多語言推理、文本理解、轉換和代碼生成。"
+
+#: apps/application/serializers/application.py:468
+#: apps/application/serializers/application.py:468
+msgid "Affiliation user"
+msgstr "關聯用戶"
+
+#: no source
+msgid "Agent ID is required"
+msgstr "Agent ID 是必填項"
+
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:417
+#: apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py:386
+msgid "Agent Key is required for agent tool 【{name}】"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:411
+#: apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py:380
+msgid "Agent 【{name}】 access token authentication is not supported for agent tool"
+msgstr ""
+
+#: no source
+msgid "AI reply: "
+msgstr "AI 回復: "
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:240
+msgid "Alibaba Cloud Bailian"
+msgstr "阿里雲百鍊"
+
+#: no source
+msgid "Allow cross domain"
+msgstr "允許跨域"
+
+#: apps/knowledge/serializers/paragraph.py:167
+msgid "Already associated, please do not associate again"
+msgstr "已關聯，請勿再次關聯"
+
+#: apps/chat/serializers/chat_record.py:94
+msgid "Already voted, please cancel first and then vote again"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:96
+msgid "Amazon Titan Text Express has context lengths of up to 8,000 tokens, making it ideal for a variety of high-level general language tasks, such as open-ended text generation and conversational chat, as well as support in retrieval-augmented generation (RAG). At launch, the model is optimized for English, but other languages are supported."
+msgstr "Amazon Titan Text Express 的上下文長度長達 8000 個 tokens，因而非常適合各種高級常規語言任務，例如開放式文本生成和對話式聊天，以及檢索增強生成（RAG）中的支持。在發布時，該模型針對英語進行了優化，但也支持其他語言。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:90
+msgid "Amazon Titan Text Lite is a lightweight, efficient model ideal for fine-tuning English-language tasks, including summarization and copywriting, where customers require smaller, more cost-effective, and highly customizable models."
+msgstr "Amazon Titan Text Lite 是一種輕量級的高效模型，非常適合英語任務的微調，包括摘要和文案寫作等，在這種場景下，客戶需要更小、更經濟高效且高度可定製的模型"
+
+#: no source
+msgid "An error occurred while processing the GET request {e}"
+msgstr "get 請求處理時發生錯誤 {e}"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:41
+msgid "An update to Claude 2 that doubles the context window and improves reliability, hallucination rates, and evidence-based accuracy in long documents and RAG contexts."
+msgstr "Claude 2 的更新，採用雙倍的上下文窗口，並在長文檔和 RAG 上下文中提高可靠性、幻覺率和循證準確性。"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:53
 msgid "animation"
 msgstr "動畫"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:53
-msgid "painting"
-msgstr "油畫"
+#: no source
+msgid "Animation 1.3.0-Vincent Picture"
+msgstr "動漫1.3.0-文生圖"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:54
-msgid "watercolor"
-msgstr "水彩"
+#: no source
+msgid "Animation 1.3.1-Vincent Picture"
+msgstr "動漫1.3.1-文生圖"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:55
-msgid "sketch"
-msgstr "素描"
+#: apps/application/serializers/application_chat.py:220
+#: apps/application/views/application_chat_record.py:165
+#: apps/application/views/application_chat_record.py:166
+#: apps/application/views/application_chat_record.py:167
+#: apps/common/constants/permission_constants.py:370
+msgid "Annotation"
+msgstr "标注"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:56
-msgid "Chinese painting"
-msgstr "中國畫"
+#: apps/application/serializers/application_chat.py:216
+msgid "answer"
+msgstr "回答"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:57
-msgid "flat illustration"
-msgstr "扁平插畫"
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:48
+msgid "Anthropic is a powerful model that can handle a variety of tasks, from complex dialogue and creative content generation to detailed command obedience."
+msgstr "Anthropic 功能強大的模型，可處理各種任務，從複雜的對話和創意內容生成到詳細的指令服從。"
 
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:20
-msgid "Timbre"
-msgstr "音色"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:20
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:15
-msgid "Chinese sounds can support mixed scenes of Chinese and English"
-msgstr "中文音色支持中英文混合場景"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:26
-msgid "Long Xiaochun"
-msgstr "龍小淳"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:27
-msgid "Long Xiaoxia"
-msgstr "龍小夏"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:28
-msgid "Long Xiaochen"
-msgstr "龍小誠"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:29
-msgid "Long Xiaobai"
-msgstr "龍小白"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:30
-msgid "Long Laotie"
-msgstr "龍老鐵"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:31
-msgid "Long Shu"
-msgstr "龍書"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:32
-msgid "Long Shuo"
-msgstr "龍碩"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:33
-msgid "Long Jing"
-msgstr "龍婧"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:34
-msgid "Long Miao"
-msgstr "龍妙"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:35
-msgid "Long Yue"
-msgstr "龍悅"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:36
-msgid "Long Yuan"
-msgstr "龍媛"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:37
-msgid "Long Fei"
-msgstr "龍飛"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:38
-msgid "Long Jielidou"
-msgstr "龍傑力豆"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:39
-msgid "Long Tong"
-msgstr "龍彤"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:40
-msgid "Long Xiang"
-msgstr "龍祥"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:47
-msgid "Speaking speed"
-msgstr "語速"
-
-#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:47
-msgid "[0.5, 2], the default is 1, usually one decimal place is enough"
-msgstr "[0.5,2]，默認為1，通常一位小數就足夠了"
-
-#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:28
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:32
-#: apps/models_provider/impl/azure_model_provider/credential/image.py:35
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:64
-#: apps/models_provider/impl/azure_model_provider/credential/stt.py:28
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:63
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:46
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/gemini_model_provider/credential/image.py:27
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:26
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:32
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:46
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:62
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:63
-#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/openai_model_provider/credential/image.py:30
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:53
-#: apps/models_provider/impl/openai_model_provider/credential/stt.py:27
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:66
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:45
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:30
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:32
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:27
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:66
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:27
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/tencent_model_provider/credential/image.py:32
-#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/vllm_model_provider/credential/image.py:27
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:65
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:31
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:27
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:52
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:30
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:46
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:56
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:55
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:72
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:34
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:71
-#: apps/models_provider/impl/xf_model_provider/credential/stt.py:29
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:52
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:40
-#: apps/models_provider/impl/xinference_model_provider/credential/image.py:27
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:59
-#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:29
-#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:26
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:64
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:44
-#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:26
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:51
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:45
-#, python-brace-format
-msgid "{key}  is required"
-msgstr "{key} 是必填項"
-
-#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:24
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:33
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:44
-#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:30
-#: apps/models_provider/impl/openai_model_provider/credential/llm.py:33
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:25
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:32
-#: apps/models_provider/impl/xf_model_provider/credential/llm.py:51
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:25
-#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:32
-msgid "Specify the maximum number of tokens that the model can generate"
-msgstr "指定模型可以生成的最大 tokens 數"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:36
-msgid ""
-"An update to Claude 2 that doubles the context window and improves "
-"reliability, hallucination rates, and evidence-based accuracy in long "
-"documents and RAG contexts."
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:21
+msgid "API"
 msgstr ""
-"Claude 2 的更新，採用雙倍的上下文窗口，並在長文檔和 RAG 上下文中提高可靠性、"
-"幻覺率和循證準確性。"
 
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:43
-msgid ""
-"Anthropic is a powerful model that can handle a variety of tasks, from "
-"complex dialogue and creative content generation to detailed command "
-"obedience."
-msgstr ""
-"Anthropic 功能強大的模型，可處理各種任務，從複雜的對話和創意內容生成到詳細的"
-"指令服從。"
+#: apps/application/serializers/application_chat.py:289
+msgid "API Call"
+msgstr "API 調用"
 
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:50
-msgid ""
-"The Claude 3 Haiku is Anthropic's fastest and most compact model, with near-"
-"instant responsiveness. The model can answer simple queries and requests "
-"quickly. Customers will be able to build seamless AI experiences that mimic "
-"human interactions. Claude 3 Haiku can process images and return text "
-"output, and provides 200K context windows."
-msgstr ""
-"Claude 3 Haiku 是 Anthropic 最快速、最緊湊的模型，具有近乎即時的響應能力。該"
-"模型可以快速回答簡單的查詢和請求。客戶將能夠構建模仿人類交互的無縫人工智能體"
-"驗。 Claude 3 Haiku 可以處理圖像和返回文本輸出，並且提供 200K 上下文窗口。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:57
-msgid ""
-"The Claude 3 Sonnet model from Anthropic strikes the ideal balance between "
-"intelligence and speed, especially when it comes to handling enterprise "
-"workloads. This model offers maximum utility while being priced lower than "
-"competing products, and it's been engineered to be a solid choice for "
-"deploying AI at scale."
-msgstr ""
-"Anthropic 推出的 Claude 3 Sonnet 模型在智能和速度之間取得理想的平衡，尤其是在"
-"處理企業工作負載方面。該模型提供最大的效用，同時價格低於競爭產品，並且其經過"
-"精心設計，是大規模部署人工智慧的可靠選擇。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:64
-msgid ""
-"The Claude 3.5 Sonnet raises the industry standard for intelligence, "
-"outperforming competing models and the Claude 3 Opus in extensive "
-"evaluations, with the speed and cost-effectiveness of our mid-range models."
-msgstr ""
-"Claude 3.5 Sonnet提高了智能的行業標準，在廣泛的評估中超越了競爭對手的型號和"
-"Claude 3 Opus，具有我們中端型號的速度和成本效益。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:71
-msgid ""
-"A faster, more affordable but still very powerful model that can handle a "
-"range of tasks including casual conversation, text analysis, summarization "
-"and document question answering."
-msgstr ""
-"一種更快速、更實惠但仍然非常強大的模型，它可以處理一系列任務，包括隨意對話、"
-"文本分析、摘要和文檔問題回答。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:78
-msgid ""
-"Titan Text Premier is the most powerful and advanced model in the Titan Text "
-"series, designed to deliver exceptional performance for a variety of "
-"enterprise applications. With its cutting-edge features, it delivers greater "
-"accuracy and outstanding results, making it an excellent choice for "
-"organizations looking for a top-notch text processing solution."
-msgstr ""
-"Titan Text Premier 是 Titan Text 系列中功能強大且先進的型號，旨在為各種企業應"
-"用程序提供卓越的性能。憑藉其尖端功能，它提供了更高的準確性和出色的結果，使其"
-"成為尋求一流文本處理解決方案的組織的絕佳選擇。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:85
-msgid ""
-"Amazon Titan Text Lite is a lightweight, efficient model ideal for fine-"
-"tuning English-language tasks, including summarization and copywriting, "
-"where customers require smaller, more cost-effective, and highly "
-"customizable models."
-msgstr ""
-"Amazon Titan Text Lite 是一種輕量級的高效模型，非常適合英語任務的微調，包括摘"
-"要和文案寫作等，在這種場景下，客戶需要更小、更經濟高效且高度可定製的模型"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:91
-msgid ""
-"Amazon Titan Text Express has context lengths of up to 8,000 tokens, making "
-"it ideal for a variety of high-level general language tasks, such as open-"
-"ended text generation and conversational chat, as well as support in "
-"retrieval-augmented generation (RAG). At launch, the model is optimized for "
-"English, but other languages are supported."
-msgstr ""
-"Amazon Titan Text Express 的上下文長度長達 8000 個 tokens，因而非常適合各種高"
-"級常規語言任務，例如開放式文本生成和對話式聊天，以及檢索增強生成（RAG）中的支"
-"持。在發布時，該模型針對英語進行了優化，但也支持其他語言。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:97
-msgid ""
-"7B dense converter for rapid deployment and easy customization. Small in "
-"size yet powerful in a variety of use cases. Supports English and code, as "
-"well as 32k context windows."
-msgstr ""
-"7B 密集型轉換器，可快速部署，易於定製。體積雖小，但功能強大，適用於各種用例。"
-"支持英語和代碼，以及 32k 的上下文窗口。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:103
-msgid ""
-"Advanced Mistral AI large-scale language model capable of handling any "
-"language task, including complex multilingual reasoning, text understanding, "
-"transformation, and code generation."
-msgstr ""
-"先進的 Mistral AI 大型語言模型，能夠處理任何語言任務，包括複雜的多語言推理、"
-"文本理解、轉換和代碼生成。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:109
-msgid ""
-"Ideal for content creation, conversational AI, language understanding, R&D, "
-"and enterprise applications"
-msgstr "非常適合內容創作、對話式人工智慧、語言理解、研發和企業智能體"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:115
-msgid ""
-"Ideal for limited computing power and resources, edge devices, and faster "
-"training times."
-msgstr "非常適合有限的計算能力和資源、邊緣設備和更快的訓練時間。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:123
-msgid ""
-"Titan Embed Text is the largest embedding model in the Amazon Titan Embed "
-"series and can handle various text embedding tasks, such as text "
-"classification, text similarity calculation, etc."
-msgstr ""
-"Titan Embed Text 是 Amazon Titan Embed 系列中最大的嵌入模型，可以處理各種文本"
-"嵌入任務，如文本分類、文本相似度計算等。"
-
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:28
-#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:47
-#, python-brace-format
-msgid "The following fields are required: {keys}"
-msgstr "以下欄位是必填項: {keys}"
-
-#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:44
-#: apps/models_provider/impl/azure_model_provider/credential/llm.py:76
-msgid "Verification failed, please check whether the parameters are correct"
-msgstr "認證失敗，請檢查參數是否正確"
-
-#: apps/models_provider/impl/azure_model_provider/credential/tti.py:28
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:29
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:29
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:28
-msgid "Picture quality"
-msgstr "圖片質量"
-
-#: apps/models_provider/impl/azure_model_provider/credential/tts.py:17
-#: apps/models_provider/impl/openai_model_provider/credential/tts.py:17
-msgid ""
-"Try out the different sounds (Alloy, Echo, Fable, Onyx, Nova, and Sparkle) "
-"to find one that suits your desired tone and audience. The current voiceover "
-"is optimized for English."
-msgstr ""
-"嘗試不同的聲音（合金、回聲、寓言、縞瑪瑙、新星和閃光），找到一種適合您所需的"
-"音調和聽眾的聲音。當前的語音針對英語進行了優化。"
-
-#: apps/models_provider/impl/deepseek_model_provider/deepseek_model_provider.py:24
-msgid "Good at common conversational tasks, supports 32K contexts"
-msgstr "擅長通用對話任務，支持 32K 上下文"
-
-#: apps/models_provider/impl/deepseek_model_provider/deepseek_model_provider.py:29
-msgid "Good at handling programming tasks, supports 16K contexts"
-msgstr "擅長處理編程任務，支持 16K 上下文"
-
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:32
-msgid "Latest Gemini 1.0 Pro model, updated with Google update"
-msgstr "最新的 Gemini 1.0 Pro 模型，更新了 Google 更新"
-
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:36
-msgid "Latest Gemini 1.0 Pro Vision model, updated with Google update"
-msgstr "最新的Gemini 1.0 Pro Vision模型，隨Google更新而更新"
-
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:43
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:47
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:54
-#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:58
-msgid "Latest Gemini 1.5 Flash model, updated with Google updates"
-msgstr "最新的Gemini 1.5 Flash模型，隨Google更新而更新"
-
-#: apps/models_provider/impl/gemini_model_provider/model/stt.py:53
-msgid "convert audio to text"
-msgstr "將音頻轉換為文本"
-
-#: apps/models_provider/impl/local_model_provider/credential/embedding.py:53
-#: apps/models_provider/impl/local_model_provider/credential/reranker.py:54
-msgid "Model catalog"
-msgstr "模型目錄"
-
-#: apps/models_provider/impl/local_model_provider/local_model_provider.py:39
-msgid "local model"
-msgstr "本地模型"
+#: no source
+msgid "API Details"
+msgstr "API詳情"
 
 #: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:30
-#: apps/models_provider/impl/ollama_model_provider/credential/image.py:23
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:43
 #: apps/models_provider/impl/ollama_model_provider/credential/llm.py:48
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:35
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:43
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:45
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:42
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:43
 #: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:24
 #: apps/models_provider/impl/xinference_model_provider/credential/llm.py:44
 msgid "API domain name is invalid"
 msgstr "API 域名無效"
 
-#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:35
-#: apps/models_provider/impl/ollama_model_provider/credential/image.py:28
-#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:53
-#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:40
-#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:47
-#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:30
-#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:48
-msgid "The model does not exist, please download the model first"
-msgstr "模型不存在，請先下載模型"
+#: apps/application/flow/step_node/application_node/i_application_node.py:18
+msgid "API Input Fields"
+msgstr "API 輸入欄位"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:56
-msgid ""
-"Llama 2 is a set of pretrained and fine-tuned generative text models ranging "
-"in size from 7 billion to 70 billion. This is a repository of 7B pretrained "
-"models. Links to other models can be found in the index at the bottom."
+#: apps/common/constants/permission_constants.py:376
+msgid "API KEY"
 msgstr ""
-"Llama 2 是一組經過預訓練和微調的生成文本模型，其規模從 70 億到 700 億個不等。"
-"這是 7B 預訓練模型的存儲庫。其他模型的連結可以在底部的索引中找到。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:60
-msgid ""
-"Llama 2 is a set of pretrained and fine-tuned generative text models ranging "
-"in size from 7 billion to 70 billion. This is a repository of 13B pretrained "
-"models. Links to other models can be found in the index at the bottom."
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:43
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:14
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:31
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:21
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:35
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:74
+msgid "API Key"
 msgstr ""
-"Llama 2 是一組經過預訓練和微調的生成文本模型，其規模從 70 億到 700 億個不等。"
-"這是 13B 預訓練模型的存儲庫。其他模型的連結可以在底部的索引中找到。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:64
-msgid ""
-"Llama 2 is a set of pretrained and fine-tuned generative text models ranging "
-"in size from 7 billion to 70 billion. This is a repository of 70B pretrained "
-"models. Links to other models can be found in the index at the bottom."
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:95
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:87
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:44
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:42
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:31
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:13
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:30
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:20
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:70
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:83
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:47
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:34
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:73
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:74
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:52
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:29
+msgid "API URL"
 msgstr ""
-"Llama 2 是一組經過預訓練和微調的生成文本模型，其規模從 70 億到 700 億個不等。"
-"這是 70B 預訓練模型的存儲庫。其他模型的連結可以在底部的索引中找到。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:68
-msgid ""
-"Since the Chinese alignment of Llama2 itself is weak, we use the Chinese "
-"instruction set to fine-tune meta-llama/Llama-2-13b-chat-hf with LoRA so "
-"that it has strong Chinese conversation capabilities."
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:20
+msgid "API Version"
 msgstr ""
-"由於Llama2本身的中文對齊較弱，我們採用中文指令集，對meta-llama/Llama-2-13b-"
-"chat-hf進行LoRA微調，使其具備較強的中文對話能力。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:72
-msgid ""
-"Meta Llama 3: The most capable public product LLM to date. 8 billion "
-"parameters."
-msgstr "Meta Llama 3：迄今為止最有能力的公開產品LLM。80億參數。"
+#: apps/application/serializers/application_api_key.py:106
+msgid "APIKey does not exist"
+msgstr "APIKey 不存在"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:76
-msgid ""
-"Meta Llama 3: The most capable public product LLM to date. 70 billion "
-"parameters."
-msgstr "Meta Llama 3：迄今為止最有能力的公開產品LLM。700億參數。"
+#: apps/application/serializers/application_api_key.py:76
+msgid "ApiKeyId"
+msgstr "ApiKey ID"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:80
-msgid ""
-"Compared with previous versions, qwen 1.5 0.5b has significantly enhanced "
-"the model's alignment with human preferences and its multi-language "
-"processing capabilities. Models of all sizes support a context length of "
-"32768 tokens. 500 million parameters."
+#: no source
+msgid "App ID is required"
+msgstr "App ID 是必填項"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:47
+msgid "App IDs"
 msgstr ""
-"qwen 1.5 0.5b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有"
-"顯著增強。所有規模的模型都支持32768個tokens的上下文長度。5億參數。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:84
-msgid ""
-"Compared with previous versions, qwen 1.5 1.8b has significantly enhanced "
-"the model's alignment with human preferences and its multi-language "
-"processing capabilities. Models of all sizes support a context length of "
-"32768 tokens. 1.8 billion parameters."
+#: no source
+msgid "App Key is required"
+msgstr "App Key 是必填項"
+
+#: no source
+msgid "App Secret is required"
+msgstr "App Secret 是必填項"
+
+#: apps/common/constants/permission_constants.py:404
+msgid "Appearance Settings"
+msgstr "外觀設置"
+
+#: apps/application/views/application.py:61
+#: apps/application/views/application.py:80
+#: apps/application/views/application.py:99
+#: apps/application/views/application.py:121
+#: apps/application/views/application.py:148
+#: apps/application/views/application.py:175
+#: apps/application/views/application.py:201
+#: apps/application/views/application.py:227
+#: apps/application/views/application.py:251
+#: apps/application/views/application.py:278
+#: apps/application/views/application.py:303
+#: apps/application/views/application.py:322
+#: apps/application/views/application.py:359
+#: apps/application/views/application.py:398
+#: apps/application/views/application.py:441
+#: apps/application/views/application.py:467
+#: apps/application/views/application.py:493
+#: apps/application/views/application.py:520
+#: apps/application/views/application_access_token.py:43
+#: apps/application/views/application_access_token.py:65
+#: apps/application/views/application_chat.py:126
+#: apps/application/views/application_chat.py:152
+#: apps/application/views/application_chat.py:168
+#: apps/application/views/application_stats.py:33
+#: apps/application/views/application_stats.py:61
+#: apps/application/views/application_stats.py:88
+#: apps/chat/serializers/chat.py:157
+#: apps/chat/views/chat.py:264
+#: apps/common/constants/permission_constants.py:340
+#: apps/common/constants/permission_constants.py:353
+#: apps/common/constants/permission_constants.py:434
+#: apps/common/constants/permission_constants.py:438
+msgid "Application"
+msgstr "智能體"
+
+#: apps/common/constants/permission_constants.py:396
+#: apps/common/constants/permission_constants.py:440
+msgid "Application Access"
+msgstr "智能體介入"
+
+#: apps/chat/views/chat.py:101
+#: apps/chat/views/chat.py:102
+#: apps/chat/views/chat.py:103
+msgid "Application Anonymous Certification"
+msgstr "智能體匿名認證"
+
+#: apps/application/views/application_api_key.py:37
+#: apps/application/views/application_api_key.py:64
+#: apps/application/views/application_api_key.py:89
+#: apps/application/views/application_api_key.py:115
+msgid "Application Api Key"
+msgstr "智能體 API 密鑰"
+
+#: apps/application/serializers/application_chat_record.py:61
+msgid "Application authentication information does not exist"
+msgstr "智能體認證信息不存在"
+
+#: apps/homepage/views/homepage.py:259
+#: apps/homepage/views/homepage.py:260
+msgid "Application data aggregation"
+msgstr "應用資料彙總"
+
+#: apps/application/serializers/application.py:345
+msgid "application describe"
+msgstr "智能體描述"
+
+#: apps/application/api/application_api.py:82
+#: apps/application/serializers/application.py:296
+#: apps/application/serializers/application.py:449
+#: apps/application/serializers/application.py:463
+#: apps/application/serializers/application.py:463
+#: apps/application/serializers/application.py:593
+msgid "Application Description"
+msgstr "智能體描述"
+
+#: apps/application/serializers/application.py:1736
+#: apps/chat/serializers/chat.py:487
+#: apps/chat/serializers/chat.py:548
+#: apps/oss/serializers/file.py:222
+msgid "Application does not exist"
+msgstr "智能體不存在"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:15
+#: apps/application/serializers/application.py:993
+#: apps/application/serializers/application_access_token.py:47
+#: apps/application/serializers/application_chat.py:40
+#: apps/application/serializers/application_chat.py:58
+#: apps/application/serializers/application_chat_link.py:57
+#: apps/application/serializers/application_chat_record.py:47
+#: apps/application/serializers/application_chat_record.py:92
+#: apps/application/serializers/application_chat_record.py:201
+#: apps/application/serializers/application_chat_record.py:249
+#: apps/application/serializers/application_stats.py:39
+#: apps/application/serializers/application_version.py:21
+#: apps/application/serializers/application_version.py:69
+#: apps/chat/serializers/chat.py:218
+#: apps/chat/serializers/chat.py:290
+#: apps/chat/serializers/chat.py:604
+#: apps/chat/serializers/chat.py:616
+#: apps/chat/serializers/chat_authentication.py:93
+#: apps/chat/serializers/chat_record.py:102
+#: apps/chat/serializers/chat_record.py:126
+#: apps/chat/serializers/chat_record.py:154
+#: apps/chat/serializers/chat_record.py:166
+#: apps/homepage/api/home_page_api.py:163
+#: apps/homepage/api/home_page_api.py:193
+#: apps/homepage/serializers/homepage.py:656
+msgid "Application ID"
+msgstr "智能體 ID"
+
+#: apps/application/serializers/application_api_key.py:38
+#: apps/application/serializers/application_api_key.py:75
+#: apps/knowledge/serializers/knowledge.py:134
+msgid "application id"
+msgstr "智能體 ID"
+
+#: apps/application/serializers/application_chat_record.py:379
+msgid "Application id"
 msgstr ""
-"qwen 1.5 1.8b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有"
-"顯著增強。所有規模的模型都支持32768個tokens的上下文長度。18億參數。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:88
-msgid ""
-"Compared with previous versions, qwen 1.5 4b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"4 billion parameters."
+#: apps/application/serializers/application.py:1004
+#: apps/application/serializers/application_access_token.py:57
+#: apps/application/serializers/application_api_key.py:48
+#: apps/application/serializers/application_api_key.py:85
+#: apps/application/serializers/application_chat.py:75
+#: apps/application/serializers/application_chat_record.py:57
+#: apps/application/serializers/application_chat_record.py:103
+#: apps/application/serializers/application_chat_record.py:215
+#: apps/application/serializers/application_chat_record.py:262
+#: apps/application/serializers/application_chat_record.py:390
+#: apps/application/serializers/application_stats.py:50
+#: apps/application/serializers/application_version.py:80
+#: apps/chat/serializers/chat.py:167
+msgid "Application id does not exist"
+msgstr "智能體 ID 不存在"
+
+#: apps/knowledge/serializers/knowledge.py:135
+msgid "application id list"
+msgstr "智能體 ID 列表"
+
+#: apps/application/api/application_api.py:75
+#: apps/application/serializers/application.py:289
+#: apps/application/serializers/application.py:448
+#: apps/application/serializers/application.py:461
+#: apps/application/serializers/application.py:461
+#: apps/application/serializers/application.py:586
+#: apps/homepage/serializers/homepage.py:389
+#: apps/homepage/serializers/homepage.py:489
+#: apps/homepage/serializers/homepage.py:516
+#: apps/homepage/serializers/homepage.py:625
+msgid "Application Name"
+msgstr "智能體名稱"
+
+#: apps/application/serializers/application.py:338
+msgid "application name"
+msgstr "智能體名稱"
+
+#: apps/homepage/api/home_page_api.py:164
+#: apps/homepage/api/home_page_api.py:194
+msgid "Application name"
+msgstr "應用名稱"
+
+#: no source
+msgid "Application Password Certification"
+msgstr "智能體密碼認證"
+
+#: apps/homepage/api/home_page_api.py:189
+msgid "Application question ranking list"
+msgstr "應用提問次數排行榜列表"
+
+#: apps/application/views/application_stats.py:56
+#: apps/application/views/application_stats.py:57
+#: apps/application/views/application_stats.py:58
+msgid "Application token usage statistics"
+msgstr "智能體令牌使用統計"
+
+#: apps/homepage/api/home_page_api.py:159
+msgid "Application tokens ranking list"
+msgstr "應用 tokens 消耗排行榜列表"
+
+#: apps/application/views/application_stats.py:83
+#: apps/application/views/application_stats.py:84
+#: apps/application/views/application_stats.py:85
+msgid "Application top question statistics"
+msgstr "智能體提問次數統計"
+
+#: apps/application/serializers/application.py:373
+msgid "Application Type"
+msgstr "智能體類型"
+
+#: apps/application/serializers/application.py:466
+#: apps/application/serializers/application.py:466
+msgid "Application type"
+msgstr "智能體類型"
+
+#: apps/application/serializers/application.py:377
+msgid "Application type only supports SIMPLE|WORK_FLOW"
+msgstr "智能體類型僅支持 SIMPLE|WORK_FLOW"
+
+#: apps/application/serializers/application_version.py:71
+msgid "Application version ID"
 msgstr ""
-"qwen 1.5 4b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯"
-"著增強。所有規模的模型都支持32768個tokens的上下文長度。40億參數。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:93
-msgid ""
-"Compared with previous versions, qwen 1.5 7b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"7 billion parameters."
+#: no source
+msgid "Application/application access"
+msgstr "智能體/智能體訪問"
+
+#: apps/application/views/application_chat.py:50
+#: apps/application/views/application_chat.py:75
+#: apps/application/views/application_chat.py:101
+#: apps/application/views/application_chat_record.py:37
+#: apps/application/views/application_chat_record.py:63
+#: apps/application/views/application_chat_record.py:92
+#: apps/application/views/application_chat_record.py:122
+#: apps/application/views/application_chat_record.py:146
+#: apps/application/views/application_chat_record.py:171
+#: apps/application/views/application_chat_record.py:202
+msgid "Application/Conversation Log"
+msgstr "智能體/對話日誌"
+
+#: no source
+msgid "Application/Get platform status"
+msgstr "智能體/獲取平臺狀態"
+
+#: apps/application/views/application_version.py:35
+#: apps/application/views/application_version.py:59
+#: apps/application/views/application_version.py:84
+#: apps/application/views/application_version.py:106
+msgid "Application/Version"
+msgstr "智能體/ 版本"
+
+#: no source
+msgid "Applications Resource"
+msgstr "智能體資源"
+
+#: no source
+msgid "app_id is required"
+msgstr "app_id 是必填項"
+
+#: no source
+msgid "app_secret is required"
+msgstr "app_secret 是必填項"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:32
+msgid "Arabic"
+msgstr "阿拉伯語"
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:22
+msgid "array"
 msgstr ""
-"qwen 1.5 7b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯"
-"著增強。所有規模的模型都支持32768個tokens的上下文長度。70億參數。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:97
-msgid ""
-"Compared with previous versions, qwen 1.5 14b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"14 billion parameters."
+#: apps/homepage/api/home_page_api.py:226
+msgid "Asker user information"
+msgstr "提問使用者資訊"
+
+#: apps/knowledge/task/handler.py:134
+msgid "Association problem failed {error}"
+msgstr "關聯問題失敗 {error}"
+
+#: apps/models_provider/api/provide.py:45
+msgid "attrs"
+msgstr "屬性"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:23
+#: apps/chat/serializers/chat.py:94
+msgid "Audio"
+msgstr "音頻"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:23
+msgid "Audio file recognition - Tongyi Qwen"
+msgstr "錄音文件識別-通義千問"
+
+#: no source
+msgid "Auth Type"
+msgstr "認證類型"
+
+#: no source
+msgid "Authentication Configuration"
+msgstr "認證配置"
+
+#: apps/models_provider/impl/xf_model_provider/model/tts/super_humanoid_tts.py:114
+msgid "Authentication failed (HTTP 401). Please check: 1) API URL is correct for TTS service; 2) APP ID, API Key, and API Secret are correct; 3) Your iFlytek account has TTS service enabled."
 msgstr ""
-"qwen 1.5 14b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯"
-"著增強。所有規模的模型都支持32768個tokens的上下文長度。140億參數。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:101
-msgid ""
-"Compared with previous versions, qwen 1.5 32b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"32 billion parameters."
+#: no source
+msgid "Authentication failed. Please verify that the parameters are correct"
+msgstr "認證失敗，請檢查參數是否正確"
+
+#: apps/chat/serializers/chat.py:67
+#: apps/chat/serializers/chat.py:69
+#: apps/chat/serializers/chat.py:71
+msgid "Authentication failed. Please verify that the parameters are correct."
 msgstr ""
-"qwen 1.5 32b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯"
-"著增強。所有規模的模型都支持32768個tokens的上下文長度。320億參數。"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:105
-msgid ""
-"Compared with previous versions, qwen 1.5 72b has significantly enhanced the "
-"model's alignment with human preferences and its multi-language processing "
-"capabilities. Models of all sizes support a context length of 32768 tokens. "
-"72 billion parameters."
-msgstr ""
-"qwen 1.5 72b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯"
-"著增強。所有規模的模型都支持32768個tokens的上下文長度。720億參數。"
+#: apps/common/auth/handle/impl/application_key.py:34
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:40
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:42
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:44
+#: apps/common/auth/handle/impl/chat_anonymous_user_token.py:48
+#: apps/common/auth/handle/impl/user_token.py:317
+#: apps/trigger/handler/impl/trigger/event_trigger.py:120
+#: apps/trigger/handler/impl/trigger/event_trigger.py:123
+msgid "Authentication information is incorrect"
+msgstr "身份驗證信息不正確"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:109
-msgid ""
-"Compared with previous versions, qwen 1.5 110b has significantly enhanced "
-"the model's alignment with human preferences and its multi-language "
-"processing capabilities. Models of all sizes support a context length of "
-"32768 tokens. 110 billion parameters."
-msgstr ""
-"qwen 1.5 110b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有"
-"顯著增強。所有規模的模型都支持32768個tokens的上下文長度。1100億參數。"
+#: apps/common/auth/authenticate.py:84
+#: apps/common/auth/authenticate.py:91
+#: apps/common/auth/authenticate.py:97
+#: apps/common/auth/authenticate.py:110
+#: apps/common/auth/authenticate.py:117
+#: apps/common/auth/authenticate.py:123
+#: apps/common/auth/authenticate.py:136
+#: apps/common/auth/authenticate.py:143
+#: apps/common/auth/authenticate.py:149
+msgid "Authentication information is incorrect! illegal user"
+msgstr "身份驗證信息不正確！非法用戶"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:153
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:193
-msgid ""
-"Phi-3 Mini is Microsoft's 3.8B parameter, lightweight, state-of-the-art open "
-"model."
-msgstr "Phi-3 Mini是Microsoft的3.8B參數，輕量級，最先進的開放模型。"
+#: no source
+msgid "authentication type"
+msgstr "認證類型"
 
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:162
-#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:197
-msgid ""
-"A high-performance open embedding model with a large token context window."
-msgstr "一個具有大 tokens上下文窗口的高性能開放嵌入模型。"
+#: no source
+msgid "Authorization address cannot be empty"
+msgstr "認證地址不能為空"
 
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:16
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:16
-msgid ""
-"The image generation endpoint allows you to create raw images based on text "
-"prompts. When using the DALL·E 3, the image size can be 1024x1024, 1024x1792 "
-"or 1792x1024 pixels."
-msgstr ""
-"圖像生成端點允許您根據文本提示創建原始圖像。使用 DALL·E 3 時，圖像的尺寸可以"
-"為 1024x1024、1024x1792 或 1792x1024 像素。"
+#: no source
+msgid "Authorization knowledge workspace"
+msgstr "授權知識工作空間"
 
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:29
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:29
-msgid ""
-"\n"
-"By default, images are produced in standard quality, but with DALL·E 3 you "
-"can set quality: \"hd\" to enhance detail. Square, standard quality images "
-"are generated fastest.\n"
-"        "
-msgstr ""
-"默認情況下，圖像以標準質量生成，但使用 DALL·E 3 時，您可以設置質量：「hd」以增"
-"強細節。方形、標準質量的圖像生成速度最快。"
+#: no source
+msgid "Authorization knowledge workspace "
+msgstr "授權知識工作空間"
 
-#: apps/models_provider/impl/openai_model_provider/credential/tti.py:44
-#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:44
-msgid ""
-"You can use DALL·E 3 to request 1 image at a time (requesting more images by "
-"issuing parallel requests), or use DALL·E 2 with the n parameter to request "
-"up to 10 images at a time."
-msgstr ""
-"您可以使用 DALL·E 3 一次請求 1 個圖像（通過發出並行請求來請求更多圖像），或者"
-"使用帶有 n 參數的 DALL·E 2 一次最多請求 10 個圖像。"
+#: no source
+msgid "Authorization model workspace"
+msgstr "授權模型工作空間"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:35
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:119
-#: apps/models_provider/impl/siliconCloud_model_provider/siliconCloud_model_provider.py:118
-msgid "The latest gpt-3.5-turbo, updated with OpenAI adjustments"
-msgstr "最新的gpt-3.5-turbo，隨OpenAI調整而更新"
+#: no source
+msgid "Authorization model workspace "
+msgstr "授權模型工作空間"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:38
-msgid "Latest gpt-4, updated with OpenAI adjustments"
-msgstr "最新的gpt-4，隨OpenAI調整而更新"
+#: no source
+msgid "Authorization tool workspace"
+msgstr "授權工作空間工具"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:40
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:99
-msgid ""
-"The latest GPT-4o, cheaper and faster than gpt-4-turbo, updated with OpenAI "
-"adjustments"
-msgstr "最新的GPT-4o，比gpt-4-turbo更便宜、更快，隨OpenAI調整而更新"
+#: no source
+msgid "Authorization tool workspace "
+msgstr "授權工作空間工具"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:43
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:102
-msgid ""
-"The latest gpt-4o-mini, cheaper and faster than gpt-4o, updated with OpenAI "
-"adjustments"
-msgstr "最新的gpt-4o-mini，比gpt-4o更便宜、更快，隨OpenAI調整而更新"
+#: no source
+msgid "Authorized pagination list for obtaining resources"
+msgstr "獲取資源的關係分頁清單"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:46
-msgid "The latest gpt-4-turbo, updated with OpenAI adjustments"
-msgstr "最新的gpt-4-turbo，隨OpenAI調整而更新"
+#: apps/knowledge/serializers/document.py:202
+msgid "Auto Clean"
+msgstr "自動清理"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:49
-msgid "The latest gpt-4-turbo-preview, updated with OpenAI adjustments"
-msgstr "最新的gpt-4-turbo-preview，隨OpenAI調整而更新"
+#: apps/application/serializers/application_api_key.py:23
+msgid "Availability"
+msgstr "可用"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:53
-msgid ""
-"gpt-3.5-turbo snapshot on January 25, 2024, supporting context length 16,385 "
-"tokens"
-msgstr "2024年1月25日的gpt-3.5-turbo快照，支持上下文長度16,385 tokens"
+#: no source
+msgid "avatar"
+msgstr "頭像"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:57
-msgid ""
-"gpt-3.5-turbo snapshot on November 6, 2023, supporting context length 16,385 "
-"tokens"
-msgstr "2023年11月6日的gpt-3.5-turbo快照，支持上下文長度16,385 tokens"
+#: no source
+msgid "avatar url"
+msgstr "頭像地址"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:61
-msgid ""
-"[Legacy] gpt-3.5-turbo snapshot on June 13, 2023, will be deprecated on June "
-"13, 2024"
-msgstr "[Legacy] 2023年6月13日的gpt-3.5-turbo快照，將於2024年6月13日棄用"
+#: apps/homepage/serializers/homepage.py:493
+msgid "Average Number of Conversation Turns per Person"
+msgstr "人均對話輪次"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:65
-msgid ""
-"gpt-4o snapshot on May 13, 2024, supporting context length 128,000 tokens"
-msgstr "2024年5月13日的gpt-4o快照，支持上下文長度128,000 tokens"
+#: apps/homepage/serializers/homepage.py:306
+#: apps/homepage/serializers/homepage.py:630
+msgid "Average tokens per request"
+msgstr "單次請求平均Token數"
 
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:69
-msgid ""
-"gpt-4-turbo snapshot on April 9, 2024, supporting context length 128,000 "
-"tokens"
-msgstr "2024年4月9日的gpt-4-turbo快照，支持上下文長度128,000 tokens"
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:72
-msgid ""
-"gpt-4-turbo snapshot on January 25, 2024, supporting context length 128,000 "
-"tokens"
-msgstr "2024年1月25日的gpt-4-turbo快照，支持上下文長度128,000 tokens"
-
-#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:75
-msgid ""
-"gpt-4-turbo snapshot on November 6, 2023, supporting context length 128,000 "
-"tokens"
-msgstr "2023年11月6日的gpt-4-turbo快照，支持上下文長度128,000 tokens"
-
-#: apps/models_provider/impl/tencent_cloud_model_provider/tencent_cloud_model_provider.py:58
-msgid "Tencent Cloud"
-msgstr "騰訊雲"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:41
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:88
-#, python-brace-format
-msgid "{keys} is required"
-msgstr "{keys} 是必填項"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:14
-msgid "painting style"
-msgstr "繪畫風格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:14
-msgid "If not passed, the default value is 201 (Japanese anime style)"
-msgstr "如果未傳遞，則默認值為201（日本動漫風格）"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:18
-msgid "Not limited to style"
-msgstr "不限於風格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:19
-msgid "ink painting"
-msgstr "水墨畫"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:20
-msgid "concept art"
-msgstr "概念藝術"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:21
-msgid "Oil painting 1"
-msgstr "油畫1"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:22
-msgid "Oil Painting 2 (Van Gogh)"
-msgstr "油畫2（梵谷）"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:23
-msgid "watercolor painting"
-msgstr "水彩畫"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:24
-msgid "pixel art"
-msgstr "像素畫"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:25
-msgid "impasto style"
-msgstr "厚塗風格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:26
-msgid "illustration"
-msgstr "插圖"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:27
-msgid "paper cut style"
-msgstr "剪紙風格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:28
-msgid "Impressionism 1 (Monet)"
-msgstr "印象派1（莫奈）"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:29
-msgid "Impressionism 2"
-msgstr "印象派2"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:31
-msgid "classical portraiture"
-msgstr "古典肖像畫"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:32
-msgid "black and white sketch"
-msgstr "黑白素描畫"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:33
-msgid "cyberpunk"
-msgstr "賽博朋克"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:34
-msgid "science fiction style"
-msgstr "科幻風格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:35
-msgid "dark style"
-msgstr "暗黑風格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:37
-msgid "vaporwave"
-msgstr "蒸汽波"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:38
-msgid "Japanese animation"
-msgstr "日系動漫"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:39
-msgid "monster style"
-msgstr "怪獸風格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:40
-msgid "Beautiful ancient style"
-msgstr "唯美古風"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:41
-msgid "retro anime"
-msgstr "復古動漫"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:42
-msgid "Game cartoon hand drawing"
-msgstr "遊戲卡通手繪"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:43
-msgid "Universal realistic style"
-msgstr "通用寫實風格"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:50
-msgid "Generate image resolution"
-msgstr "生成圖像解析度"
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:50
-msgid "If not transmitted, the default value is 768:768."
-msgstr "不傳默認使用768:768。"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:38
-msgid ""
-"The most effective version of the current hybrid model, the trillion-level "
-"parameter scale MOE-32K long article model. Reaching the absolute leading "
-"level on various benchmarks, with complex instructions and reasoning, "
-"complex mathematical capabilities, support for function call, and "
-"application focus optimization in fields such as multi-language translation, "
-"finance, law, and medical care"
-msgstr ""
-"當前混元模型中效果最優版本，萬億級參數規模 MOE-32K 長文模型。在各種 "
-"benchmark 上達到絕對領先的水平，複雜指令和推理，具備複雜數學能力，支持 "
-"functioncall，在多語言翻譯、金融法律醫療等領域智能體重點優化"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:45
-msgid ""
-"A better routing strategy is adopted to simultaneously alleviate the "
-"problems of load balancing and expert convergence. For long articles, the "
-"needle-in-a-haystack index reaches 99.9%"
-msgstr ""
-"採用更優的路由策略，同時緩解了負載均衡和專家趨同的問題。長文方面，大海撈針指"
-"標達到99.9%"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:51
-msgid ""
-"Upgraded to MOE structure, the context window is 256k, leading many open "
-"source models in multiple evaluation sets such as NLP, code, mathematics, "
-"industry, etc."
-msgstr ""
-"升級為 MOE 結構，上下文窗口為 256k ，在 NLP，代碼，數學，行業等多項評測集上領"
-"先眾多開源模型"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:57
-msgid ""
-"Hunyuan's latest version of the role-playing model, a role-playing model "
-"launched by Hunyuan's official fine-tuning training, is based on the Hunyuan "
-"model combined with the role-playing scene data set for additional training, "
-"and has better basic effects in role-playing scenes."
-msgstr ""
-"混元最新版角色扮演模型，混元官方精調訓練推出的角色扮演模型，基於混元模型結合"
-"角色扮演場景數據集進行增訓，在角色扮演場景具有更好的基礎效果"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:63
-msgid ""
-"Hunyuan's latest MOE architecture FunctionCall model has been trained with "
-"high-quality FunctionCall data and has a context window of 32K, leading in "
-"multiple dimensions of evaluation indicators."
-msgstr ""
-"混元最新 MOE 架構 FunctionCall 模型，經過高質量的 FunctionCall 數據訓練，上下"
-"文窗口達 32K，在多個維度的評測指標上處於領先。"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:69
-msgid ""
-"Hunyuan's latest code generation model, after training the base model with "
-"200B high-quality code data, and iterating on high-quality SFT data for half "
-"a year, the context long window length has been increased to 8K, and it "
-"ranks among the top in the automatic evaluation indicators of code "
-"generation in the five major languages; the five major languages In the "
-"manual high-quality evaluation of 10 comprehensive code tasks that consider "
-"all aspects, the performance is in the first echelon."
-msgstr ""
-"混元最新代碼生成模型，經過 200B 高質量代碼數據增訓基座模型，迭代半年高質量 "
-"SFT 數據訓練，上下文長窗口長度增大到 8K，五大語言代碼生成自動評測指標上位居前"
-"列；五大語言10項考量各方面綜合代碼任務人工高質量評測上，性能處於第一梯隊"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:77
-msgid ""
-"Tencent's Hunyuan Embedding interface can convert text into high-quality "
-"vector data. The vector dimension is 1024 dimensions."
-msgstr ""
-"騰訊混元 Embedding 接口，可以將文本轉化為高質量的向量數據。向量維度為1024維。"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:87
-msgid "Mixed element visual model"
-msgstr "混元視覺模型"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:94
-msgid "Hunyuan graph model"
-msgstr "混元生圖模型"
-
-#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:125
-msgid "Tencent Hunyuan"
-msgstr "騰訊混元"
-
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:24
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:42
-msgid "Facebook’s 125M parameter model"
-msgstr "Facebook的125M參數模型"
-
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:25
-msgid "BAAI’s 7B parameter model"
-msgstr "BAAI的7B參數模型"
-
-#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:26
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:35
 msgid "BAAI’s 13B parameter mode"
 msgstr "BAAI的13B參數模型"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:16
-msgid ""
-"If the gap between width, height and 512 is too large, the picture rendering "
-"effect will be poor and the probability of excessive delay will increase "
-"significantly. Recommended ratio and corresponding width and height before "
-"super score: width*height"
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:33
+msgid "BAAI’s 7B parameter model"
+msgstr "BAAI的7B參數模型"
+
+#: no source
+msgid "Base DN cannot be empty"
+msgstr "Base DN不能為空"
+
+#: apps/models_provider/api/model.py:51
+#: apps/models_provider/serializers/model_serializer.py:66
+#: apps/models_provider/serializers/model_serializer.py:252
+#: apps/models_provider/serializers/model_serializer.py:288
+#: apps/models_provider/serializers/model_serializer.py:361
+#: apps/models_provider/serializers/model_serializer.py:544
+msgid "base model"
+msgstr "基礎模型"
+
+#: apps/models_provider/serializers/model_serializer.py:264
+#: apps/models_provider/serializers/model_serializer.py:301
+msgid "base model【{model_name}】already exists"
+msgstr "模型【{model_name}】已存在"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:27
+msgid "Base URL"
 msgstr ""
-"寬、高與512差距過大，則出圖效果不佳、延遲過長概率顯著增加。超分前建議比例及對"
-"應寬高：width*height"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:15
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:15
-msgid "timbre"
-msgstr "音色"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:31
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:28
-msgid "speaking speed"
-msgstr "語速"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:31
-msgid "[0.2,3], the default is 1, usually one decimal place is enough"
-msgstr "[0.2,3]，默認為1，通常保留一位小數即可"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:39
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:44
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:88
-msgid ""
-"The user goes to the model inference page of Volcano Ark to create an "
-"inference access point. Here, you need to enter ep-xxxxxxxxxx-yyyy to call "
-"it."
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:21
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:21
+msgid "Base Url"
 msgstr ""
-"用戶前往火山方舟的模型推理頁面創建推理接入點，這裡需要輸入ep-xxxxxxxxxx-yyyy"
-"進行調用"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:59
-msgid "Universal 2.0-Vincent Diagram"
-msgstr "通用2.0-文生圖"
+#: apps/application/flow/common.py:282
+msgid "Basic information node is required"
+msgstr "基本信息節點是必需的"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:64
-msgid "Universal 2.0Pro-Vincent Chart"
-msgstr "通用2.0Pro-文生圖"
+#: no source
+msgid "Batch add chat user to group"
+msgstr "批量添加對話用戶到用戶組"
 
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:69
-msgid "Universal 1.4-Vincent Chart"
-msgstr "通用1.4-文生圖"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:74
-msgid "Animation 1.3.0-Vincent Picture"
-msgstr "動漫1.3.0-文生圖"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:79
-msgid "Animation 1.3.1-Vincent Picture"
-msgstr "動漫1.3.1-文生圖"
-
-#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:113
-msgid "volcano engine"
-msgstr "火山引擎"
-
-#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:51
-#, python-brace-format
-msgid "{model_name} The model does not support"
-msgstr "{model_name} 模型不支持"
-
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:24
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:53
-msgid ""
-"ERNIE-Bot-4 is a large language model independently developed by Baidu. It "
-"covers massive Chinese data and has stronger capabilities in dialogue Q&A, "
-"content creation and generation."
+#: apps/knowledge/views/document.py:711
+#: apps/knowledge/views/document.py:712
+msgid "Batch add tags to documents"
 msgstr ""
-"ERNIE-Bot-4是百度自行研發的大語言模型，覆蓋海量中文數據，具有更強的對話問答、"
-"內容創作生成等能力。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:27
-msgid ""
-"ERNIE-Bot is a large language model independently developed by Baidu. It "
-"covers massive Chinese data and has stronger capabilities in dialogue Q&A, "
-"content creation and generation."
+#: no source
+msgid "Batch add user to group"
+msgstr "批量添加用戶到組"
+
+#: apps/knowledge/views/problem.py:107
+#: apps/knowledge/views/problem.py:108
+#: apps/knowledge/views/problem.py:109
+msgid "Batch associated paragraphs"
+msgstr "批量關聯段落"
+
+#: no source
+msgid "Batch associated shared paragraphs"
+msgstr "批量關聯段落"
+
+#: no source
+msgid "Batch associated system paragraphs"
+msgstr "批量關聯段落"
+
+#: apps/common/constants/permission_constants.py:392
+msgid "Batch delete"
+msgstr "批量刪除"
+
+#: apps/knowledge/views/tag.py:128
+msgid "Batch Delete a knowledge tag"
 msgstr ""
-"ERNIE-Bot是百度自行研發的大語言模型，覆蓋海量中文數據，具有更強的對話問答、內"
-"容創作生成等能力。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:30
-msgid ""
-"ERNIE-Bot-turbo is a large language model independently developed by Baidu. "
-"It covers massive Chinese data, has stronger capabilities in dialogue Q&A, "
-"content creation and generation, and has a faster response speed."
+#: apps/application/views/application.py:316
+#: apps/application/views/application.py:317
+#: apps/application/views/application.py:318
+msgid "Batch delete applications"
+msgstr "批量刪除應用"
+
+#: no source
+msgid "Batch delete chat user"
+msgstr "批量刪除對話用戶"
+
+#: apps/knowledge/views/document.py:1114
+#: apps/knowledge/views/document.py:1115
+msgid "Batch Delete Documents Tag"
 msgstr ""
-"ERNIE-Bot-turbo是百度自行研發的大語言模型，覆蓋海量中文數據，具有更強的對話問"
-"答、內容創作生成等能力，響應速度更快。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:33
-msgid ""
-"BLOOMZ-7B is a well-known large language model in the industry. It was "
-"developed and open sourced by BigScience and can output text in 46 languages "
-"and 13 programming languages."
+#: apps/chat/views/chat_record.py:107
+#: apps/chat/views/chat_record.py:108
+#: apps/chat/views/chat_record.py:109
+msgid "Batch delete history conversation"
 msgstr ""
-"BLOOMZ-7B是業內知名的大語言模型，由BigScience研發並開源，能夠以46種語言和13種"
-"程式語言輸出文本。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:39
-msgid ""
-"Llama-2-13b-chat was developed by Meta AI and is open source. It performs "
-"well in scenarios such as coding, reasoning and knowledge application. "
-"Llama-2-13b-chat is a native open source version with balanced performance "
-"and effect, suitable for conversation scenarios."
+#: apps/knowledge/views/knowledge.py:143
+#: apps/knowledge/views/knowledge.py:144
+#: apps/knowledge/views/knowledge.py:145
+msgid "Batch delete knowledge"
+msgstr "批量刪除知識庫"
+
+#: apps/knowledge/views/tag.py:127
+msgid "Batch Delete Knowledge Tag"
 msgstr ""
-"Llama-2-13b-chat由Meta AI研發並開源，在編碼、推理及知識智能體等場景表現優秀，"
-"Llama-2-13b-chat是性能與效果均衡的原生開源版本，適用於對話場景。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:42
-msgid ""
-"Llama-2-70b-chat was developed by Meta AI and is open source. It performs "
-"well in scenarios such as coding, reasoning, and knowledge application. "
-"Llama-2-70b-chat is a native open source version with high-precision effects."
+#: apps/tools/views/tool.py:205
+#: apps/tools/views/tool.py:206
+#: apps/tools/views/tool.py:207
+msgid "Batch delete tools"
+msgstr "批量刪除工具"
+
+#: apps/users/views/user.py:249
+#: apps/users/views/user.py:250
+#: apps/users/views/user.py:251
+msgid "Batch delete user"
+msgstr "批量刪除用戶"
+
+#: apps/knowledge/views/problem.py:137
+#: apps/knowledge/views/problem.py:138
+#: apps/knowledge/views/problem.py:139
+#: apps/knowledge/views/termbase.py:93
+#: apps/knowledge/views/termbase.py:94
+#: apps/knowledge/views/termbase.py:95
+msgid "Batch deletion issues"
+msgstr "批量刪除問題"
+
+#: no source
+msgid "Batch deletion shared issues"
+msgstr "批量刪除問題"
+
+#: no source
+msgid "Batch deletion system issues"
+msgstr "批量刪除問題"
+
+#: apps/knowledge/views/termbase.py:128
+#: apps/knowledge/views/termbase.py:129
+#: apps/knowledge/views/termbase.py:130
+msgid "Batch export termbase"
 msgstr ""
-"Llama-2-70b-chat由Meta AI研發並開源，在編碼、推理及知識智能體等場景表現優秀，"
-"Llama-2-70b-chat是高精度效果的原生開源版本。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:45
-msgid ""
-"The Chinese enhanced version developed by the Qianfan team based on "
-"Llama-2-7b has performed well on Chinese knowledge bases such as CMMLU and C-"
-"EVAL."
+#: apps/knowledge/views/paragraph.py:143
+#: apps/knowledge/views/paragraph.py:144
+#: apps/knowledge/views/paragraph.py:145
+msgid "Batch Generate Related"
+msgstr "批量生成相關"
+
+#: no source
+msgid "Batch generate related"
+msgstr "批量生成相關"
+
+#: apps/knowledge/views/document.py:748
+#: apps/knowledge/views/document.py:749
+#: apps/knowledge/views/document.py:750
+msgid "Batch generate related problems"
+msgstr "批量生成相關問題"
+
+#: no source
+msgid "Batch generate related shared problems"
+msgstr "批量生成相關問題"
+
+#: no source
+msgid "Batch generate related system problems"
+msgstr "批量生成相關問題"
+
+#: no source
+msgid "Batch generate shared related"
+msgstr "批量生成相關"
+
+#: no source
+msgid "Batch generate system related"
+msgstr "批量生成相關"
+
+#: apps/common/constants/permission_constants.py:393
+msgid "Batch move"
+msgstr "批量移動"
+
+#: apps/application/views/application.py:353
+#: apps/application/views/application.py:354
+#: apps/application/views/application.py:355
+msgid "Batch move applications"
+msgstr "批量移動應用"
+
+#: apps/knowledge/views/knowledge.py:181
+#: apps/knowledge/views/knowledge.py:182
+#: apps/knowledge/views/knowledge.py:183
+msgid "Batch move knowledge"
+msgstr "批量移動知識庫"
+
+#: apps/tools/views/tool.py:243
+#: apps/tools/views/tool.py:244
+#: apps/tools/views/tool.py:245
+msgid "Batch move tools"
+msgstr "批量移動工具"
+
+#: apps/knowledge/views/paragraph.py:81
+#: apps/knowledge/views/paragraph.py:82
+#: apps/knowledge/views/paragraph.py:83
+msgid "Batch Paragraph"
+msgstr "批量段落"
+
+#: apps/knowledge/views/document.py:633
+#: apps/knowledge/views/document.py:634
+msgid "Batch refresh document vector library"
+msgstr "批量刷新文檔向量庫"
+
+#: no source
+msgid "Batch refresh shared document vector library"
+msgstr "批量刷新共享文檔向量庫"
+
+#: no source
+msgid "Batch refresh system document vector library"
+msgstr "批量刷新文檔向量庫"
+
+#: no source
+msgid "Batch Remove Documents from Tag"
+msgstr "批量刪除標籤下的文件"
+
+#: no source
+msgid "Batch set user roles"
+msgstr "批量設置用戶角色"
+
+#: no source
+msgid "Batch shared paragraph"
+msgstr "批量關聯段落"
+
+#: apps/knowledge/views/document.py:553
+#: apps/knowledge/views/document.py:554
+#: apps/knowledge/views/document.py:555
+msgid "Batch sync documents"
+msgstr "批量同步文檔"
+
+#: no source
+msgid "Batch sync shared documents"
+msgstr "批量同步共享文檔"
+
+#: no source
+msgid "Batch sync system knowledges"
+msgstr "批量同步知識庫"
+
+#: no source
+msgid "Batch synchronize lark document"
+msgstr "批量同步飛書文檔"
+
+#: no source
+msgid "Batch system paragraph"
+msgstr "批量關聯段落"
+
+#: apps/knowledge/views/document.py:672
+#: apps/knowledge/views/document.py:673
+msgid "Batch tokenize document library"
 msgstr ""
-"千帆團隊在Llama-2-7b基礎上的中文增強版本，在CMMLU、C-EVAL等中文知識庫上表現優"
-"異。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:49
-msgid ""
-"Embedding-V1 is a text representation model based on Baidu Wenxin large "
-"model technology. It can convert text into a vector form represented by "
-"numerical values and can be used in text retrieval, information "
-"recommendation, knowledge mining and other scenarios. Embedding-V1 provides "
-"the Embeddings interface, which can generate corresponding vector "
-"representations based on input content. You can call this interface to input "
-"text into the model and obtain the corresponding vector representation for "
-"subsequent text processing and analysis."
+#: apps/application/views/application.py:392
+#: apps/application/views/application.py:393
+#: apps/application/views/application.py:394
+msgid "Batch update application chat log clear policy"
 msgstr ""
-"Embedding-V1是一個基於百度文心大模型技術的文本表示模型，可以將文本轉化為用數"
-"值表示的向量形式，用於文本檢索、信息推薦、知識挖掘等場景。 Embedding-V1提供了"
-"Embeddings接口，可以根據輸入內容生成對應的向量表示。您可以通過調用該接口，將"
-"文本輸入到模型中，獲取到對應的向量表示，從而進行後續的文本處理和分析。"
 
-#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:66
-msgid "Thousand sails large model"
-msgstr "千帆大模型"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:39
+msgid "Beautiful ancient style"
+msgstr "唯美古風"
 
-#: apps/models_provider/impl/xf_model_provider/credential/image.py:42
-msgid "Please outline this picture"
-msgstr "請描述這張圖片"
-
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:15
-msgid "Speaker"
-msgstr "發音人"
-
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:16
-msgid ""
-"Speaker, optional value: Please go to the console to add a trial or purchase "
-"speaker. After adding, the speaker parameter value will be displayed."
+#: apps/chat/serializers/chat_record.py:27
+msgid "Bidding Status"
 msgstr ""
-"發音人，可選值：請到控制臺添加試用或購買發音人，添加後即顯示發音人參數值"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:21
-msgid "iFlytek Xiaoyan"
-msgstr "訊飛小燕"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:31
+msgid "black and white sketch"
+msgstr "黑白素描畫"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:22
-msgid "iFlytek Xujiu"
-msgstr "訊飛許久"
+#: apps/knowledge/serializers/document.py:1310
+msgid "blank line"
+msgstr "空行"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:23
-msgid "iFlytek Xiaoping"
-msgstr "訊飛小萍"
+#: apps/oss/serializers/file.py:247
+msgid "Blocked unsafe redirect to internal host"
+msgstr "阻止不安全的重定向到內部主機"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:24
-msgid "iFlytek Xiaojing"
-msgstr "訊飛小婧"
+#: no source
+msgid "BLOOMZ-7B is a well-known large language model in the industry. It was developed and open sourced by BigScience and can output text in 46 languages and 13 programming languages."
+msgstr "BLOOMZ-7B是業內知名的大語言模型，由BigScience研發並開源，能夠以46種語言和13種程式語言輸出文本。"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:25
-msgid "iFlytek Xuxiaobao"
-msgstr "訊飛許小寶"
+#: apps/trigger/serializers/trigger.py:244
+msgid "body must be an array"
+msgstr "body 必須是陣列類型"
 
-#: apps/models_provider/impl/xf_model_provider/credential/tts.py:28
-msgid "Speech speed, optional value: [0-100], default is 50"
-msgstr "語速，可選值：[0-100]，默認為50"
+#: no source
+msgid "Bot User Token is required"
+msgstr "機器人用戶令牌是必填項"
 
-#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:39
-#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:50
-msgid "Chinese and English recognition"
-msgstr "中英文識別"
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:25
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:13
+msgid "Branch id"
+msgstr "分支 ID"
 
-#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:66
-msgid "iFlytek Spark"
-msgstr "訊飛星火"
-
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:15
-msgid ""
-"The image generation endpoint allows you to create raw images based on text "
-"prompts. The dimensions of the image can be 1024x1024, 1024x1792, or "
-"1792x1024 pixels."
-msgstr ""
-"圖像生成端點允許您根據文本提示創建原始圖像。圖像的尺寸可以為 1024x1024、"
-"1024x1792 或 1792x1024 像素。"
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:26
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:15
+msgid "Branch Type"
+msgstr "分支類型"
 
 #: apps/models_provider/impl/xinference_model_provider/credential/tti.py:29
-msgid ""
-"By default, images are generated in standard quality, you can set quality: "
-"\"hd\" to enhance detail. Square, standard quality images are generated "
-"fastest."
-msgstr ""
-"默認情況下，圖像以標準質量生成，您可以設置質量：「hd」以增強細節。方形、標準質"
-"量的圖像生成速度最快。"
+msgid "By default, images are generated in standard quality, you can set quality: \"hd\" to enhance detail. Square, standard quality images are generated fastest."
+msgstr "默認情況下，圖像以標準質量生成，您可以設置質量：「hd」以增強細節。方形、標準質量的圖像生成速度最快。"
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:42
-msgid ""
-"You can request 1 image at a time (requesting more images by making parallel "
-"requests), or up to 10 images at a time using the n parameter."
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:28
+msgid "\nBy default, images are produced in standard quality, but with DALL·E 3 you can set quality: \"hd\" to enhance detail. Square, standard quality images are generated fastest.\n        "
+msgstr "默認情況下，圖像以標準質量生成，但使用 DALL·E 3 時，您可以設置質量：「hd」以增強細節。方形、標準質量的圖像生成速度最快。"
+
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:28
+msgid "       \nBy default, images are produced in standard quality.\n        "
 msgstr ""
-"您可以一次請求 1 個圖像（通過發出並行請求來請求更多圖像），或者使用 n 參數一"
-"次最多請求 10 個圖像。"
+
+#: no source
+msgid "Callback URL is required"
+msgstr "Callback URL 是必填項"
+
+#: no source
+msgid "callback_url is required"
+msgstr "callback_url 是必填項"
+
+#: apps/knowledge/views/knowledge_workflow.py:199
+#: apps/knowledge/views/knowledge_workflow.py:200
+#: apps/knowledge/views/knowledge_workflow.py:201
+msgid "Cancel knowledge workflow action"
+msgstr ""
+
+#: no source
+msgid "Cancel shared task"
+msgstr "取消任務"
+
+#: no source
+msgid "Cancel shared tasks in batches"
+msgstr "批量取消任務"
+
+#: no source
+msgid "Cancel system task"
+msgstr "取消任務"
+
+#: no source
+msgid "Cancel system tasks in batches"
+msgstr "批量取消任務"
+
+#: apps/knowledge/views/document.py:438
+#: apps/knowledge/views/document.py:439
+#: apps/knowledge/views/document.py:440
+msgid "Cancel task"
+msgstr "取消任務"
+
+#: apps/knowledge/views/document.py:475
+#: apps/knowledge/views/document.py:476
+#: apps/knowledge/views/document.py:477
+msgid "Cancel tasks in batches"
+msgstr "批量取消任務"
+
+#: apps/users/serializers/user.py:671
+#: apps/users/serializers/user.py:674
+#: apps/users/serializers/user.py:685
+msgid "Cannot delete built-in role"
+msgstr "無法刪除內置角色"
+
+#: apps/folders/serializers/folder.py:247
+msgid "Cannot delete root folder"
+msgstr "無法刪除根文件夾"
+
+#: apps/users/serializers/user.py:504
+msgid "Cannot modify administrator status"
+msgstr "不能修改管理員狀態"
+
+#: no source
+msgid "Cannot modify built-in role"
+msgstr "不能修改內置角色"
+
+#: no source
+msgid "Cannot remove member from built-in role"
+msgstr "不能從內置角色中移除成員"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:22
+msgid "Cantonese"
+msgstr "粵語"
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:23
+msgid "Cantonese female"
+msgstr "粵語女"
+
+#: apps/users/serializers/login.py:35
+#: apps/users/serializers/login.py:268
+msgid "captcha"
+msgstr "驗證碼"
+
+#: apps/users/serializers/login.py:207
+msgid "Captcha code error or expiration"
+msgstr "驗證碼錯誤或過期"
+
+#: apps/users/serializers/login.py:200
+msgid "Captcha is required"
+msgstr "驗證碼是必填項"
+
+#: no source
+msgid "CAS authentication failed"
+msgstr "CAS 認證失敗"
+
+#: no source
+msgid "CAS Log in"
+msgstr "CAS 登錄"
+
+#: apps/models_provider/serializers/model_serializer.py:68
+#: apps/models_provider/serializers/model_serializer.py:254
+#: apps/models_provider/serializers/model_serializer.py:290
+msgid "certification information"
+msgstr "認證信息"
+
+#: no source
+msgid "Change chat user password"
+msgstr "修改對話用戶密碼"
+
+#: apps/common/constants/permission_constants.py:1306
+msgid "Change Password"
+msgstr "修改密碼"
+
+#: apps/users/serializers/user.py:1146
+#: apps/users/views/user.py:265
+#: apps/users/views/user.py:266
+#: apps/users/views/user.py:267
+#: apps/users/views/user.py:300
+#: apps/users/views/user.py:301
+#: apps/users/views/user.py:302
+msgid "Change password"
+msgstr "修改密碼"
+
+#: apps/chat/views/chat.py:79
+#: apps/chat/views/chat.py:106
+#: apps/chat/views/chat.py:128
+#: apps/chat/views/chat.py:145
+#: apps/chat/views/chat.py:163
+#: apps/chat/views/chat.py:189
+#: apps/chat/views/chat.py:207
+#: apps/chat/views/chat.py:225
+#: apps/chat/views/chat.py:244
+#: apps/chat/views/chat_embed.py:27
+#: apps/chat/views/chat_record.py:35
+#: apps/chat/views/chat_record.py:54
+#: apps/chat/views/chat_record.py:74
+#: apps/chat/views/chat_record.py:92
+#: apps/chat/views/chat_record.py:112
+#: apps/chat/views/chat_record.py:130
+#: apps/chat/views/chat_record.py:150
+#: apps/chat/views/chat_record.py:170
+#: apps/chat/views/chat_record.py:191
+#: apps/oss/views/file.py:80
+msgid "Chat"
+msgstr "聊天"
+
+#: no source
+msgid "chat background"
+msgstr "聊天背景"
+
+#: no source
+msgid "chat background url"
+msgstr "聊天背景地址"
+
+#: apps/chat/serializers/chat.py:55
+msgid "Chat context"
+msgstr "聊天上下文"
+
+#: apps/application/serializers/application_chat_link.py:131
+msgid "Chat has been deleted"
+msgstr "聊天記錄已被刪除"
+
+#: apps/application/api/application_chat_link.py:38
+#: apps/application/api/application_chat_record.py:46
+#: apps/application/api/application_chat_record.py:115
+#: apps/application/serializers/application_chat.py:49
+#: apps/application/serializers/application_chat_record.py:93
+#: apps/chat/api/vote_api.py:27
+#: apps/chat/serializers/chat_record.py:128
+#: apps/chat/serializers/chat_record.py:167
+msgid "Chat ID"
+msgstr "對話 ID"
+
+#: apps/application/serializers/application_chat.py:35
+msgid "chat id"
+msgstr "對話 ID"
+
+#: apps/application/serializers/application_chat_link.py:67
+msgid "Chat id does not exist"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:48
+msgid "Chat ID List"
+msgstr "對話 ID 列表"
+
+#: apps/chat/serializers/chat_record.py:135
+msgid "Chat is not exist"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:34
+msgid "Chat record aggregation"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:33
+msgid "Chat record data aggregation"
+msgstr ""
+
+#: apps/application/api/application_chat_record.py:122
+#: apps/chat/api/vote_api.py:34
+msgid "Chat Record ID"
+msgstr "對話記錄 ID"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:72
+msgid "Chat record id"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:46
+msgid "Chat record IDs"
+msgstr ""
+
+#: apps/application/serializers/application_chat_link.py:52
+msgid "Chat record ids can not be empty"
+msgstr ""
+
+#: apps/application/views/application_chat_link.py:30
+#: apps/application/views/application_chat_link.py:50
+msgid "Chat record link"
+msgstr "聊天記錄連結"
+
+#: apps/common/constants/permission_constants.py:405
+#: apps/common/constants/permission_constants.py:431
+msgid "Chat User"
+msgstr "對話用戶"
+
+#: no source
+msgid "Chat user"
+msgstr "聊天用戶"
+
+#: apps/common/constants/permission_constants.py:407
+msgid "Chat User Auth"
+msgstr "對話用戶認證"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:71
+msgid "Chat user id"
+msgstr "對話用戶 ID"
+
+#: apps/application/serializers/application_chat.py:37
+#: apps/chat/serializers/chat_record.py:103
+#: apps/chat/serializers/chat_record.py:127
+#: apps/chat/serializers/chat_record.py:155
+#: apps/chat/serializers/chat_record.py:168
+msgid "Chat User ID"
+msgstr "對話用戶 ID"
+
+#: apps/homepage/api/home_page_api.py:217
+msgid "Chat user ID"
+msgstr "對話使用者 ID"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:74
+msgid "Chat user Type"
+msgstr "對話用戶類型"
+
+#: apps/application/serializers/application_chat.py:38
+msgid "Chat User Type"
+msgstr "對話用戶類型"
+
+#: apps/homepage/api/home_page_api.py:219
+msgid "Chat user type"
+msgstr "對話使用者類型"
+
+#: no source
+msgid "Chat User/Authentication Configuration"
+msgstr "對話用戶/認證配置"
+
+#: no source
+msgid "Chat User/login"
+msgstr "對話用戶/登錄"
+
+#: no source
+msgid "Chat User/login authentication"
+msgstr "對話用戶/登錄認證"
+
+#: no source
+msgid "Chat User/logout"
+msgstr "對話用戶/登出"
+
+#: no source
+msgid "Chat User/Three-party login"
+msgstr "對話用戶/三方登錄"
+
+#: apps/tools/views/tool.py:403
+#: apps/tools/views/tool.py:404
+#: apps/tools/views/tool.py:405
+msgid "Check code"
+msgstr "檢查代碼"
+
+#: no source
+msgid "Check if the fields are correct"
+msgstr "檢查欄位是否正確"
+
+#: apps/system_manage/serializers/valid_serializers.py:41
+msgid "check quantity"
+msgstr ""
+
+#: no source
+msgid "Check shared code"
+msgstr "檢查代碼"
+
+#: no source
+msgid "Check system code"
+msgstr "檢查代碼"
+
+#: apps/users/views/user.py:339
+#: apps/users/views/user.py:340
+#: apps/users/views/user.py:341
+msgid "Check whether the verification code is correct"
+msgstr "檢查驗證碼是否正確"
+
+#: no source
+msgid "Check workspace can it be deleted"
+msgstr "檢查工作空間是否可以被刪除"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:26
+#: apps/chat/serializers/chat.py:97
+msgid "Child Nodes"
+msgstr "子節點"
+
+#: no source
+msgid "Children"
+msgstr "子級"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:80
+msgid "Chinese (including various dialects such as Cantonese), English, Japanese, and Korean support free switching between multiple languages."
+msgstr "中文（含粵語等各種方言）、英文、日語、韓語支持多個語種自由切換"
+
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:50
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:52
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:67
+msgid "Chinese and English recognition"
+msgstr "中英文識別"
 
 #: apps/models_provider/impl/xinference_model_provider/credential/tts.py:20
 msgid "Chinese female"
@@ -4869,13 +1441,1368 @@ msgstr "中文女"
 msgid "Chinese male"
 msgstr "中文男"
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:22
-msgid "Japanese male"
-msgstr "日語男"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:20
+msgid "Chinese medical"
+msgstr "中文醫療"
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:23
-msgid "Cantonese female"
-msgstr "粵語女"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:57
+msgid "Chinese painting"
+msgstr "中國畫"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:21
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:14
+msgid "Chinese sounds can support mixed scenes of Chinese and English"
+msgstr "中文音色支持中英文混合場景"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:16
+msgid "Chinese telephone universal"
+msgstr "中文電話通用"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:19
+msgid "Chinese, English, and Guangdong"
+msgstr "中文、英文和廣東話"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:45
+msgid "chunk size"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:50
+msgid "chunk size reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:47
+msgid "chunk size type"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:30
+msgid "classical portraiture"
+msgstr "古典肖像畫"
+
+#: apps/application/serializers/application.py:1746
+msgid "Clean time"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:371
+msgid "Clear Policy"
+msgstr "清除策略"
+
+#: apps/chat/serializers/chat.py:219
+#: apps/chat/serializers/chat.py:287
+#: apps/chat/serializers/chat.py:534
+msgid "Client id"
+msgstr "客戶端 ID"
+
+#: no source
+msgid "Client ID cannot be empty"
+msgstr "客戶端 ID 不能為空"
+
+#: no source
+msgid "Client ID is required"
+msgstr "Client ID 是必填項"
+
+#: no source
+msgid "Client secret cannot be empty"
+msgstr "客戶端密鑰不能為空"
+
+#: no source
+msgid "Client Secret is required"
+msgstr "客戶端密鑰是必填項"
+
+#: apps/chat/serializers/chat.py:220
+#: apps/chat/serializers/chat.py:288
+#: apps/chat/serializers/chat.py:535
+msgid "Client Type"
+msgstr "客戶端類型"
+
+#: apps/users/serializers/user.py:974
+msgid "Code"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:44
+msgid "\nCode Llama Instruct is a fine-tuned version of Code Llama's instructions, designed to perform specific tasks.\n        "
+msgstr "Code Llama Instruct 是 Code Llama 的指令微調版本，專為執行特定任務而設計。"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:37
+msgid "Code Llama is a language model specifically designed for code generation."
+msgstr "Code Llama 是一個專門用於代碼生成的語言模型。"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:53
+msgid "Code Llama Python is a language model specifically designed for Python code generation."
+msgstr "Code Llama Python 是一個專門用於 Python 代碼生成的語言模型。"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:67
+msgid "CodeQwen 1.5 Chat is a chat model version of CodeQwen 1.5."
+msgstr "CodeQwen 1.5 Chat 是一個聊天模型版本的 CodeQwen 1.5。"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:60
+msgid "CodeQwen 1.5 is a language model for code generation with high performance."
+msgstr "CodeQwen 1.5 是一個用於代碼生成的語言模型，具有較高的性能。"
+
+#: apps/knowledge/serializers/document.py:1307
+msgid "comma"
+msgstr "逗號"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:18
+msgid "Commonly used in Chinese"
+msgstr "中文常用"
+
+#: apps/application/api/application_chat.py:88
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:19
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:20
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:19
+#: apps/application/serializers/application_chat.py:63
+msgid "Comparator"
+msgstr "比較器"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:80
+msgid "Compared with previous versions, qwen 1.5 0.5b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 500 million parameters."
+msgstr "qwen 1.5 0.5b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯著增強。所有規模的模型都支持32768個tokens的上下文長度。5億參數。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:84
+msgid "Compared with previous versions, qwen 1.5 1.8b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 1.8 billion parameters."
+msgstr "qwen 1.5 1.8b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯著增強。所有規模的模型都支持32768個tokens的上下文長度。18億參數。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:109
+msgid "Compared with previous versions, qwen 1.5 110b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 110 billion parameters."
+msgstr "qwen 1.5 110b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯著增強。所有規模的模型都支持32768個tokens的上下文長度。1100億參數。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:97
+msgid "Compared with previous versions, qwen 1.5 14b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 14 billion parameters."
+msgstr "qwen 1.5 14b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯著增強。所有規模的模型都支持32768個tokens的上下文長度。140億參數。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:101
+msgid "Compared with previous versions, qwen 1.5 32b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 32 billion parameters."
+msgstr "qwen 1.5 32b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯著增強。所有規模的模型都支持32768個tokens的上下文長度。320億參數。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:88
+msgid "Compared with previous versions, qwen 1.5 4b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 4 billion parameters."
+msgstr "qwen 1.5 4b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯著增強。所有規模的模型都支持32768個tokens的上下文長度。40億參數。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:105
+msgid "Compared with previous versions, qwen 1.5 72b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 72 billion parameters."
+msgstr "qwen 1.5 72b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯著增強。所有規模的模型都支持32768個tokens的上下文長度。720億參數。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:93
+msgid "Compared with previous versions, qwen 1.5 7b has significantly enhanced the model's alignment with human preferences and its multi-language processing capabilities. Models of all sizes support a context length of 32768 tokens. 7 billion parameters."
+msgstr "qwen 1.5 7b 相較於以往版本，模型與人類偏好的對齊程度以及多語言處理能力上有顯著增強。所有規模的模型都支持32768個tokens的上下文長度。70億參數。"
+
+#: apps/application/serializers/application_chat.py:172
+msgid "complete"
+msgstr "內容完善"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:44
+msgid "Completion problem"
+msgstr "完成問題"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:68
+msgid "Completion Question"
+msgstr "完成問題"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:19
+msgid "concept art"
+msgstr "概念藝術"
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:27
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:26
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:25
+msgid "Condition or|and"
+msgstr "條件 或|與"
+
+#: no source
+msgid "Config"
+msgstr "配置"
+
+#: no source
+msgid "Configuration information is wrong and failed to save"
+msgstr "配置信息錯誤，保存失敗"
+
+#: no source
+msgid "Confirm Password"
+msgstr "確認密碼"
+
+#: no source
+msgid "Connection failed"
+msgstr "連接失敗"
+
+#: apps/application/serializers/application_chat.py:220
+msgid "Consuming tokens"
+msgstr "消耗的令牌"
+
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:14
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:38
+#: apps/chat/serializers/chat.py:206
+#: apps/knowledge/serializers/paragraph.py:70
+#: apps/knowledge/serializers/problem.py:28
+#: apps/knowledge/serializers/problem.py:32
+#: apps/knowledge/serializers/problem.py:236
+#: apps/knowledge/serializers/termbase.py:22
+#: apps/knowledge/serializers/termbase.py:29
+#: apps/knowledge/serializers/termbase.py:141
+msgid "content"
+msgstr "內容"
+
+#: apps/chat/serializers/chat.py:50
+msgid "Content"
+msgstr ""
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:37
+msgid "Content cannot be empty"
+msgstr "內容不能為空"
+
+#: no source
+msgid "Content generated by AI"
+msgstr "AI 生成的內容"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:37
+msgid "Context Type"
+msgstr "上下文類型"
+
+#: apps/application/serializers/application_chat_record.py:78
+#: apps/chat/serializers/chat.py:301
+#: apps/chat/serializers/chat.py:484
+msgid "Conversation does not exist"
+msgstr "對話不存在"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:60
+#: apps/application/serializers/application_chat.py:214
+#: apps/application/serializers/application_chat.py:263
+#: apps/application/serializers/application_chat_link.py:56
+#: apps/application/serializers/application_chat_record.py:45
+#: apps/application/serializers/application_chat_record.py:203
+#: apps/application/serializers/application_chat_record.py:253
+#: apps/application/serializers/application_chat_record.py:371
+#: apps/application/serializers/application_chat_record.py:471
+#: apps/chat/serializers/chat.py:136
+#: apps/chat/serializers/chat.py:212
+#: apps/chat/serializers/chat.py:286
+#: apps/chat/serializers/chat_record.py:45
+msgid "Conversation ID"
+msgstr "對話 ID"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:55
+msgid "Conversation list"
+msgstr "對話列表"
+
+#: apps/common/constants/permission_constants.py:398
+#: apps/common/constants/permission_constants.py:442
+msgid "Conversation log"
+msgstr "對話日誌"
+
+#: apps/application/serializers/application_chat_record.py:224
+#: apps/application/serializers/application_chat_record.py:436
+#: apps/application/serializers/application_chat_record.py:514
+#: apps/chat/serializers/chat.py:388
+msgid "Conversation record does not exist"
+msgstr "對話記錄不存在"
+
+#: apps/application/serializers/application_chat_record.py:48
+#: apps/application/serializers/application_chat_record.py:206
+#: apps/application/serializers/application_chat_record.py:374
+#: apps/application/serializers/application_chat_record.py:474
+#: apps/chat/serializers/chat.py:80
+#: apps/chat/serializers/chat_record.py:48
+msgid "Conversation record id"
+msgstr "對話記錄 ID"
+
+#: apps/application/serializers/application_chat_record.py:302
+msgid "Conversation records that do not exist"
+msgstr "對話記錄不存在"
+
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:26
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:27
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:24
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:26
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:23
+msgid "Conversation storage type"
+msgstr "對話存儲類型"
+
+#: no source
+msgid "convert audio to text"
+msgstr "將音頻轉換為文本"
+
+#: apps/common/constants/permission_constants.py:348
+msgid "Copy"
+msgstr "複製"
+
+#: no source
+msgid "Corp ID is required"
+msgstr "Corp ID 是必填項"
+
+#: no source
+msgid "corporation"
+msgstr "公司"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:89
+msgid "CosyVoice is based on a new generation of large generative speech models, which can predict emotions, intonation, rhythm, etc. based on context, and has better anthropomorphic effects."
+msgstr "CosyVoice基於新一代生成式語音大模型，能根據上下文預測情緒、語調、韻律等，具有更好的擬人效果"
+
+#: no source
+msgid "count"
+msgstr "數量"
+
+#: apps/common/constants/permission_constants.py:350
+msgid "Create"
+msgstr "創建"
+
+#: no source
+msgid "Create a lark knowledge base"
+msgstr "創建知識庫"
+
+#: apps/knowledge/views/tag.py:21
+msgid "Create a new knowledge tag"
+msgstr ""
+
+#: no source
+msgid "Create a web site knowledge base"
+msgstr "創建web知識庫"
+
+#: apps/application/views/application.py:55
+#: apps/application/views/application.py:56
+#: apps/application/views/application.py:57
+msgid "Create an application"
+msgstr "創建一個智能體程式"
+
+#: apps/application/views/application_api_key.py:31
+#: apps/application/views/application_api_key.py:32
+#: apps/application/views/application_api_key.py:33
+msgid "Create application ApiKey"
+msgstr "創建智能體 API 密鑰"
+
+#: apps/application/views/application_api_key.py:60
+#: apps/application/views/application_api_key.py:61
+msgid "Create application ApiKey List"
+msgstr "創建智能體 API 密鑰列表"
+
+#: apps/knowledge/views/knowledge.py:594
+#: apps/knowledge/views/knowledge.py:595
+#: apps/knowledge/views/knowledge.py:596
+msgid "Create base knowledge"
+msgstr "創建知識庫"
+
+#: no source
+msgid "Create chat user"
+msgstr "創建對話用戶"
+
+#: apps/knowledge/views/document.py:53
+#: apps/knowledge/views/document.py:54
+#: apps/knowledge/views/document.py:55
+msgid "Create document"
+msgstr "創建文檔"
+
+#: apps/knowledge/views/document.py:513
+#: apps/knowledge/views/document.py:514
+#: apps/knowledge/views/document.py:515
+msgid "Create documents in batches"
+msgstr "批量創建文檔"
+
+#: apps/folders/views/folder.py:32
+#: apps/folders/views/folder.py:33
+#: apps/folders/views/folder.py:34
+msgid "Create folder"
+msgstr "創建文件夾"
+
+#: apps/knowledge/views/tag.py:20
+msgid "Create Knowledge Tag"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:229
+#: apps/knowledge/views/knowledge_workflow.py:230
+#: apps/knowledge/views/knowledge_workflow.py:231
+msgid "Create knowledge workflow"
+msgstr ""
+
+#: apps/models_provider/views/model.py:61
+#: apps/models_provider/views/model.py:62
+#: apps/models_provider/views/model.py:63
+msgid "Create model"
+msgstr "創建模型"
+
+#: no source
+msgid "Create or update Chat User Group"
+msgstr "創建或更新對話用戶組"
+
+#: apps/system_manage/views/email_setting.py:50
+#: apps/system_manage/views/email_setting.py:51
+#: apps/system_manage/views/email_setting.py:52
+msgid "Create or update email settings"
+msgstr "創建或更新郵件設置"
+
+#: no source
+msgid "Create or update role"
+msgstr "創建或更新角色"
+
+#: no source
+msgid "Create or update role permission"
+msgstr "創建或更新角色權限"
+
+#: no source
+msgid "Create or update user group"
+msgstr "創建或更新用戶組"
+
+#: no source
+msgid "Create or update workspace"
+msgstr "創建或更新工作空間"
+
+#: apps/knowledge/views/paragraph.py:50
+#: apps/knowledge/views/paragraph.py:51
+msgid "Create Paragraph"
+msgstr "創建段落"
+
+#: apps/knowledge/views/problem.py:50
+#: apps/knowledge/views/problem.py:51
+#: apps/knowledge/views/problem.py:52
+msgid "Create question"
+msgstr "創建問題"
+
+#: no source
+msgid "Create shared base knowledge"
+msgstr "創建共享知識庫"
+
+#: no source
+msgid "Create shared document"
+msgstr "創建共享文檔"
+
+#: no source
+msgid "Create shared documents in batches"
+msgstr "批量創建共享文檔"
+
+#: no source
+msgid "Create shared paragraph"
+msgstr "創建段落"
+
+#: no source
+msgid "Create shared question"
+msgstr "創建問題"
+
+#: no source
+msgid "Create shared tool"
+msgstr "創建共享工具"
+
+#: no source
+msgid "Create shared web knowledge"
+msgstr "創建 web 知識庫"
+
+#: no source
+msgid "Create system knowledge"
+msgstr "創建系統知識庫"
+
+#: no source
+msgid "Create system knowledges in batches"
+msgstr "批量創建知識庫"
+
+#: no source
+msgid "Create system paragraph"
+msgstr "創建段落"
+
+#: no source
+msgid "Create system question"
+msgstr "創建問題"
+
+#: no source
+msgid "Create SystemAPIKey"
+msgstr "創建系統 API 密鑰"
+
+#: apps/knowledge/views/termbase.py:58
+#: apps/knowledge/views/termbase.py:59
+#: apps/knowledge/views/termbase.py:60
+msgid "Create termbase"
+msgstr ""
+
+#: apps/tools/views/tool.py:44
+#: apps/tools/views/tool.py:45
+#: apps/tools/views/tool.py:46
+msgid "Create tool"
+msgstr "創建工具"
+
+#: apps/common/constants/permission_constants.py:388
+msgid "Create Trigger"
+msgstr "建立觸發器"
+
+#: apps/trigger/views/trigger.py:57
+#: apps/trigger/views/trigger.py:58
+#: apps/trigger/views/trigger.py:59
+msgid "Create trigger"
+msgstr "建立觸發器"
+
+#: apps/trigger/views/trigger.py:254
+#: apps/trigger/views/trigger.py:255
+#: apps/trigger/views/trigger.py:256
+msgid "Create trigger in source"
+msgstr "資源端建立觸發器"
+
+#: apps/application/serializers/application.py:456
+#: apps/knowledge/serializers/knowledge.py:190
+#: apps/models_provider/api/model.py:65
+#: apps/models_provider/serializers/model_serializer.py:363
+#: apps/models_provider/serializers/model_serializer.py:546
+#: apps/tools/serializers/tool.py:347
+#: apps/tools/serializers/tool.py:1695
+msgid "create user"
+msgstr "創建用戶"
+
+#: apps/trigger/serializers/trigger.py:643
+#: apps/users/views/user.py:175
+#: apps/users/views/user.py:176
+#: apps/users/views/user.py:177
+msgid "Create user"
+msgstr "創建用戶"
+
+#: apps/knowledge/views/knowledge.py:622
+#: apps/knowledge/views/knowledge.py:623
+#: apps/knowledge/views/knowledge.py:624
+msgid "Create web knowledge"
+msgstr "創建 web 知識庫"
+
+#: apps/knowledge/views/document.py:1197
+#: apps/knowledge/views/document.py:1198
+#: apps/knowledge/views/document.py:1199
+msgid "Create Web site documents"
+msgstr "創建網站文檔"
+
+#: no source
+msgid "Create Web site shared documents"
+msgstr "創建網站文檔"
+
+#: apps/application/serializers/application.py:469
+#: apps/application/serializers/application.py:469
+msgid "Creation time"
+msgstr "創建時間"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:32
+#: apps/system_manage/serializers/resource_mapping_serializers.py:114
+msgid "creator"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:230
+msgid "cron type requires cron_expression field"
+msgstr "cron 類型需要 cron_expression 欄位"
+
+#: no source
+msgid "Cross domain list"
+msgstr "跨域列表"
+
+#: apps/application/serializers/application_api_key.py:30
+msgid "Cross-domain address"
+msgstr "跨域地址"
+
+#: apps/application/serializers/application_api_key.py:31
+msgid "Cross-domain list"
+msgstr "跨域列表"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:13
+msgid "CueWord"
+msgstr "提示詞"
+
+#: apps/application/api/application_api.py:54
+#: apps/application/api/application_chat.py:110
+#: apps/application/api/application_chat_record.py:74
+#: apps/homepage/api/home_page_api.py:96
+#: apps/system_manage/api/resource_mapping.py:56
+#: apps/system_manage/api/user_resource_permission.py:207
+#: apps/system_manage/api/user_resource_permission.py:273
+#: apps/trigger/api/trigger.py:93
+#: apps/trigger/api/trigger_task.py:102
+msgid "Current page"
+msgstr "當前頁"
+
+#: apps/common/result/api.py:44
+msgid "current page"
+msgstr "當前頁"
+
+#: no source
+msgid "Currently only text messages are supported"
+msgstr "目前僅支持文本消息"
+
+#: no source
+msgid "Custom role"
+msgstr "自定義角色"
+
+#: no source
+msgid "Custom theme field type error"
+msgstr "自定義主題欄位類型錯誤"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:32
+msgid "cyberpunk"
+msgstr "賽博朋克"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:34
+msgid "dark style"
+msgstr "暗黑風格"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:83
+msgid "data source web node:{node_id} error{error}{traceback}"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:30
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:39
+msgid "Dataset id list"
+msgstr "知識庫 ID 列表"
+
+#: apps/application/serializers/application.py:606
+msgid "Dataset settings"
+msgstr "知識庫設置"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:88
+msgid "datasource data"
+msgstr ""
+
+#: apps/application/serializers/application_stats.py:31
+msgid "date"
+msgstr "日期"
+
+#: apps/chat/serializers/chat.py:291
+#: apps/chat/serializers/chat.py:536
+msgid "Debug"
+msgstr "調試"
+
+#: no source
+msgid "Debug shared Tool"
+msgstr "調試共享工具"
+
+#: no source
+msgid "Debug system tool"
+msgstr "調試工具"
+
+#: apps/tools/views/tool.py:99
+#: apps/tools/views/tool.py:100
+#: apps/tools/views/tool.py:101
+msgid "Debug Tool"
+msgstr "調試工具"
+
+#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:74
+msgid "Deepseek is a large-scale language model with 13 billion parameters."
+msgstr "Deepseek Chat 是一個聊天模型版本的 Deepseek。"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:216
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:72
+msgid "default"
+msgstr ""
+
+#: no source
+msgid "Default user group cannot be deleted"
+msgstr "默認用戶組不能被刪除"
+
+#: apps/models_provider/api/provide.py:41
+msgid "default value"
+msgstr "默認值"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:49
+msgid "Default value, the image style is randomly output by the model"
+msgstr "默認值，圖片風格由模型隨機輸出"
+
+#: no source
+msgid "Default workspace cannot be deleted"
+msgstr "默認工作空間不能被刪除"
+
+#: apps/users/serializers/user.py:71
+msgid "defaultPermission"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:351
+msgid "Delete"
+msgstr "刪除"
+
+#: apps/application/views/application_chat_record.py:196
+#: apps/application/views/application_chat_record.py:197
+#: apps/application/views/application_chat_record.py:198
+msgid "Delete a Annotation"
+msgstr "刪除注釋"
+
+#: apps/knowledge/views/tag.py:101
+msgid "Delete a knowledge tag"
+msgstr ""
+
+#: apps/application/views/application_api_key.py:109
+#: apps/application/views/application_api_key.py:110
+#: apps/application/views/application_api_key.py:111
+msgid "Delete Application API_KEY"
+msgstr "刪除智能體 API 密鑰"
+
+#: no source
+msgid "Delete application API_KEY"
+msgstr "删除智能體 API KEY"
+
+#: no source
+msgid "Delete chat user"
+msgstr "刪除對話用戶"
+
+#: no source
+msgid "Delete chat user group"
+msgstr "刪除對話用戶組"
+
+#: apps/knowledge/views/document.py:186
+#: apps/knowledge/views/document.py:187
+#: apps/knowledge/views/document.py:188
+msgid "Delete document"
+msgstr "刪除文檔"
+
+#: apps/knowledge/views/document.py:1072
+#: apps/knowledge/views/document.py:1073
+#: apps/knowledge/views/document.py:1074
+msgid "Delete document tags"
+msgstr ""
+
+#: apps/knowledge/views/document.py:593
+#: apps/knowledge/views/document.py:594
+#: apps/knowledge/views/document.py:595
+msgid "Delete documents in batches"
+msgstr "批量刪除文檔"
+
+#: apps/oss/views/file.py:59
+#: apps/oss/views/file.py:60
+#: apps/oss/views/file.py:61
+msgid "Delete file"
+msgstr "刪除文件"
+
+#: apps/folders/views/folder.py:146
+#: apps/folders/views/folder.py:147
+#: apps/folders/views/folder.py:148
+msgid "Delete folder"
+msgstr "刪除文件夾"
+
+#: apps/chat/views/chat_record.py:87
+#: apps/chat/views/chat_record.py:88
+#: apps/chat/views/chat_record.py:89
+msgid "Delete history conversation"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:92
+#: apps/knowledge/views/knowledge.py:93
+#: apps/knowledge/views/knowledge.py:94
+msgid "Delete knowledge"
+msgstr "刪除知識庫"
+
+#: no source
+msgid "Delete knowledge base"
+msgstr "刪除知識庫"
+
+#: apps/knowledge/views/tag.py:100
+msgid "Delete Knowledge Tag"
+msgstr ""
+
+#: apps/models_provider/views/model.py:138
+#: apps/models_provider/views/model.py:139
+#: apps/models_provider/views/model.py:140
+msgid "Delete model"
+msgstr "刪除模型"
+
+#: apps/knowledge/views/paragraph.py:239
+#: apps/knowledge/views/paragraph.py:240
+#: apps/knowledge/views/paragraph.py:241
+msgid "Delete paragraph"
+msgstr "刪除段落"
+
+#: no source
+msgid "Delete personal system API_KEY"
+msgstr "删除個人系統API KEY"
+
+#: apps/knowledge/views/problem.py:167
+#: apps/knowledge/views/problem.py:168
+#: apps/knowledge/views/problem.py:169
+msgid "Delete question"
+msgstr "刪除問題"
+
+#: no source
+msgid "Delete role"
+msgstr "刪除角色"
+
+#: no source
+msgid "Delete shared document"
+msgstr "刪除共享文檔"
+
+#: no source
+msgid "Delete shared documents in batches"
+msgstr "批量刪除共享文檔"
+
+#: no source
+msgid "Delete shared knowledge"
+msgstr "刪除共享知識庫"
+
+#: no source
+msgid "Delete shared paragraph"
+msgstr "刪除段落"
+
+#: no source
+msgid "Delete shared question"
+msgstr "刪除問題"
+
+#: no source
+msgid "Delete shared tool"
+msgstr "刪除共享工具"
+
+#: no source
+msgid "Delete system document"
+msgstr "刪除文檔"
+
+#: no source
+msgid "Delete system document in batches"
+msgstr "批量刪除文檔"
+
+#: no source
+msgid "Delete system knowledge"
+msgstr "刪除知識庫"
+
+#: no source
+msgid "Delete system knowledge in batches"
+msgstr "批量刪除知識庫"
+
+#: no source
+msgid "Delete system paragraph"
+msgstr "刪除段落"
+
+#: no source
+msgid "Delete system question"
+msgstr "刪除問題"
+
+#: no source
+msgid "Delete system tool"
+msgstr "刪除工具"
+
+#: no source
+msgid "Delete SystemAPIKey"
+msgstr "刪除系統 API 密鑰"
+
+#: apps/knowledge/views/termbase.py:163
+#: apps/knowledge/views/termbase.py:164
+#: apps/knowledge/views/termbase.py:165
+msgid "Delete termbase"
+msgstr ""
+
+#: no source
+msgid "Delete the System task source trigger"
+msgstr "刪除系統任務來源觸發器"
+
+#: apps/trigger/views/trigger.py:375
+#: apps/trigger/views/trigger.py:376
+#: apps/trigger/views/trigger.py:377
+msgid "Delete the task source trigger"
+msgstr "刪除資源端觸發器"
+
+#: apps/trigger/views/trigger.py:150
+#: apps/trigger/views/trigger.py:151
+#: apps/trigger/views/trigger.py:152
+msgid "Delete the trigger"
+msgstr "刪除觸發器"
+
+#: apps/tools/views/tool.py:175
+#: apps/tools/views/tool.py:176
+#: apps/tools/views/tool.py:177
+msgid "Delete tool"
+msgstr "刪除工具"
+
+#: apps/common/constants/permission_constants.py:390
+msgid "Delete Trigger"
+msgstr "刪除觸發器"
+
+#: apps/trigger/views/trigger.py:175
+#: apps/trigger/views/trigger.py:176
+#: apps/trigger/views/trigger.py:177
+msgid "Delete trigger in batches"
+msgstr "批次刪除觸發器"
+
+#: apps/users/views/user.py:206
+#: apps/users/views/user.py:207
+#: apps/users/views/user.py:208
+msgid "Delete user"
+msgstr "刪除用戶"
+
+#: no source
+msgid "Delete user group"
+msgstr "刪除用戶組"
+
+#: no source
+msgid "Delete workspace"
+msgstr "刪除工作空間"
+
+#: apps/application/views/application.py:170
+#: apps/application/views/application.py:171
+#: apps/application/views/application.py:172
+msgid "Deleting application"
+msgstr "刪除智能體"
+
+#: apps/application/views/application_chat.py:146
+#: apps/application/views/application_chat.py:147
+#: apps/application/views/application_chat.py:148
+#: apps/chat/views/chat.py:157
+#: apps/chat/views/chat.py:158
+#: apps/chat/views/chat.py:159
+msgid "dialogue"
+msgstr "對話"
+
+#: no source
+msgid "Dialogue log"
+msgstr "對話日誌"
+
+#: apps/common/constants/permission_constants.py:397
+#: apps/common/constants/permission_constants.py:399
+#: apps/common/constants/permission_constants.py:419
+#: apps/common/constants/permission_constants.py:429
+#: apps/common/constants/permission_constants.py:441
+msgid "Dialogue users"
+msgstr "對話用戶"
+
+#: apps/application/views/application_stats.py:28
+#: apps/application/views/application_stats.py:29
+#: apps/application/views/application_stats.py:30
+#: apps/homepage/views/homepage.py:232
+#: apps/homepage/views/homepage.py:233
+msgid "Dialogue-related statistical trends"
+msgstr "與對話有關的統計趨勢"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:24
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:22
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:22
+msgid "Dimensions"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:380
+msgid "Dingding"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:293
+msgid "DingTalk"
+msgstr "釘釘應用"
+
+#: no source
+msgid "dingtalk"
+msgstr "钉钉"
+
+#: no source
+msgid "DingTalk application: {user}"
+msgstr "釘釘智能體: {user}"
+
+#: no source
+msgid "DingTalk callback"
+msgstr "釘釘回調"
+
+#: no source
+msgid "DingTalk OAuth2 callback"
+msgstr "釘釘 OAuth2 回調"
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:24
+msgid "Direct answer content"
+msgstr "直接回答內容"
+
+#: apps/knowledge/serializers/document.py:174
+#: apps/knowledge/serializers/document.py:250
+msgid "directly return similarity"
+msgstr "直接返回相似度"
+
+#: apps/knowledge/serializers/knowledge.py:771
+msgid "Directly return similarity"
+msgstr "直接回傳相似度"
+
+#: apps/knowledge/views/paragraph.py:339
+#: apps/knowledge/views/paragraph.py:340
+#: apps/knowledge/views/paragraph.py:341
+msgid "Disassociation issue"
+msgstr "取消關聯問題"
+
+#: no source
+msgid "Disassociation shared issue"
+msgstr "取消關聯問題"
+
+#: no source
+msgid "Disassociation system issue"
+msgstr "取消關聯問題"
+
+#: no source
+msgid "disclaimer"
+msgstr "免責申明"
+
+#: no source
+msgid "disclaimer value"
+msgstr "免責申明內容"
+
+#: apps/application/serializers/application_access_token.py:38
+msgid "Display execution details"
+msgstr "是否顯示執行詳情"
+
+#: apps/common/constants/permission_constants.py:375
+#: apps/common/constants/permission_constants.py:402
+msgid "Display Settings"
+msgstr "顯示設置"
+
+#: no source
+msgid "Display settings"
+msgstr "顯示設置"
+
+#: no source
+msgid "Displaying knowledge sources is not enabled"
+msgstr "知識庫來源展示未開啟"
+
+#: apps/users/serializers/user.py:1104
+msgid "Do not send emails again within {seconds} seconds"
+msgstr "不要在 {seconds} 秒內再次發送郵件"
+
+#: apps/chat/serializers/chat.py:78
+msgid "Do you want to reply again"
+msgstr "是否重新回復"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:22
+#: apps/application/flow/step_node/document_extract_node/i_document_extract_node.py:13
+#: apps/chat/serializers/chat.py:93
+msgid "document"
+msgstr "文檔"
+
+#: apps/common/constants/permission_constants.py:355
+#: apps/common/constants/permission_constants.py:413
+#: apps/common/constants/permission_constants.py:423
+msgid "Document"
+msgstr "文檔"
+
+#: no source
+msgid "Document does not belong to current knowledge"
+msgstr "文件不屬於當前知識庫"
+
+#: apps/application/api/application_chat_record.py:136
+msgid "Document ID"
+msgstr "文檔 ID"
+
+#: apps/application/serializers/application_chat_record.py:251
+#: apps/application/serializers/application_chat_record.py:378
+#: apps/application/serializers/application_chat_record.py:478
+msgid "Document id"
+msgstr "文檔 ID"
+
+#: apps/knowledge/serializers/document.py:358
+#: apps/knowledge/serializers/document.py:588
+#: apps/knowledge/serializers/document.py:685
+#: apps/knowledge/serializers/document.py:1002
+#: apps/knowledge/serializers/document.py:1699
+#: apps/knowledge/serializers/document.py:1774
+#: apps/knowledge/serializers/document.py:1815
+#: apps/knowledge/serializers/document.py:1880
+#: apps/knowledge/serializers/paragraph.py:97
+#: apps/knowledge/serializers/paragraph.py:109
+#: apps/knowledge/serializers/paragraph.py:206
+#: apps/knowledge/serializers/paragraph.py:340
+#: apps/knowledge/serializers/paragraph.py:438
+#: apps/knowledge/serializers/paragraph.py:475
+#: apps/knowledge/serializers/paragraph.py:554
+#: apps/knowledge/serializers/paragraph.py:603
+#: apps/knowledge/serializers/paragraph.py:780
+#: apps/knowledge/serializers/problem.py:37
+#: apps/knowledge/serializers/problem.py:52
+msgid "document id"
+msgstr "文檔 ID"
+
+#: apps/knowledge/serializers/document.py:1871
+msgid "Document id does not belong to current knowledge"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1715
+#: apps/knowledge/serializers/document.py:1792
+#: apps/knowledge/serializers/document.py:1833
+#: apps/knowledge/serializers/document.py:1896
+msgid "Document id does not exist"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:236
+#: apps/knowledge/serializers/document.py:243
+msgid "document id list"
+msgstr "文檔 ID 列表"
+
+#: apps/knowledge/serializers/document.py:601
+#: apps/knowledge/serializers/document.py:699
+msgid "document id not exist"
+msgstr "文檔 ID 不存在"
+
+#: apps/knowledge/serializers/document.py:177
+#: apps/knowledge/serializers/document.py:480
+msgid "document is active"
+msgstr "文檔已激活"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:13
+#: apps/application/flow/step_node/knowledge_write_node/i_knowledge_write_node.py:20
+#: apps/knowledge/serializers/document.py:358
+msgid "document list"
+msgstr "文檔列表"
+
+#: apps/knowledge/serializers/knowledge.py:775
+msgid "Document meta"
+msgstr "文件元資料"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:53
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:54
+#: apps/knowledge/serializers/document.py:138
+#: apps/knowledge/serializers/document.py:138
+#: apps/knowledge/serializers/document.py:159
+#: apps/knowledge/serializers/document.py:159
+#: apps/knowledge/serializers/document.py:475
+msgid "document name"
+msgstr "文檔名稱"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:32
+msgid "document name relate problem"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:35
+msgid "document name relate problem reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:28
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:39
+msgid "document name relate problem type"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:774
+msgid "Document type"
+msgstr "文件類型"
+
+#: apps/knowledge/serializers/document.py:208
+#: apps/knowledge/serializers/document.py:209
+msgid "document url list"
+msgstr "文檔 URL 列表"
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:19
+msgid "domain"
+msgstr ""
+
+#: no source
+msgid "Download"
+msgstr "下載"
+
+#: apps/tools/serializers/tool.py:1378
+msgid "download callback url"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:372
+msgid "Download Original Document"
+msgstr "下載原文件"
+
+#: no source
+msgid "Download shared source file"
+msgstr "下載共享源文件"
+
+#: apps/knowledge/views/document.py:952
+#: apps/knowledge/views/document.py:953
+msgid "Download source file"
+msgstr "下載源文件"
+
+#: no source
+msgid "Download system source file"
+msgstr "下載系統源文件"
+
+#: apps/tools/serializers/tool.py:1377
+msgid "download url"
+msgstr ""
+
+#: no source
+msgid "draggable"
+msgstr "是否可拖動"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:43
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:43
+msgid "Duration"
+msgstr "時長"
+
+#: apps/common/constants/permission_constants.py:347
+msgid "Edit"
+msgstr "編輯"
+
+#: no source
+msgid "Edit folder"
+msgstr "編輯文件夾"
+
+#: apps/knowledge/views/knowledge.py:65
+#: apps/knowledge/views/knowledge.py:66
+#: apps/knowledge/views/knowledge.py:67
+msgid "Edit knowledge"
+msgstr "修改知識庫"
+
+#: apps/knowledge/views/knowledge_workflow.py:366
+#: apps/knowledge/views/knowledge_workflow.py:367
+#: apps/knowledge/views/knowledge_workflow.py:368
+msgid "Edit knowledge workflow"
+msgstr ""
+
+#: no source
+msgid "Edit Resource chat user group List"
+msgstr "編輯資源聊天用戶組列表"
+
+#: no source
+msgid "Edit Resource chat user List"
+msgstr "編輯資源聊天用戶列表"
+
+#: no source
+msgid "Edit shared tool icon"
+msgstr "修改共享工具圖標"
+
+#: no source
+msgid "Edit system tool icon"
+msgstr "修改工具圖標"
+
+#: apps/tools/views/tool.py:428
+#: apps/tools/views/tool.py:429
+#: apps/tools/views/tool.py:430
+msgid "Edit tool icon"
+msgstr "修改工具圖標"
+
+#: apps/tools/views/tool_workflow.py:68
+#: apps/tools/views/tool_workflow.py:69
+#: apps/tools/views/tool_workflow.py:70
+msgid "Edit tool workflow"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:389
+msgid "Edit Trigger"
+msgstr "編輯觸發器"
+
+#: apps/system_manage/views/user_resource_permission.py:142
+#: apps/system_manage/views/user_resource_permission.py:143
+#: apps/system_manage/views/user_resource_permission.py:144
+msgid "Edit user authorization status of resource"
+msgstr "修改資源對用戶的授權狀態"
+
+#: no source
+msgid "edition"
+msgstr "版本"
+
+#: apps/users/serializers/user.py:67
+#: apps/users/serializers/user.py:165
+#: apps/users/serializers/user.py:248
+#: apps/users/serializers/user.py:388
+#: apps/users/serializers/user.py:970
+#: apps/users/serializers/user.py:1085
+#: apps/users/serializers/user.py:1164
+msgid "Email"
+msgstr "郵箱"
+
+#: apps/common/constants/exception_code_constants.py:34
+msgid "Email format error"
+msgstr "郵箱格式錯誤"
+
+#: apps/users/serializers/user.py:424
+msgid "Email is already in use"
+msgstr "郵箱已被使用"
+
+#: apps/users/api/user.py:154
+msgid "Email or Username"
+msgstr "郵箱或用戶名"
+
+#: no source
+msgid "Email or username"
+msgstr "郵箱或用戶名"
+
+#: apps/common/constants/exception_code_constants.py:33
+#: apps/common/constants/exception_code_constants.py:45
+msgid "Email sending failed"
+msgstr "郵件發送失敗"
+
+#: apps/common/constants/permission_constants.py:352
+msgid "Email Setting"
+msgstr "郵箱設置"
+
+#: apps/system_manage/views/email_setting.py:55
+#: apps/system_manage/views/email_setting.py:70
+#: apps/system_manage/views/email_setting.py:86
+msgid "Email Settings"
+msgstr "郵箱設置"
+
+#: no source
+msgid "Email settings"
+msgstr "郵件設置"
+
+#: apps/system_manage/serializers/email_setting.py:52
+msgid "Email verification failed"
+msgstr "郵件認證失敗"
+
+#: apps/common/constants/permission_constants.py:373
+msgid "Embed third party"
+msgstr "嵌入第三方"
+
+#: apps/models_provider/base_model_provider.py:148
+msgid "Embedding Model"
+msgstr "向量模型"
+
+#: no source
+msgid "embedding model"
+msgstr "向量模型"
+
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:46
+msgid "Embedding-V1 is a text representation model based on Baidu Wenxin large model technology. It can convert text into a vector form represented by numerical values and can be used in text retrieval, information recommendation, knowledge mining and other scenarios. Embedding-V1 provides the Embeddings interface, which can generate corresponding vector representations based on input content. You can call this interface to input text into the model and obtain the corresponding vector representation for subsequent text processing and analysis."
+msgstr "Embedding-V1是一個基於百度文心大模型技術的文本表示模型，可以將文本轉化為用數值表示的向量形式，用於文本檢索、信息推薦、知識挖掘等場景。 Embedding-V1提供了Embeddings接口，可以根據輸入內容生成對應的向量表示。您可以通過調用該接口，將文本輸入到模型中，獲取到對應的向量表示，從而進行後續的文本處理和分析。"
+
+#: no source
+msgid "Enable"
+msgstr "啟用"
+
+#: apps/users/serializers/login.py:37
+msgid "encryptedData"
+msgstr ""
+
+#: apps/common/job/clean_chat_job.py:45
+msgid "end clean chat log"
+msgstr "結束清理聊天日誌"
+
+#: apps/common/job/clean_debug_file_job.py:30
+msgid "end clean debug file"
+msgstr "結束清理調試文件"
+
+#: apps/application/serializers/application.py:278
+msgid "End of thinking process marker"
+msgstr "思考過程結束標記"
+
+#: apps/common/job/client_access_num_job.py:27
+msgid "end reset access_num"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:57
+#: apps/application/serializers/application_stats.py:41
+#: apps/homepage/serializers/homepage.py:92
+#: apps/homepage/serializers/homepage.py:153
+#: apps/homepage/serializers/homepage.py:219
+#: apps/homepage/serializers/homepage.py:391
+#: apps/homepage/serializers/homepage.py:518
+#: apps/homepage/serializers/homepage.py:658
+msgid "End time"
+msgstr "結束時間"
+
+#: apps/common/event/listener_manage.py:411
+msgid "End--->Embedding document: {document_id}"
+msgstr "結束--->向量文檔: {document_id}"
+
+#: apps/common/event/listener_manage.py:436
+msgid "End--->Embedding knowledge: {knowledge_id}"
+msgstr "結束--->向量知識庫: {knowledge_id}"
+
+#: apps/common/event/listener_manage.py:147
+msgid "End--->Embedding paragraph: {paragraph_id_list}"
+msgstr "結束--->向量段落: {paragraph_id_list}"
+
+#: apps/common/event/listener_manage.py:197
+msgid "End--->Embedding paragraph: {paragraph_id}"
+msgstr "結束--->向量段落: {paragraph_id}"
+
+#: apps/knowledge/task/sync.py:33
+#: apps/knowledge/task/sync.py:55
+msgid "End--->End synchronization web knowledge base:{knowledge_id}"
+msgstr "結束--->結束同步 web 知識庫:{knowledge_id}"
+
+#: apps/knowledge/task/generate.py:107
+msgid "End--->Generate problem: {document_id}"
+msgstr "結束--->生成問題: {document_id}"
+
+#: apps/common/event/listener_manage.py:569
+msgid "End--->Tokenize document: {document_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:250
+msgid "End--->Tokenize paragraph: {paragraph_id}"
+msgstr ""
+
+#: apps/knowledge/task/embedding.py:137
+msgid "End--->Vectorized knowledge: {knowledge_id}"
+msgstr "結束--->向量知識庫: {knowledge_id}"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:12
+msgid "Engine model type"
+msgstr "引擎模型類型"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:21
+msgid "English"
+msgstr "英文"
 
 #: apps/models_provider/impl/xinference_model_provider/credential/tts.py:24
 msgid "English female"
@@ -4885,231 +2812,641 @@ msgstr "英文女"
 msgid "English male"
 msgstr "英文男"
 
-#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:26
-msgid "Korean female"
-msgstr "韓語女"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:17
+msgid "English telephone universal"
+msgstr "英文電話通用"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:37
-msgid ""
-"Code Llama is a language model specifically designed for code generation."
-msgstr "Code Llama 是一個專門用於代碼生成的語言模型。"
+#: apps/knowledge/serializers/document.py:1309
+msgid "enter"
+msgstr "回車"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:44
-msgid ""
-"\n"
-"Code Llama Instruct is a fine-tuned version of Code Llama's instructions, "
-"designed to perform specific tasks.\n"
-"        "
+#: apps/application/serializers/application_chat.py:290
+msgid "Enterprise WeChat"
+msgstr "企業微信應用"
+
+#: no source
+msgid "Enterprise WeChat customer service: "
+msgstr "企業微信客服: "
+
+#: apps/application/serializers/application_chat.py:294
+msgid "Enterprise WeChat Robot"
+msgstr "企業微信機器人"
+
+#: no source
+msgid "Enterprise WeChat user: "
+msgstr "企業微信用戶: "
+
+#: apps/common/constants/permission_constants.py:378
+msgid "Enterprise WeiXin"
 msgstr ""
-"Code Llama Instruct 是 Code Llama 的指令微調版本，專為執行特定任務而設計。"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:53
-msgid ""
-"Code Llama Python is a language model specifically designed for Python code "
-"generation."
-msgstr "Code Llama Python 是一個專門用於 Python 代碼生成的語言模型。"
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:31
+msgid "ERNIE-Bot is a large language model independently developed by Baidu. It covers massive Chinese data and has stronger capabilities in dialogue Q&A, content creation and generation."
+msgstr "ERNIE-Bot是百度自行研發的大語言模型，覆蓋海量中文數據，具有更強的對話問答、內容創作生成等能力。"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:60
-msgid ""
-"CodeQwen 1.5 is a language model for code generation with high performance."
-msgstr "CodeQwen 1.5 是一個用於代碼生成的語言模型，具有較高的性能。"
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:28
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:59
+msgid "ERNIE-Bot-4 is a large language model independently developed by Baidu. It covers massive Chinese data and has stronger capabilities in dialogue Q&A, content creation and generation."
+msgstr "ERNIE-Bot-4是百度自行研發的大語言模型，覆蓋海量中文數據，具有更強的對話問答、內容創作生成等能力。"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:67
-msgid "CodeQwen 1.5 Chat is a chat model version of CodeQwen 1.5."
-msgstr "CodeQwen 1.5 Chat 是一個聊天模型版本的 CodeQwen 1.5。"
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:34
+msgid "ERNIE-Bot-turbo is a large language model independently developed by Baidu. It covers massive Chinese data, has stronger capabilities in dialogue Q&A, content creation and generation, and has a faster response speed."
+msgstr "ERNIE-Bot-turbo是百度自行研發的大語言模型，覆蓋海量中文數據，具有更強的對話問答、內容創作生成等能力，響應速度更快。"
 
-#: apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py:74
-msgid "Deepseek is a large-scale language model with 13 billion parameters."
-msgstr "Deepseek Chat 是一個聊天模型版本的 Deepseek。"
+#: apps/common/result/api.py:18
+#: apps/common/result/api.py:19
+#: apps/common/result/api.py:28
+#: apps/common/result/api.py:29
+msgid "error prompt"
+msgstr "錯誤提示"
 
-#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:16
-msgid ""
-"Image size, only cogview-3-plus supports this parameter. Optional range: "
-"[1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440], the "
-"default is 1024x1024."
+#: apps/trigger/serializers/trigger.py:418
+#: apps/trigger/serializers/trigger.py:442
+msgid "Error source type"
 msgstr ""
-"圖片尺寸，僅 cogview-3-plus 支持該參數。可選範圍："
-"[1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440]，默認是"
-"1024x1024。"
 
-#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:34
-msgid ""
-"Have strong multi-modal understanding capabilities. Able to understand up to "
-"five images simultaneously and supports video content understanding"
-msgstr "具有強大的多模態理解能力。能夠同時理解多達五張圖像，並支持視頻內容理解"
+#: apps/trigger/serializers/trigger.py:117
+msgid "Error trigger type"
+msgstr "觸發器類型錯誤"
+
+#: apps/trigger/handler/impl/trigger/event_trigger.py:80
+#: apps/trigger/handler/impl/trigger/event_trigger.py:81
+#: apps/trigger/handler/impl/trigger/event_trigger.py:82
+msgid "Event Trigger WebHook"
+msgstr ""
+
+#: apps/models_provider/views/provide.py:57
+#: apps/models_provider/views/provide.py:58
+#: apps/models_provider/views/provide.py:59
+msgid "Example of obtaining model list"
+msgstr "獲取模型列表示例"
+
+#: apps/application/flow/step_node/loop_node/impl/base_loop_node.py:150
+msgid "Exceeding the maximum number of cycles"
+msgstr ""
+
+#: apps/application/serializers/application_api_key.py:33
+msgid "Expiration time"
+msgstr ""
+
+#: no source
+msgid "expired"
+msgstr "過期時間"
+
+#: apps/common/constants/permission_constants.py:362
+msgid "Export"
+msgstr "導出"
+
+#: apps/application/views/application.py:142
+#: apps/application/views/application.py:143
+#: apps/application/views/application.py:144
+msgid "Export application"
+msgstr "導出智能體"
+
+#: no source
+msgid "Export Application"
+msgstr "導出智能體"
+
+#: apps/application/views/application_chat.py:95
+#: apps/application/views/application_chat.py:96
+#: apps/application/views/application_chat.py:97
+msgid "Export conversation"
+msgstr "導出對話"
+
+#: apps/knowledge/views/document.py:886
+#: apps/knowledge/views/document.py:887
+msgid "Export document"
+msgstr "導出文檔"
+
+#: apps/knowledge/views/knowledge.py:363
+#: apps/knowledge/views/knowledge.py:364
+msgid "Export knowledge base"
+msgstr "導出知識庫"
+
+#: apps/knowledge/views/knowledge.py:390
+#: apps/knowledge/views/knowledge.py:391
+msgid "Export knowledge base containing images"
+msgstr "導出包含圖片的知識庫"
+
+#: apps/knowledge/views/knowledge.py:417
+#: apps/knowledge/views/knowledge.py:418
+msgid "Export knowledge bundle"
+msgstr "匯出知識庫"
+
+#: apps/knowledge/views/knowledge_workflow.py:292
+#: apps/knowledge/views/knowledge_workflow.py:293
+#: apps/knowledge/views/knowledge_workflow.py:294
+msgid "Export knowledge workflow"
+msgstr "匯出知識工作流"
+
+#: no source
+msgid "Export operate log"
+msgstr "導出操作日誌"
+
+#: no source
+msgid "Export shared document"
+msgstr "導出共享文檔"
+
+#: no source
+msgid "Export shared knowledge base"
+msgstr "導出共享知識庫"
+
+#: no source
+msgid "Export shared knowledge base containing images"
+msgstr "導出包含圖片的共享知識庫"
+
+#: no source
+msgid "Export shared knowledge bundle"
+msgstr "匯出共享知識庫"
+
+#: no source
+msgid "Export shared tool"
+msgstr "導出共享工具"
+
+#: no source
+msgid "Export system knowledge"
+msgstr "導出知識庫"
+
+#: no source
+msgid "Export system knowledge base"
+msgstr "導出系統知識庫"
+
+#: no source
+msgid "Export system knowledge base containing images"
+msgstr "導出包含圖片的系統知識庫"
+
+#: no source
+msgid "Export system knowledge bundle"
+msgstr "匯出系統知識庫"
+
+#: no source
+msgid "Export system tool"
+msgstr "導出工具"
+
+#: apps/tools/views/tool.py:374
+#: apps/tools/views/tool.py:375
+#: apps/tools/views/tool.py:376
+msgid "Export tool"
+msgstr "導出工具"
+
+#: apps/knowledge/views/document.py:919
+#: apps/knowledge/views/document.py:920
+msgid "Export Zip document"
+msgstr "導出 Zip 文檔"
+
+#: no source
+msgid "Export Zip shared document"
+msgstr "導出共享文檔 Zip"
+
+#: no source
+msgid "Export Zip system knowledge"
+msgstr "導出Zip知識庫"
+
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:31
+#: apps/models_provider/impl/vllm_model_provider/vllm_model_provider.py:64
+msgid "Facebook’s 125M parameter model"
+msgstr "Facebook的125M參數模型"
+
+#: no source
+msgid "Fail"
+msgstr "失敗"
+
+#: apps/homepage/api/home_page_api.py:312
+msgid "Failed document count"
+msgstr "失敗文件數量"
+
+#: apps/users/views/user.py:402
+msgid "Failed to change password"
+msgstr "修改密碼失敗"
+
+#: apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py:65
+#: apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py:59
+msgid "Failed to generate video"
+msgstr "生成視頻失敗"
+
+#: no source
+msgid "Failed to get Lark collaborators"
+msgstr "獲取 Lark 協作者失敗"
+
+#: no source
+msgid "Failed to get lark document list!"
+msgstr "獲取飛書文檔列表失敗！"
+
+#: no source
+msgid "Failed to get Lark user details"
+msgstr "獲取 Lark 用戶詳情失敗"
+
+#: no source
+msgid "Failed to get WeCom access token"
+msgstr "獲取 WeCom 訪問權杖失敗"
+
+#: no source
+msgid "Failed to get WeCom agent info"
+msgstr "獲取 WeCom 智能助手信息失敗"
+
+#: no source
+msgid "Failed to get WeCom department users"
+msgstr "獲取 WeCom 部門用戶失敗"
+
+#: no source
+msgid "Failed to get WeCom user info"
+msgstr "獲取 WeCom 用戶詳情失敗"
+
+#: apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py:92
+msgid "Failed to obtain the image"
+msgstr "獲取圖片失敗"
+
+#: no source
+msgid "Failed to obtain user information"
+msgstr "獲取用戶信息失敗"
+
+#: apps/knowledge/task/embedding.py:28
+#: apps/knowledge/task/embedding.py:85
+msgid "Failed to obtain vector model: {error} {traceback}"
+msgstr "向量模型獲取失敗: {error} {traceback}"
+
+#: apps/oss/serializers/file.py:202
+msgid "Failed to resolve host: {error}"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:358
+#: apps/knowledge/serializers/knowledge.py:387
+msgid "Failed to send the vectorization task, please try again later!"
+msgstr "發送向量化任務失敗，請稍後再試！"
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:80
+msgid "Faster, more affordable TTS model"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:216
+msgid "Feedback reason"
+msgstr "反饋理由"
+
+#: apps/common/constants/permission_constants.py:379
+msgid "Feishu"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:601
+msgid "field has no value set"
+msgstr "欄位未設置值"
+
+#: apps/tools/serializers/tool.py:273
+msgid "field label"
+msgstr "標籤"
+
+#: no source
+msgid "Field mapping cannot be empty"
+msgstr "欄位映射不能為空"
+
+#: apps/tools/serializers/tool.py:272
+msgid "field name"
+msgstr "欄位名稱"
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:56
+msgid "Field: {name} No value set"
+msgstr "欄位：{name} 未設置值"
+
+#: apps/tools/serializers/tool.py:613
+msgid "Field: {name} Type: {type} Value: {value} Type conversion error"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:98
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:74
+msgid "Field: {name} Type: {_type} is required"
+msgstr ""
+
+#: no source
+msgid "Field: {name} Type: {_type} Value: {value} Type conversion error"
+msgstr "欄位：{name} 類型：{_type} 值：{value} 類型轉換錯誤"
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:81
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:112
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:57
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:88
+#: apps/trigger/handler/impl/trigger/event_trigger.py:48
+msgid "Field: {name} Type: {_type} Value: {value} Type error"
+msgstr "欄位：{name} 類型：{_type} 值：{value} 類型轉換錯誤"
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:76
+#: apps/application/flow/step_node/tool_node/impl/base_tool_node.py:52
+#: apps/trigger/handler/impl/trigger/event_trigger.py:43
+msgid "Field: {name} Type: {_type} Value: {value} Unsupported this type"
+msgstr "欄位：{name} 類型：{_type} 值：{value} 不支持該類型"
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:21
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:22
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:21
+msgid "Fields"
+msgstr "欄位"
+
+#: apps/tools/serializers/tool.py:255
+msgid "fields only support string|int|dict|array|float"
+msgstr "欄位僅支持字符串|整數|字典|數組|浮點數"
+
+#: apps/application/serializers/application.py:581
+#: apps/application/serializers/application.py:976
+#: apps/knowledge/serializers/document.py:216
+#: apps/knowledge/serializers/document.py:222
+#: apps/knowledge/serializers/document.py:1881
+#: apps/knowledge/serializers/knowledge.py:116
+#: apps/knowledge/serializers/knowledge_workflow.py:93
+#: apps/oss/serializers/file.py:69
+#: apps/tools/serializers/tool.py:908
+#: apps/tools/serializers/tool.py:1529
+#: apps/tools/serializers/tool_workflow.py:124
+msgid "file"
+msgstr "文件"
+
+#: apps/oss/views/file.py:23
+#: apps/oss/views/file.py:44
+#: apps/oss/views/file.py:64
+msgid "File"
+msgstr "文件"
+
+#: apps/application/serializers/application.py:1748
+msgid "File clean time"
+msgstr ""
+
+#: apps/application/serializers/application.py:1756
+msgid "File clean time cannot exceed clean time"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:138
+msgid "file count limit"
+msgstr "文件數量限制"
+
+#: apps/knowledge/serializers/document.py:197
+#: apps/knowledge/serializers/document.py:216
+#: apps/knowledge/serializers/document.py:222
+msgid "file list"
+msgstr "文件 列表"
+
+#: apps/knowledge/serializers/document.py:764
+msgid "File not exist. Only manually uploaded documents are supported"
+msgstr "文件不存在, 僅支持手動上傳的文檔"
+
+#: apps/oss/serializers/file.py:109
+msgid "File not found"
+msgstr "文件未找到"
+
+#: apps/oss/serializers/file.py:250
+msgid "File size exceeds limit"
+msgstr "文件大小超出限制"
+
+#: apps/knowledge/serializers/knowledge.py:137
+msgid "file size limit"
+msgstr "文件大小限制"
+
+#: apps/oss/serializers/file.py:224
+msgid "File upload is not enabled"
+msgstr "文件上傳未啟用"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:28
+msgid "Filipino language"
+msgstr "菲律賓語"
+
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:35
+msgid "First frame url"
+msgstr ""
+
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:53
+msgid "First frame url cannot be empty"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:58
+msgid "flat illustration"
+msgstr "扁平插畫"
+
+#: no source
+msgid "float icon"
+msgstr "浮動圖標"
+
+#: no source
+msgid "float icon url"
+msgstr "浮動圖標地址"
+
+#: no source
+msgid "Float location field type error"
+msgstr "浮動位置欄位類型錯誤"
+
+#: no source
+msgid "float location type"
+msgstr "浮動位置類型"
+
+#: no source
+msgid "float location value"
+msgstr "浮動位置值"
+
+#: no source
+msgid "float location x"
+msgstr "浮動位置 X"
+
+#: no source
+msgid "float location y"
+msgstr "浮動位置 Y"
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:37
-msgid ""
-"Focus on single picture understanding. Suitable for scenarios requiring "
-"efficient image analysis"
+msgid "Focus on single picture understanding. Suitable for scenarios requiring efficient image analysis"
 msgstr "專注於單圖理解。適用於需要高效圖像解析的場景"
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:40
-msgid ""
-"Focus on single picture understanding. Suitable for scenarios requiring "
-"efficient image analysis (free)"
+msgid "Focus on single picture understanding. Suitable for scenarios requiring efficient image analysis (free)"
 msgstr "專注於單圖理解。適用於需要高效圖像解析的場景(免費)"
 
-#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:46
-msgid ""
-"Quickly and accurately generate images based on user text descriptions. "
-"Resolution supports 1024x1024"
-msgstr "根據用戶文字描述快速、精準生成圖像。解析度支持1024x1024"
+#: apps/common/constants/permission_constants.py:443
+#: apps/common/constants/permission_constants.py:444
+#: apps/common/constants/permission_constants.py:445
+#: apps/folders/views/folder.py:38
+#: apps/folders/views/folder.py:72
+#: apps/folders/views/folder.py:99
+#: apps/folders/views/folder.py:131
+#: apps/folders/views/folder.py:151
+msgid "Folder"
+msgstr "文件夾"
+
+#: no source
+msgid "folder"
+msgstr "文件夾"
+
+#: apps/folders/serializers/folder.py:98
+msgid "Folder depth cannot exceed 10000 levels"
+msgstr ""
+
+#: no source
+msgid "Folder depth cannot exceed 5 levels"
+msgstr "文件夾深度不能超過5級"
+
+#: apps/folders/models/folder.py:8
+#: apps/folders/models/folder.py:19
+#: apps/folders/serializers/folder.py:128
+msgid "folder description"
+msgstr "文件夾描述"
+
+#: apps/folders/serializers/folder.py:188
+#: apps/folders/serializers/folder.py:245
+msgid "Folder does not exist"
+msgstr "文件夾不存在"
+
+#: apps/application/api/application_api.py:68
+#: apps/application/serializers/application.py:302
+#: apps/application/serializers/application.py:347
+#: apps/application/serializers/application.py:447
+#: apps/folders/serializers/folder.py:126
+#: apps/folders/serializers/folder.py:176
+#: apps/knowledge/serializers/common.py:66
+#: apps/knowledge/serializers/knowledge.py:110
+#: apps/knowledge/serializers/knowledge.py:121
+#: apps/knowledge/serializers/knowledge.py:176
+#: apps/knowledge/serializers/knowledge.py:885
+#: apps/tools/serializers/tool.py:319
+#: apps/tools/serializers/tool.py:342
+#: apps/tools/serializers/tool.py:911
+#: apps/tools/serializers/tool.py:1687
+msgid "folder id"
+msgstr "文件夾 ID"
+
+#: apps/application/serializers/application.py:582
+msgid "Folder ID"
+msgstr ""
+
+#: apps/folders/models/folder.py:6
+#: apps/folders/models/folder.py:17
+#: apps/folders/serializers/folder.py:127
+msgid "folder name"
+msgstr "文件夾名稱"
+
+#: apps/folders/serializers/folder.py:153
+#: apps/folders/serializers/folder.py:201
+#: apps/folders/serializers/folder.py:222
+msgid "Folder name already exists"
+msgstr "文件夾名稱已存在"
+
+#: apps/knowledge/serializers/knowledge.py:261
+#: apps/knowledge/serializers/knowledge.py:292
+#: apps/tools/serializers/tool.py:1703
+msgid "Folder not found"
+msgstr "文件夾不存在"
+
+#: no source
+msgid "Folder token"
+msgstr "文件夾 Token"
+
+#: no source
+msgid "folder token"
+msgstr "文件夾令牌"
+
+#: apps/folders/serializers/folder.py:129
+msgid "folder user id"
+msgstr "文件夾用戶 ID"
+
+#: apps/application/flow/step_node/form_node/i_form_node.py:20
+msgid "Form Configuration"
+msgstr "表單配置"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:27
+#: apps/application/flow/step_node/form_node/i_form_node.py:22
+msgid "Form Data"
+msgstr "表單數據"
+
+#: apps/application/flow/step_node/form_node/i_form_node.py:21
+msgid "Form output content"
+msgstr "表單輸出內容"
+
+#: no source
+msgid "forum url"
+msgstr "論壇網址"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:35
+msgid "French"
+msgstr "法語"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:46
+msgid "function"
+msgstr "工具內容"
+
+#: apps/tools/serializers/tool.py:336
+msgid "function content"
+msgstr "工具內容"
+
+#: apps/tools/serializers/tool.py:1169
+msgid "Function does not exist"
+msgstr "工具不存在"
+
+#: apps/tools/serializers/tool.py:1150
+msgid "function ID"
+msgstr "工具 ID"
+
+#: no source
+msgid "Function {name} is unavailable"
+msgstr "工具 {name} 不可用"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:302
+msgid "function_name"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:41
+msgid "Game cartoon hand drawing"
+msgstr "遊戲卡通手繪"
+
+#: apps/common/constants/permission_constants.py:364
+msgid "Generate"
+msgstr "生成問題"
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:49
-msgid ""
-"Generate high-quality images based on user text descriptions, supporting "
-"multiple image sizes"
+msgid "Generate high-quality images based on user text descriptions, supporting multiple image sizes"
 msgstr "根據用戶文字描述生成高質量圖像，支持多圖片尺寸"
 
 #: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:52
-msgid ""
-"Generate high-quality images based on user text descriptions, supporting "
-"multiple image sizes (free)"
+msgid "Generate high-quality images based on user text descriptions, supporting multiple image sizes (free)"
 msgstr "根據用戶文字描述生成高質量圖像，支持多圖片尺寸(免費)"
 
-#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:75
-msgid "zhipu AI"
-msgstr "智譜 AI"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:49
+msgid "Generate image resolution"
+msgstr "生成圖像解析度"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:32
-#: apps/models_provider/serializers/model_apply_serializers.py:37
-msgid "vector text"
-msgstr "向量文本"
+#: apps/knowledge/task/generate.py:103
+msgid "Generate issue based on document: {document_id} error {error}{traceback}"
+msgstr "生成問題基於文檔: {document_id} 錯誤 {error}{traceback}"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:33
-msgid "vector text list"
-msgstr "向量文本列表"
+#: apps/application/views/application_chat.py:162
+#: apps/application/views/application_chat.py:163
+#: apps/application/views/application_chat.py:164
+msgid "generate prompt"
+msgstr "生成提示詞"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:41
-msgid "text"
-msgstr "文本"
+#: apps/knowledge/views/knowledge.py:482
+#: apps/knowledge/views/knowledge.py:483
+#: apps/knowledge/views/knowledge.py:484
+msgid "Generate related"
+msgstr "生成相關"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:42
-msgid "metadata"
-msgstr "元數據"
+#: no source
+msgid "Generate related documents"
+msgstr "生成相關文檔"
 
-#: apps/models_provider/serializers/model_apply_serializers.py:47
-msgid "query"
-msgstr "查詢"
+#: apps/application/views/application_chat_link.py:24
+#: apps/application/views/application_chat_link.py:25
+#: apps/application/views/application_chat_link.py:26
+msgid "Generate share link"
+msgstr "產生分享連結"
 
-#: apps/models_provider/serializers/model_serializer.py:44
-#: apps/models_provider/serializers/model_serializer.py:257
-msgid "parameter configuration"
-msgstr "參數配置"
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:36
+msgid "German"
+msgstr "德語"
 
-#: apps/models_provider/serializers/model_serializer.py:45
-#: apps/models_provider/serializers/model_serializer.py:222
-#: apps/models_provider/serializers/model_serializer.py:258
-msgid "certification information"
-msgstr "認證信息"
+#: apps/knowledge/views/problem.py:79
+#: apps/knowledge/views/problem.py:80
+#: apps/knowledge/views/problem.py:81
+msgid "Get a list of associated paragraphs"
+msgstr "獲取關聯段落列表"
 
-#: apps/models_provider/serializers/model_serializer.py:118
-msgid "Shared models cannot be deleted or modified"
-msgstr "共享模型不能被刪除或修改"
+#: no source
+msgid "Get a list of associated shared paragraphs"
+msgstr "獲取關聯段落列表"
 
-#: apps/models_provider/serializers/model_serializer.py:230
-#: apps/models_provider/serializers/model_serializer.py:269
-#, python-brace-format
-msgid "base model【{model_name}】already exists"
-msgstr "模型【{model_name}】已存在"
-
-#: apps/models_provider/serializers/model_serializer.py:309
-msgid "Model saving failed"
-msgstr "模型保存失敗"
-
-#: apps/models_provider/views/model.py:60
-#: apps/models_provider/views/model.py:61
-#: apps/models_provider/views/model.py:62 apps/shared/views/shared_model.py:55
-#: apps/shared/views/shared_model.py:56 apps/shared/views/shared_model.py:57
-msgid "Create model"
-msgstr "創建模型"
-
-#: apps/models_provider/views/model.py:90
-#: apps/models_provider/views/model.py:91
-#: apps/models_provider/views/model.py:92 apps/shared/views/shared_model.py:84
-#: apps/shared/views/shared_model.py:85 apps/shared/views/shared_model.py:86
-msgid "Query model list"
-msgstr "查詢模型列表"
-
-#: apps/models_provider/views/model.py:107
-#: apps/models_provider/views/model.py:108
-#: apps/models_provider/views/model.py:109
-#: apps/shared/views/shared_model.py:101 apps/shared/views/shared_model.py:102
-#: apps/shared/views/shared_model.py:103
-msgid "Update model"
-msgstr "更新模型"
-
-#: apps/models_provider/views/model.py:125
-#: apps/models_provider/views/model.py:126
-#: apps/models_provider/views/model.py:127
-#: apps/shared/views/shared_model.py:119 apps/shared/views/shared_model.py:120
-#: apps/shared/views/shared_model.py:121
-msgid "Delete model"
-msgstr "刪除模型"
-
-#: apps/models_provider/views/model.py:140
-#: apps/models_provider/views/model.py:141
-#: apps/models_provider/views/model.py:142
-#: apps/shared/views/shared_model.py:133 apps/shared/views/shared_model.py:134
-#: apps/shared/views/shared_model.py:135
-msgid "Query model details"
-msgstr "查詢模型詳情"
-
-#: apps/models_provider/views/model.py:155
-#: apps/models_provider/views/model.py:156
-#: apps/models_provider/views/model.py:157
-#: apps/shared/views/shared_model.py:148 apps/shared/views/shared_model.py:149
-#: apps/shared/views/shared_model.py:150
-msgid "Get model parameter form"
-msgstr "獲取模型參數表單"
-
-#: apps/models_provider/views/model.py:167
-#: apps/models_provider/views/model.py:168
-#: apps/models_provider/views/model.py:169
-#: apps/shared/views/shared_model.py:160 apps/shared/views/shared_model.py:161
-#: apps/shared/views/shared_model.py:162
-msgid "Save model parameter form"
-msgstr "保存模型參數表單"
-
-#: apps/models_provider/views/model.py:187
-#: apps/models_provider/views/model.py:189
-#: apps/models_provider/views/model.py:191
-#: apps/shared/views/shared_model.py:179 apps/shared/views/shared_model.py:181
-#: apps/shared/views/shared_model.py:183
-msgid ""
-"Query model meta information, this interface does not carry authentication "
-"information"
-msgstr "查詢模型元信息，該接口不攜帶認證信息"
-
-#: apps/models_provider/views/model.py:204
-#: apps/models_provider/views/model.py:205
-#: apps/models_provider/views/model.py:206
-#: apps/shared/views/shared_model.py:196 apps/shared/views/shared_model.py:197
-#: apps/shared/views/shared_model.py:198
-msgid "Pause model download"
-msgstr "下載模型暫停"
-
-#: apps/models_provider/views/model.py:222
-#: apps/models_provider/views/model.py:223
-#: apps/models_provider/views/model.py:224
-msgid "Get Share model"
-msgstr "獲取共享模型"
-
-#: apps/models_provider/views/model_apply.py:25
-#: apps/models_provider/views/model_apply.py:26
-#: apps/models_provider/views/model_apply.py:27
-#: apps/models_provider/views/model_apply.py:37
-#: apps/models_provider/views/model_apply.py:38
-#: apps/models_provider/views/model_apply.py:39
-msgid "Vectorization documentation"
-msgstr "向量化文檔"
-
-#: apps/models_provider/views/model_apply.py:49
-#: apps/models_provider/views/model_apply.py:50
-#: apps/models_provider/views/model_apply.py:51
-msgid "Reorder documents"
-msgstr "重新排序文檔"
+#: no source
+msgid "Get a list of associated system paragraphs"
+msgstr "獲取關聯段落列表"
 
 #: apps/models_provider/views/provide.py:21
 #: apps/models_provider/views/provide.py:22
@@ -5123,1480 +3460,221 @@ msgstr "獲取模型供應商列表"
 msgid "Get a list of model types"
 msgstr "獲取模型類型列表"
 
-#: apps/models_provider/views/provide.py:57
-#: apps/models_provider/views/provide.py:58
-#: apps/models_provider/views/provide.py:59
-msgid "Example of obtaining model list"
-msgstr "獲取模型列表示例"
-
-#: apps/models_provider/views/provide.py:75
-#: apps/models_provider/views/provide.py:76
-#: apps/models_provider/views/provide.py:77
-msgid "Get model default parameters"
-msgstr "獲取模型默認參數"
-
-#: apps/models_provider/views/provide.py:92
-#: apps/models_provider/views/provide.py:93
-#: apps/models_provider/views/provide.py:94
-msgid "Get the model creation form"
-msgstr "獲取模型創建表單"
-
-#: apps/oss/serializers/file.py:80
-msgid "File not found"
-msgstr "文件未找到"
-
-#: apps/oss/views/file.py:21 apps/oss/views/file.py:22
-#: apps/oss/views/file.py:23
-msgid "Upload file"
-msgstr "上傳文件"
-
-#: apps/oss/views/file.py:27 apps/oss/views/file.py:41
-#: apps/oss/views/file.py:53
-msgid "File"
-msgstr "文件"
-
-#: apps/oss/views/file.py:36 apps/oss/views/file.py:37
-#: apps/oss/views/file.py:38
-msgid "Get file"
-msgstr "獲取文件"
-
-#: apps/oss/views/file.py:48 apps/oss/views/file.py:49
-#: apps/oss/views/file.py:50
-msgid "Delete file"
-msgstr "刪除文件"
-
-#: apps/resource_manage/views/document.py:30
-#: apps/resource_manage/views/document.py:31
-#: apps/resource_manage/views/document.py:32
-msgid "Create system knowledge"
-msgstr "創建系統知識庫"
-
-#: apps/resource_manage/views/document.py:36
-#: apps/resource_manage/views/document.py:56
-#: apps/resource_manage/views/document.py:83
-#: apps/resource_manage/views/document.py:113
-#: apps/resource_manage/views/document.py:130
-#: apps/resource_manage/views/document.py:155
-#: apps/resource_manage/views/document.py:183
-#: apps/resource_manage/views/document.py:210
-#: apps/resource_manage/views/document.py:237
-#: apps/resource_manage/views/document.py:267
-#: apps/resource_manage/views/document.py:296
-#: apps/resource_manage/views/document.py:317
-#: apps/resource_manage/views/document.py:345
-#: apps/resource_manage/views/document.py:362
-#: apps/resource_manage/views/document.py:383
-#: apps/resource_manage/views/document.py:411
-#: apps/resource_manage/views/document.py:435
-#: apps/resource_manage/views/document.py:460
-#: apps/resource_manage/views/document.py:485
-#: apps/resource_manage/views/document.py:507
-#: apps/resource_manage/views/document.py:530
-#: apps/resource_manage/views/document.py:553
-#: apps/resource_manage/views/document.py:571
-#: apps/resource_manage/views/document.py:585
-msgid "System Knowledge/Documentation"
-msgstr "系統知識庫/文檔"
-
-#: apps/resource_manage/views/document.py:51
-#: apps/resource_manage/views/document.py:52
-#: apps/resource_manage/views/document.py:53
-msgid "Get system document"
-msgstr "獲取文檔"
-
-#: apps/resource_manage/views/document.py:77
-#: apps/resource_manage/views/document.py:78
-#: apps/resource_manage/views/document.py:79
-msgid "Segmented system document"
-msgstr "分段文檔"
-
-#: apps/resource_manage/views/document.py:108
-#: apps/resource_manage/views/document.py:109
-#: apps/resource_manage/views/document.py:110
-msgid "Get a list of system segment IDs"
-msgstr "獲取分段ID列表"
-
-#: apps/resource_manage/views/document.py:124
-#: apps/resource_manage/views/document.py:125
-#: apps/resource_manage/views/document.py:126
-msgid "Cancel system tasks in batches"
-msgstr "批量取消任務"
-
-#: apps/resource_manage/views/document.py:149
-#: apps/resource_manage/views/document.py:150
-#: apps/resource_manage/views/document.py:151
-msgid "Create system knowledges in batches"
-msgstr "批量創建知識庫"
-
-#: apps/resource_manage/views/document.py:177
-#: apps/resource_manage/views/document.py:178
-#: apps/resource_manage/views/document.py:179
-msgid "Batch sync system knowledges"
-msgstr "批量同步知識庫"
-
-#: apps/resource_manage/views/document.py:204
-#: apps/resource_manage/views/document.py:206
-msgid "Delete system document in batches"
-msgstr "批量刪除文檔"
-
-#: apps/resource_manage/views/document.py:205
-msgid "Delete system knowledge in batches"
-msgstr "批量刪除知識庫"
-
-#: apps/resource_manage/views/document.py:232
-#: apps/resource_manage/views/document.py:233
-msgid "Batch refresh system document vector library"
-msgstr "批量刷新文檔向量庫"
-
-#: apps/resource_manage/views/document.py:261
-#: apps/resource_manage/views/document.py:262
-#: apps/resource_manage/views/document.py:263
-msgid "Batch generate related system problems"
-msgstr "批量生成相關問題"
-
-#: apps/resource_manage/views/document.py:290
-#: apps/resource_manage/views/document.py:291
-#: apps/resource_manage/views/document.py:292
-msgid "Modify system document hit processing methods in batches"
-msgstr "批量修改文檔命中處理方式"
-
-#: apps/resource_manage/views/document.py:312
-#: apps/resource_manage/views/document.py:313
-msgid "Migrate system knowledges in batches"
-msgstr "批量遷移知識庫"
-
-#: apps/resource_manage/views/document.py:340
-#: apps/resource_manage/views/document.py:341
-#: apps/resource_manage/views/document.py:342
-msgid "Get system document details"
-msgstr "獲取文檔詳情"
-
-#: apps/resource_manage/views/document.py:356
-#: apps/resource_manage/views/document.py:357
-#: apps/resource_manage/views/document.py:358
-msgid "Modify system document"
-msgstr "修改文檔"
-
-#: apps/resource_manage/views/document.py:378
-#: apps/resource_manage/views/document.py:379
-#: apps/resource_manage/views/document.py:380
-msgid "Delete system document"
-msgstr "刪除文檔"
-
-#: apps/resource_manage/views/document.py:405
-#: apps/resource_manage/views/document.py:406
-#: apps/resource_manage/views/document.py:407
-msgid "Synchronize system web site types"
-msgstr "同步網站類型"
-
-#: apps/resource_manage/views/document.py:429
-#: apps/resource_manage/views/document.py:430
-#: apps/resource_manage/views/document.py:431
-msgid "Refresh system knowledge vector library"
-msgstr "刷新文檔向量庫"
-
-#: apps/resource_manage/views/document.py:454
-#: apps/resource_manage/views/document.py:455
-#: apps/resource_manage/views/document.py:456
-msgid "Cancel system task"
-msgstr "取消任務"
-
-#: apps/resource_manage/views/document.py:480
-#: apps/resource_manage/views/document.py:481
-#: apps/resource_manage/views/document.py:482
-msgid "Get system document by pagination"
-msgstr "分頁獲取文檔"
-
-#: apps/resource_manage/views/document.py:503
-#: apps/resource_manage/views/document.py:504
-msgid "Export system knowledge"
-msgstr "導出知識庫"
-
-#: apps/resource_manage/views/document.py:526
-#: apps/resource_manage/views/document.py:527
-msgid "Export Zip system knowledge"
-msgstr "導出Zip知識庫"
-
-#: apps/resource_manage/views/document.py:549
-#: apps/resource_manage/views/document.py:550
-msgid "Download system source file"
-msgstr "下載系統源文件"
-
-#: apps/resource_manage/views/document.py:567
-#: apps/resource_manage/views/document.py:568
-msgid "Get system QA template"
-msgstr "獲取系統問答模板"
-
-#: apps/resource_manage/views/document.py:581
-#: apps/resource_manage/views/document.py:582
-msgid "Get system form template"
-msgstr "獲取系統表單模板"
-
-#: apps/resource_manage/views/knowledge.py:26
-#: apps/resource_manage/views/knowledge.py:27
-#: apps/resource_manage/views/knowledge.py:28
-msgid "Get system knowledge list"
-msgstr "獲取系統知識庫列表"
-
-#: apps/resource_manage/views/knowledge.py:31
-#: apps/resource_manage/views/knowledge.py:50
-#: apps/resource_manage/views/knowledge.py:72
-#: apps/resource_manage/views/knowledge.py:87
-#: apps/resource_manage/views/knowledge.py:102
-#: apps/resource_manage/views/knowledge.py:121
-#: apps/resource_manage/views/knowledge.py:147
-#: apps/resource_manage/views/knowledge.py:174
-#: apps/resource_manage/views/knowledge.py:192
-#: apps/resource_manage/views/knowledge.py:210
-#: apps/resource_manage/views/knowledge.py:231
-#: apps/resource_manage/views/knowledge.py:252
-#: apps/resource_manage/views/knowledge.py:272
-msgid "System Knowledge"
-msgstr "系統知識庫"
-
-#: apps/resource_manage/views/knowledge.py:45
-#: apps/resource_manage/views/knowledge.py:46
-#: apps/resource_manage/views/knowledge.py:47
-msgid "Get system knowledge list by pagination"
-msgstr "獲取系統知識庫分頁列表"
-
-#: apps/resource_manage/views/knowledge.py:66
-#: apps/resource_manage/views/knowledge.py:67
-#: apps/resource_manage/views/knowledge.py:68
-msgid "Update system knowledge"
-msgstr "更新系統知識庫"
-
-#: apps/resource_manage/views/knowledge.py:82
-#: apps/resource_manage/views/knowledge.py:83
-#: apps/resource_manage/views/knowledge.py:84
-msgid "Get system knowledge"
-msgstr "獲取知識庫"
-
-#: apps/resource_manage/views/knowledge.py:97
-#: apps/resource_manage/views/knowledge.py:98
-#: apps/resource_manage/views/knowledge.py:99
-msgid "Delete system knowledge"
-msgstr "刪除知識庫"
-
-#: apps/resource_manage/views/knowledge.py:115
-#: apps/resource_manage/views/knowledge.py:116
-#: apps/resource_manage/views/knowledge.py:117
-msgid "Synchronize the system knowledge base of the website"
-msgstr "同步網站知識庫"
-
-#: apps/resource_manage/views/knowledge.py:141
-#: apps/resource_manage/views/knowledge.py:142
-#: apps/resource_manage/views/knowledge.py:143
-msgid "System Hit test list"
-msgstr "命中測試列表"
-
-#: apps/resource_manage/views/knowledge.py:168
-#: apps/resource_manage/views/knowledge.py:169
-#: apps/resource_manage/views/knowledge.py:170
-msgid "System Re-vectorize"
-msgstr "重新向量化"
-
-#: apps/resource_manage/views/knowledge.py:188
-#: apps/resource_manage/views/knowledge.py:189
-msgid "Export system knowledge base"
-msgstr "導出系統知識庫"
-
-#: apps/resource_manage/views/knowledge.py:206
-#: apps/resource_manage/views/knowledge.py:207
-msgid "Export system knowledge base containing images"
-msgstr "導出包含圖片的系統知識庫"
-
-#: apps/resource_manage/views/knowledge.py:225
-#: apps/resource_manage/views/knowledge.py:226
-#: apps/resource_manage/views/knowledge.py:227
-msgid "System generate related"
-msgstr "生成相關"
-
-#: apps/resource_manage/views/knowledge.py:247
-#: apps/resource_manage/views/knowledge.py:248
-#: apps/resource_manage/views/knowledge.py:249
-msgid "Get model for system knowledge base"
-msgstr "獲取系統知識庫模型"
-
-#: apps/resource_manage/views/knowledge.py:267
-#: apps/resource_manage/views/knowledge.py:268
-#: apps/resource_manage/views/knowledge.py:269
-msgid "Get embedding model for system knowledge base"
-msgstr "獲取系統知識庫嵌入模型"
-
-#: apps/resource_manage/views/paragraph.py:24
-#: apps/resource_manage/views/paragraph.py:25
-#: apps/resource_manage/views/paragraph.py:26
-msgid "System paragraph list"
-msgstr "段落列表"
-
-#: apps/resource_manage/views/paragraph.py:29
-#: apps/resource_manage/views/paragraph.py:50
-#: apps/resource_manage/views/paragraph.py:76
-#: apps/resource_manage/views/paragraph.py:93
-#: apps/resource_manage/views/paragraph.py:125
-#: apps/resource_manage/views/paragraph.py:151
-#: apps/resource_manage/views/paragraph.py:179
-#: apps/resource_manage/views/paragraph.py:201
-#: apps/resource_manage/views/paragraph.py:233
-#: apps/resource_manage/views/paragraph.py:259
-#: apps/resource_manage/views/paragraph.py:283
-#: apps/resource_manage/views/paragraph.py:314
-#: apps/resource_manage/views/paragraph.py:344
-#: apps/resource_manage/views/paragraph.py:370
-msgid "System Knowledge/Documentation/Paragraph"
-msgstr "系統知識庫/文檔/段落"
-
-#: apps/resource_manage/views/paragraph.py:45
-#: apps/resource_manage/views/paragraph.py:46
-msgid "Create system paragraph"
-msgstr "創建段落"
-
-#: apps/resource_manage/views/paragraph.py:70
-#: apps/resource_manage/views/paragraph.py:71
-#: apps/resource_manage/views/paragraph.py:72
-msgid "Batch system paragraph"
-msgstr "批量關聯段落"
-
-#: apps/resource_manage/views/paragraph.py:88
-#: apps/resource_manage/views/paragraph.py:89
-msgid "Migrate system paragraphs in batches"
-msgstr "批量遷移段落"
-
-#: apps/resource_manage/views/paragraph.py:119
-#: apps/resource_manage/views/paragraph.py:120
-#: apps/resource_manage/views/paragraph.py:121
-msgid "Batch generate system related"
-msgstr "批量生成相關"
-
-#: apps/resource_manage/views/paragraph.py:145
-#: apps/resource_manage/views/paragraph.py:146
-#: apps/resource_manage/views/paragraph.py:147
-msgid "Modify system paragraph data"
-msgstr "修改段落數據"
-
-#: apps/resource_manage/views/paragraph.py:174
-#: apps/resource_manage/views/paragraph.py:175
-#: apps/resource_manage/views/paragraph.py:176
-msgid "Get system paragraph details"
-msgstr "獲取段落詳情"
-
-#: apps/resource_manage/views/paragraph.py:196
-#: apps/resource_manage/views/paragraph.py:197
-#: apps/resource_manage/views/paragraph.py:198
-msgid "Delete system paragraph"
-msgstr "刪除段落"
-
-#: apps/resource_manage/views/paragraph.py:227
-#: apps/resource_manage/views/paragraph.py:228
-#: apps/resource_manage/views/paragraph.py:229
-msgid "Add system associated questions"
-msgstr "添加關聯問題"
-
-#: apps/resource_manage/views/paragraph.py:254
-#: apps/resource_manage/views/paragraph.py:255
-#: apps/resource_manage/views/paragraph.py:256
-msgid "Get a list of system paragraph questions"
+#: apps/knowledge/views/paragraph.py:310
+#: apps/knowledge/views/paragraph.py:311
+#: apps/knowledge/views/paragraph.py:312
+msgid "Get a list of paragraph questions"
 msgstr "獲取段落問題列表"
 
-#: apps/resource_manage/views/paragraph.py:277
-#: apps/resource_manage/views/paragraph.py:278
-#: apps/resource_manage/views/paragraph.py:279
-msgid "Disassociation system issue"
-msgstr "取消關聯問題"
-
-#: apps/resource_manage/views/paragraph.py:308
-#: apps/resource_manage/views/paragraph.py:309
-#: apps/resource_manage/views/paragraph.py:310
-msgid "Related system questions"
-msgstr "關聯問題"
-
-#: apps/resource_manage/views/paragraph.py:339
-#: apps/resource_manage/views/paragraph.py:340
-#: apps/resource_manage/views/paragraph.py:341
-msgid "Get system paragraph list by pagination"
-msgstr "獲取段落列表"
-
-#: apps/resource_manage/views/problem.py:23
-#: apps/resource_manage/views/problem.py:24
-#: apps/resource_manage/views/problem.py:25
-msgid "System question list"
-msgstr "問題列表"
-
-#: apps/resource_manage/views/problem.py:28
-#: apps/resource_manage/views/problem.py:50
-#: apps/resource_manage/views/problem.py:71
-#: apps/resource_manage/views/problem.py:94
-#: apps/resource_manage/views/problem.py:115
-#: apps/resource_manage/views/problem.py:135
-#: apps/resource_manage/views/problem.py:158
-#: apps/resource_manage/views/problem.py:182
-msgid "System Knowledge/Documentation/Paragraph/Question"
-msgstr "系統知識庫/文檔/段落/問題"
-
-#: apps/resource_manage/views/problem.py:44
-#: apps/resource_manage/views/problem.py:45
-#: apps/resource_manage/views/problem.py:46
-msgid "Create system question"
-msgstr "創建問題"
-
-#: apps/resource_manage/views/problem.py:66
-#: apps/resource_manage/views/problem.py:67
-#: apps/resource_manage/views/problem.py:68
-msgid "Get a list of associated system paragraphs"
-msgstr "獲取關聯段落列表"
-
-#: apps/resource_manage/views/problem.py:88
-#: apps/resource_manage/views/problem.py:89
-#: apps/resource_manage/views/problem.py:90
-msgid "Batch associated system paragraphs"
-msgstr "批量關聯段落"
-
-#: apps/resource_manage/views/problem.py:109
-#: apps/resource_manage/views/problem.py:110
-#: apps/resource_manage/views/problem.py:111
-msgid "Batch deletion system issues"
-msgstr "批量刪除問題"
-
-#: apps/resource_manage/views/problem.py:130
-#: apps/resource_manage/views/problem.py:131
-#: apps/resource_manage/views/problem.py:132
-msgid "Delete system question"
-msgstr "刪除問題"
-
-#: apps/resource_manage/views/problem.py:152
-#: apps/resource_manage/views/problem.py:153
-#: apps/resource_manage/views/problem.py:154
-msgid "Modify system question"
-msgstr "修改問題"
-
-#: apps/resource_manage/views/problem.py:177
-#: apps/resource_manage/views/problem.py:178
-#: apps/resource_manage/views/problem.py:179
-msgid "Get the list of system questions by page"
-msgstr "分頁獲取問題列表"
-
-#: apps/resource_manage/views/tool.py:24 apps/resource_manage/views/tool.py:25
-#: apps/resource_manage/views/tool.py:26
-msgid "Get system tool"
-msgstr "獲取工具"
-
-#: apps/resource_manage/views/tool.py:29 apps/resource_manage/views/tool.py:50
-#: apps/resource_manage/views/tool.py:65 apps/resource_manage/views/tool.py:80
-#: apps/resource_manage/views/tool.py:98 apps/resource_manage/views/tool.py:119
-#: apps/resource_manage/views/tool.py:137
-#: apps/resource_manage/views/tool.py:156
-#: apps/resource_manage/views/tool.py:179
-msgid "System Tool"
-msgstr "工具"
-
-#: apps/resource_manage/views/tool.py:44 apps/resource_manage/views/tool.py:45
-#: apps/resource_manage/views/tool.py:46
-msgid "Update system tool"
-msgstr "更新工具"
-
-#: apps/resource_manage/views/tool.py:60 apps/resource_manage/views/tool.py:61
-#: apps/resource_manage/views/tool.py:62
-msgid "Get system tool by id"
-msgstr "獲取工具"
-
-#: apps/resource_manage/views/tool.py:75 apps/resource_manage/views/tool.py:76
-#: apps/resource_manage/views/tool.py:77
-msgid "Delete system tool"
-msgstr "刪除工具"
-
-#: apps/resource_manage/views/tool.py:93 apps/resource_manage/views/tool.py:94
-#: apps/resource_manage/views/tool.py:95
-msgid "Get system tool list by pagination"
-msgstr "獲取工具列表"
-
-#: apps/resource_manage/views/tool.py:114
-#: apps/resource_manage/views/tool.py:115
-#: apps/resource_manage/views/tool.py:116
-msgid "Export system tool"
-msgstr "導出工具"
-
-#: apps/resource_manage/views/tool.py:132
-#: apps/resource_manage/views/tool.py:133
-#: apps/resource_manage/views/tool.py:134
-msgid "Debug system tool"
-msgstr "調試工具"
-
-#: apps/resource_manage/views/tool.py:150
-#: apps/resource_manage/views/tool.py:151
-#: apps/resource_manage/views/tool.py:152
-msgid "Check system code"
-msgstr "檢查代碼"
-
-#: apps/resource_manage/views/tool.py:173
-#: apps/resource_manage/views/tool.py:174
-#: apps/resource_manage/views/tool.py:175
-msgid "Edit system tool icon"
-msgstr "修改工具圖標"
-
-#: apps/role_setting/api/role_setting.py:16
-#: apps/role_setting/api/role_setting.py:22
-#: apps/role_setting/api/role_setting.py:33
-#: apps/role_setting/api/role_setting.py:143
-#: apps/role_setting/serializers/role_setting_serializers.py:193
-#: apps/workspace/api/workspace.py:81 apps/xpack/api/chat_user.py:104
-msgid "ID"
-msgstr ""
-
-#: apps/role_setting/api/role_setting.py:17
-#: apps/role_setting/api/role_setting.py:23
-#: apps/role_setting/api/role_setting.py:34 apps/users/serializers/user.py:258
-#: apps/xpack/api/knowledge_lark.py:24 apps/xpack/serializers/chat_user.py:235
-msgid "Name"
-msgstr "用戶名"
-
-#: apps/role_setting/api/role_setting.py:18
-#: apps/role_setting/api/role_setting.py:29
-#: apps/role_setting/serializers/role_setting_serializers.py:194
-msgid "Enable"
-msgstr "啟用"
-
-#: apps/role_setting/api/role_setting.py:26
-msgid "Permission"
-msgstr "權限"
-
-#: apps/role_setting/api/role_setting.py:37
-msgid "Children"
-msgstr "子級"
-
-#: apps/role_setting/api/role_setting.py:55
-#: apps/role_setting/serializers/role_setting_serializers.py:107
-msgid "Role type"
-msgstr "角色類型"
-
-#: apps/role_setting/api/role_setting.py:76
-msgid "Internal role"
-msgstr "內置角色"
-
-#: apps/role_setting/api/role_setting.py:80
-msgid "Custom role"
-msgstr "自定義角色"
-
-#: apps/role_setting/api/role_setting.py:108
-#: apps/role_setting/api/role_setting.py:128
-#: apps/role_setting/api/role_setting.py:164
-#: apps/role_setting/serializers/role_setting_serializers.py:110
-#: apps/role_setting/serializers/role_setting_serializers.py:329
-#: apps/users/api/user.py:26 apps/workspace/api/workspace.py:86
-msgid "Role ID"
-msgstr "角色 ID"
-
-#: apps/role_setting/api/role_setting.py:135
-msgid "User relation ID"
-msgstr "用戶關係 ID"
-
-#: apps/role_setting/api/role_setting.py:145
-#: apps/role_setting/api/role_setting.py:185
-#: apps/role_setting/serializers/role_setting_serializers.py:330
-#: apps/users/api/user.py:77 apps/users/serializers/login.py:27
-#: apps/users/serializers/user.py:56 apps/users/serializers/user.py:114
-#: apps/workspace/api/workspace.py:83 apps/workspace/api/workspace.py:124
-#: apps/workspace/serializers/workspace_serializers.py:240
-#: apps/xpack/api/auth_config.py:24 apps/xpack/api/chat_user.py:105
-#: apps/xpack/api/user_group.py:75 apps/xpack/serializers/chat_user.py:62
-#: apps/xpack/serializers/chat_user.py:564
-msgid "Username"
-msgstr "用戶名"
-
-#: apps/role_setting/api/role_setting.py:146 apps/workspace/api/workspace.py:84
-#: apps/xpack/api/chat_user.py:106
-msgid "Nickname"
-msgstr "暱稱"
-
-#: apps/role_setting/api/role_setting.py:148
-msgid "Workspace Name"
-msgstr "工作空間"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:104
-msgid "Role name"
-msgstr "角色名稱"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:122
-#: apps/role_setting/serializers/role_setting_serializers.py:200
-#: apps/role_setting/serializers/role_setting_serializers.py:325
-#: apps/role_setting/serializers/role_setting_serializers.py:337
-msgid "Role does not exist"
-msgstr "角色不存在"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:124
-#: apps/role_setting/serializers/role_setting_serializers.py:202
-msgid "Cannot modify built-in role"
-msgstr "不能修改內置角色"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:132
-msgid "Role name already exists"
-msgstr "角色名稱已存在"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:152
-msgid "Invalid role type"
-msgstr "無效的角色類型"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:204
-msgid "Cannot delete built-in role"
-msgstr "無法刪除內置角色"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:262
-#: apps/users/api/user.py:135 apps/users/serializers/user.py:471
-#: apps/workspace/serializers/workspace_serializers.py:161
-#: apps/xpack/api/user_group.py:90 apps/xpack/serializers/chat_user.py:158
-#: apps/xpack/serializers/chat_user.py:172
-#: apps/xpack/serializers/chat_user.py:502
-msgid "User IDs"
-msgstr "用戶 ID"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:267
-#: apps/users/api/user.py:30
-msgid "Workspace IDs"
-msgstr "工作空間 ID"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:272
-#: apps/workspace/serializers/workspace_serializers.py:172
-msgid "Members"
-msgstr "成員集合"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:312
-#: apps/workspace/serializers/workspace_serializers.py:223
-msgid "User relation does not exist"
-msgstr "用戶關係不存在"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:316
-#: apps/workspace/serializers/workspace_serializers.py:226
-msgid "Cannot remove member from built-in role"
-msgstr "不能從內置角色中移除成員"
-
-#: apps/role_setting/serializers/role_setting_serializers.py:370
-msgid "Only update members to normal users"
-msgstr "只能為普通用戶更新成員"
-
-#: apps/role_setting/views/role_setting.py:39
-#: apps/role_setting/views/role_setting.py:40
-#: apps/role_setting/views/role_setting.py:41
-msgid "Get role permission template"
-msgstr "獲取角色權限模板"
-
-#: apps/role_setting/views/role_setting.py:62
-#: apps/role_setting/views/role_setting.py:63
-#: apps/role_setting/views/role_setting.py:64
-msgid "Create or update role"
-msgstr "創建或更新角色"
-
-#: apps/role_setting/views/role_setting.py:80
-#: apps/role_setting/views/role_setting.py:81
-#: apps/role_setting/views/role_setting.py:82
-msgid "Get role list"
-msgstr "獲取角色列表"
-
-#: apps/role_setting/views/role_setting.py:98
-#: apps/role_setting/views/role_setting.py:99
-#: apps/role_setting/views/role_setting.py:100
-msgid "Delete role"
-msgstr "刪除角色"
-
-#: apps/role_setting/views/role_setting.py:120
-#: apps/role_setting/views/role_setting.py:121
-#: apps/role_setting/views/role_setting.py:122
-msgid "Create or update role permission"
-msgstr "創建或更新角色權限"
-
-#: apps/role_setting/views/role_setting.py:140
-#: apps/role_setting/views/role_setting.py:141
-#: apps/role_setting/views/role_setting.py:142
-msgid "Get role permission"
-msgstr "獲取角色權限"
-
-#: apps/role_setting/views/role_setting.py:161
-#: apps/role_setting/views/role_setting.py:162
-#: apps/role_setting/views/role_setting.py:163
-msgid "Add member to system role"
-msgstr "系統角色添加成員"
-
-#: apps/role_setting/views/role_setting.py:186
-#: apps/role_setting/views/role_setting.py:187
-#: apps/role_setting/views/role_setting.py:188
-msgid "Remove member from system role"
-msgstr "系統角色移除成員"
-
-#: apps/role_setting/views/role_setting.py:205
-#: apps/role_setting/views/role_setting.py:206
-#: apps/role_setting/views/role_setting.py:207
-msgid "Get system role member list"
-msgstr "獲取系統角色成員列表"
-
-#: apps/role_setting/views/role_setting.py:223
-#: apps/role_setting/views/role_setting.py:224
-#: apps/role_setting/views/role_setting.py:225
-msgid "Get Workspace role list"
-msgstr "獲取工作空間角色列表"
-
-#: apps/role_setting/views/role_setting.py:227
-#: apps/role_setting/views/role_setting.py:248
-#: apps/role_setting/views/role_setting.py:273
-#: apps/role_setting/views/role_setting.py:292
-msgid "Workspace Role"
-msgstr "工作空間角色"
-
-#: apps/role_setting/views/role_setting.py:242
-#: apps/role_setting/views/role_setting.py:243
-#: apps/role_setting/views/role_setting.py:244
-msgid "Add member to workspace role"
-msgstr "工作空間角色添加成員"
-
-#: apps/role_setting/views/role_setting.py:268
-#: apps/role_setting/views/role_setting.py:269
-#: apps/role_setting/views/role_setting.py:270
-msgid "Remove member from workspace role"
-msgstr "工作空間角色移除成員"
-
-#: apps/role_setting/views/role_setting.py:287
-#: apps/role_setting/views/role_setting.py:288
-#: apps/role_setting/views/role_setting.py:289
-msgid "Get workspace role member list"
-msgstr "獲取工作空間角色成員列表"
-
-#: apps/shared/api/shared_knowledge.py:242 apps/xpack/api/knowledge_lark.py:54
-msgid "Folder token"
-msgstr "文件夾 Token"
-
-#: apps/shared/api/shared_tool.py:19 apps/shared/api/shared_tool.py:46
-#: apps/shared/api/shared_tool.py:93 apps/shared/api/shared_tool.py:133
-#: apps/shared/serializers/shared_tool.py:43
-#: apps/shared/serializers/shared_tool.py:83 apps/tools/serializers/tool.py:142
-#: apps/tools/serializers/tool.py:158 apps/tools/serializers/tool.py:454
-msgid "tool name"
-msgstr "工具名稱"
-
-#: apps/shared/api/shared_tool.py:26 apps/shared/api/shared_tool.py:53
-#: apps/shared/api/shared_tool.py:100 apps/shared/api/shared_tool.py:140
-#: apps/shared/serializers/shared_tool.py:44
-#: apps/shared/serializers/shared_tool.py:85 apps/tools/serializers/tool.py:144
-#: apps/tools/serializers/tool.py:159
-msgid "tool description"
-msgstr "工具描述"
-
-#: apps/shared/api/shared_tool.py:166 apps/shared/api/shared_tool.py:184
-#: apps/shared/api/shared_tool.py:256 apps/shared/api/shared_tool.py:288
-#: apps/shared/api/shared_tool.py:310 apps/shared/serializers/shared_tool.py:66
-#: apps/shared/serializers/shared_tool.py:107
-#: apps/tools/serializers/tool.py:267
-msgid "tool id"
-msgstr "工具 ID"
-
-#: apps/shared/serializers/shared_knowledge.py:35
-#: apps/shared/serializers/shared_model.py:20
-#: apps/shared/serializers/shared_tool.py:19
-msgid "workspace id list"
-msgstr "工作空間ID"
-
-#: apps/shared/serializers/shared_knowledge.py:36
-#: apps/shared/serializers/shared_model.py:21
-#: apps/shared/serializers/shared_tool.py:20
-msgid "authentication type"
-msgstr "認證類型"
-
-#: apps/shared/serializers/shared_knowledge.py:196
-#: apps/shared/serializers/shared_knowledge.py:216
-#: apps/shared/serializers/shared_knowledge.py:236
-msgid "Knowledge does not exist"
-msgstr "知識庫不存在"
-
-#: apps/shared/serializers/shared_knowledge.py:218
-#: apps/shared/serializers/shared_knowledge.py:238
-msgid "Only shared knowledge can be authorized"
-msgstr "僅限共享知識庫可以被授權"
-
-#: apps/shared/serializers/shared_tool.py:74
-msgid "Only shared tools can be deleted"
-msgstr "僅限共享工具可以被刪除"
-
-#: apps/shared/serializers/shared_tool.py:76
-msgid "System tools cannot be deleted"
-msgstr "系統工具不能被刪除"
-
-#: apps/shared/serializers/shared_tool.py:118
-#: apps/shared/serializers/shared_tool.py:138
-msgid "Tool does not exist"
-msgstr "工具不存在"
-
-#: apps/shared/serializers/shared_tool.py:120
-#: apps/shared/serializers/shared_tool.py:140
-msgid "Only shared tools can be authorized"
-msgstr "僅限共享工具可以被授權"
-
-#: apps/shared/views/shared_dataset_lark_views.py:25
-#: apps/shared/views/shared_dataset_lark_views.py:26
-#: apps/shared/views/shared_dataset_lark_views.py:27
-#: apps/xpack/views/dataset_lark_views.py:23
-#: apps/xpack/views/dataset_lark_views.py:24
-#: apps/xpack/views/dataset_lark_views.py:25
-msgid "Create a lark knowledge base"
-msgstr "創建知識庫"
-
-#: apps/shared/views/shared_dataset_lark_views.py:44
-#: apps/shared/views/shared_dataset_lark_views.py:45
-#: apps/shared/views/shared_dataset_lark_views.py:46
-#: apps/xpack/views/dataset_lark_views.py:44
-#: apps/xpack/views/dataset_lark_views.py:45
-#: apps/xpack/views/dataset_lark_views.py:46
-msgid "Update a lark knowledge base"
-msgstr "更新飛書知識庫"
-
-#: apps/shared/views/shared_dataset_lark_views.py:67
-#: apps/shared/views/shared_dataset_lark_views.py:68
-#: apps/shared/views/shared_dataset_lark_views.py:69
-#: apps/xpack/views/dataset_lark_views.py:67
-#: apps/xpack/views/dataset_lark_views.py:68
-#: apps/xpack/views/dataset_lark_views.py:69
-msgid "Get document list from lark"
-msgstr "獲取飛書文檔列表"
-
-#: apps/shared/views/shared_dataset_lark_views.py:72
-#: apps/shared/views/shared_dataset_lark_views.py:90
-#: apps/shared/views/shared_dataset_lark_views.py:109
-#: apps/shared/views/shared_dataset_lark_views.py:129
-#: apps/shared/views/shared_document.py:36
-#: apps/shared/views/shared_document.py:56
-#: apps/shared/views/shared_document.py:83
-#: apps/shared/views/shared_document.py:114
-#: apps/shared/views/shared_document.py:131
-#: apps/shared/views/shared_document.py:156
-#: apps/shared/views/shared_document.py:184
-#: apps/shared/views/shared_document.py:211
-#: apps/shared/views/shared_document.py:238
-#: apps/shared/views/shared_document.py:268
-#: apps/shared/views/shared_document.py:297
-#: apps/shared/views/shared_document.py:318
-#: apps/shared/views/shared_document.py:346
-#: apps/shared/views/shared_document.py:363
-#: apps/shared/views/shared_document.py:384
-#: apps/shared/views/shared_document.py:412
-#: apps/shared/views/shared_document.py:436
-#: apps/shared/views/shared_document.py:461
-#: apps/shared/views/shared_document.py:486
-#: apps/shared/views/shared_document.py:508
-#: apps/shared/views/shared_document.py:531
-#: apps/shared/views/shared_document.py:554
-#: apps/shared/views/shared_document.py:575
-#: apps/shared/views/shared_document.py:602
-#: apps/shared/views/shared_document.py:629
-#: apps/shared/views/shared_document.py:651
-#: apps/shared/views/shared_document.py:665
-msgid "Shared Knowledge/Documentation"
-msgstr "共享知識庫/文檔"
-
-#: apps/shared/views/shared_dataset_lark_views.py:85
-#: apps/shared/views/shared_dataset_lark_views.py:86
-#: apps/shared/views/shared_dataset_lark_views.py:87
-#: apps/xpack/views/dataset_lark_views.py:86
-#: apps/xpack/views/dataset_lark_views.py:87
-#: apps/xpack/views/dataset_lark_views.py:88
-msgid "Import documents to the lark knowledge base"
-msgstr "導入文檔到飛書知識庫"
-
-#: apps/shared/views/shared_dataset_lark_views.py:104
-#: apps/shared/views/shared_dataset_lark_views.py:105
-#: apps/shared/views/shared_dataset_lark_views.py:106
-#: apps/xpack/views/dataset_lark_views.py:106
-#: apps/xpack/views/dataset_lark_views.py:107
-#: apps/xpack/views/dataset_lark_views.py:108
-msgid "Synchronize lark document"
-msgstr "同步飛書文檔"
-
-#: apps/shared/views/shared_dataset_lark_views.py:123
-#: apps/shared/views/shared_dataset_lark_views.py:124
-#: apps/shared/views/shared_dataset_lark_views.py:125
-#: apps/xpack/views/dataset_lark_views.py:126
-#: apps/xpack/views/dataset_lark_views.py:127
-#: apps/xpack/views/dataset_lark_views.py:128
-msgid "Batch synchronize lark document"
-msgstr "批量同步飛書文檔"
-
-#: apps/shared/views/shared_document.py:30
-#: apps/shared/views/shared_document.py:31
-#: apps/shared/views/shared_document.py:32
-msgid "Create shared document"
-msgstr "創建共享文檔"
-
-#: apps/shared/views/shared_document.py:51
-#: apps/shared/views/shared_document.py:52
-#: apps/shared/views/shared_document.py:53
-msgid "Get shared document"
-msgstr "獲取共享文檔"
-
-#: apps/shared/views/shared_document.py:77
-#: apps/shared/views/shared_document.py:78
-#: apps/shared/views/shared_document.py:79
-msgid "Segmented shared document"
-msgstr "分段共享文檔"
-
-#: apps/shared/views/shared_document.py:109
-#: apps/shared/views/shared_document.py:110
-#: apps/shared/views/shared_document.py:111
-msgid "Get a list of shared segment IDs"
-msgstr "獲取共享分段 ID 列表"
-
-#: apps/shared/views/shared_document.py:125
-#: apps/shared/views/shared_document.py:126
-#: apps/shared/views/shared_document.py:127
-msgid "Cancel shared tasks in batches"
-msgstr "批量取消任務"
-
-#: apps/shared/views/shared_document.py:150
-#: apps/shared/views/shared_document.py:151
-#: apps/shared/views/shared_document.py:152
-msgid "Create shared documents in batches"
-msgstr "批量創建共享文檔"
-
-#: apps/shared/views/shared_document.py:178
-#: apps/shared/views/shared_document.py:179
-#: apps/shared/views/shared_document.py:180
-msgid "Batch sync shared documents"
-msgstr "批量同步共享文檔"
-
-#: apps/shared/views/shared_document.py:205
-#: apps/shared/views/shared_document.py:206
-#: apps/shared/views/shared_document.py:207
-msgid "Delete shared documents in batches"
-msgstr "批量刪除共享文檔"
-
-#: apps/shared/views/shared_document.py:233
-#: apps/shared/views/shared_document.py:234
-msgid "Batch refresh shared document vector library"
-msgstr "批量刷新共享文檔向量庫"
-
-#: apps/shared/views/shared_document.py:262
-#: apps/shared/views/shared_document.py:263
-#: apps/shared/views/shared_document.py:264
-msgid "Batch generate related shared problems"
-msgstr "批量生成相關問題"
-
-#: apps/shared/views/shared_document.py:291
-#: apps/shared/views/shared_document.py:292
-#: apps/shared/views/shared_document.py:293
-msgid "Modify shared document hit processing methods in batches"
-msgstr "批量修改文檔命中處理方法"
-
-#: apps/shared/views/shared_document.py:313
-#: apps/shared/views/shared_document.py:314
-msgid "Migrate shared documents in batches"
-msgstr "批量遷移共享文檔"
-
-#: apps/shared/views/shared_document.py:341
-#: apps/shared/views/shared_document.py:342
-#: apps/shared/views/shared_document.py:343
-msgid "Get shared document details"
-msgstr "文檔文檔詳情"
-
-#: apps/shared/views/shared_document.py:357
-#: apps/shared/views/shared_document.py:358
-#: apps/shared/views/shared_document.py:359
-msgid "Modify shared document"
-msgstr "修改共享文檔"
-
-#: apps/shared/views/shared_document.py:379
-#: apps/shared/views/shared_document.py:380
-#: apps/shared/views/shared_document.py:381
-msgid "Delete shared document"
-msgstr "刪除共享文檔"
-
-#: apps/shared/views/shared_document.py:406
-#: apps/shared/views/shared_document.py:407
-#: apps/shared/views/shared_document.py:408
-msgid "Synchronize shared web site types"
-msgstr "同步共享網站類型"
-
-#: apps/shared/views/shared_document.py:430
-#: apps/shared/views/shared_document.py:431
-#: apps/shared/views/shared_document.py:432
-msgid "Refresh shared document vector library"
-msgstr "刷新共享文檔向量庫"
-
-#: apps/shared/views/shared_document.py:455
-#: apps/shared/views/shared_document.py:456
-#: apps/shared/views/shared_document.py:457
-msgid "Cancel shared task"
-msgstr "取消任務"
-
-#: apps/shared/views/shared_document.py:481
-#: apps/shared/views/shared_document.py:482
-#: apps/shared/views/shared_document.py:483
-msgid "Get shared document by pagination"
-msgstr "獲取共享文檔分頁列表"
-
-#: apps/shared/views/shared_document.py:504
-#: apps/shared/views/shared_document.py:505
-msgid "Export shared document"
-msgstr "導出共享文檔"
-
-#: apps/shared/views/shared_document.py:527
-#: apps/shared/views/shared_document.py:528
-msgid "Export Zip shared document"
-msgstr "導出共享文檔 Zip"
-
-#: apps/shared/views/shared_document.py:550
-#: apps/shared/views/shared_document.py:551
-msgid "Download shared source file"
-msgstr "下載共享源文件"
-
-#: apps/shared/views/shared_document.py:569
-#: apps/shared/views/shared_document.py:571
-msgid "Create Web site shared documents"
-msgstr "創建網站文檔"
-
-#: apps/shared/views/shared_document.py:596
-#: apps/shared/views/shared_document.py:597
-#: apps/shared/views/shared_document.py:598
-msgid "Import QA and create shared documentation"
-msgstr "導入問答並創建文檔"
-
-#: apps/shared/views/shared_document.py:623
-#: apps/shared/views/shared_document.py:624
-#: apps/shared/views/shared_document.py:625
-msgid "Import tables and create shared documents"
-msgstr "導入表格並創建文檔"
-
-#: apps/shared/views/shared_document.py:647
-#: apps/shared/views/shared_document.py:648
-msgid "Get shared QA template"
-msgstr "獲取共享問答模板"
-
-#: apps/shared/views/shared_document.py:661
-#: apps/shared/views/shared_document.py:662
-msgid "Get shared form template"
-msgstr "獲取共享表格模板"
-
-#: apps/shared/views/shared_knowledge.py:28
-#: apps/shared/views/shared_knowledge.py:29
-#: apps/shared/views/shared_knowledge.py:30
-msgid "Get share resource knowledge"
-msgstr "獲取共享資源知識庫"
-
-#: apps/shared/views/shared_knowledge.py:48
-#: apps/shared/views/shared_knowledge.py:49
-#: apps/shared/views/shared_knowledge.py:50
-msgid "Get shared knowledge list by pagination"
-msgstr "獲取共享知識庫分頁列表"
-
-#: apps/shared/views/shared_knowledge.py:70
-#: apps/shared/views/shared_knowledge.py:71
-#: apps/shared/views/shared_knowledge.py:72
-msgid "Update shared knowledge"
-msgstr "更新共享知識庫"
-
-#: apps/shared/views/shared_knowledge.py:86
-#: apps/shared/views/shared_knowledge.py:87
-#: apps/shared/views/shared_knowledge.py:88
-msgid "Get shared knowledge"
-msgstr "獲取共享知識庫"
-
-#: apps/shared/views/shared_knowledge.py:101
-#: apps/shared/views/shared_knowledge.py:102
-#: apps/shared/views/shared_knowledge.py:103
-msgid "Delete shared knowledge"
-msgstr "刪除共享知識庫"
-
-#: apps/shared/views/shared_knowledge.py:119
-#: apps/shared/views/shared_knowledge.py:120
-#: apps/shared/views/shared_knowledge.py:121
-msgid "Synchronize the shared knowledge base of the website"
-msgstr "同步共享知識庫網站"
-
-#: apps/shared/views/shared_knowledge.py:145
-#: apps/shared/views/shared_knowledge.py:146
-#: apps/shared/views/shared_knowledge.py:147
-msgid "Shared Hit test list"
-msgstr "命中測試列表"
-
-#: apps/shared/views/shared_knowledge.py:172
-#: apps/shared/views/shared_knowledge.py:173
-#: apps/shared/views/shared_knowledge.py:174
-msgid "Shared Re-vectorize"
-msgstr "重新向量化"
-
-#: apps/shared/views/shared_knowledge.py:192
-#: apps/shared/views/shared_knowledge.py:193
-msgid "Export shared knowledge base"
-msgstr "導出共享知識庫"
-
-#: apps/shared/views/shared_knowledge.py:210
-#: apps/shared/views/shared_knowledge.py:211
-msgid "Export shared knowledge base containing images"
-msgstr "導出包含圖片的共享知識庫"
-
-#: apps/shared/views/shared_knowledge.py:229
-#: apps/shared/views/shared_knowledge.py:230
-#: apps/shared/views/shared_knowledge.py:231
-msgid "Shared generate related"
-msgstr "生成相關"
-
-#: apps/shared/views/shared_knowledge.py:251
-#: apps/shared/views/shared_knowledge.py:252
-#: apps/shared/views/shared_knowledge.py:253
-msgid "Get model for shared knowledge base"
-msgstr "獲取共享知識庫模型"
-
-#: apps/shared/views/shared_knowledge.py:271
-#: apps/shared/views/shared_knowledge.py:272
-#: apps/shared/views/shared_knowledge.py:273
-msgid "Get embedding model for shared knowledge base"
-msgstr "獲取共享知識庫嵌入模型"
-
-#: apps/shared/views/shared_knowledge.py:291
-#: apps/shared/views/shared_knowledge.py:293
-msgid "Authorization knowledge workspace"
-msgstr "授權知識工作空間"
-
-#: apps/shared/views/shared_knowledge.py:292
-msgid "Authorization knowledge workspace "
-msgstr "授權知識工作空間"
-
-#: apps/shared/views/shared_knowledge.py:307
-#: apps/shared/views/shared_knowledge.py:308
-#: apps/shared/views/shared_knowledge.py:309
-msgid "Get Authorization knowledge workspace"
-msgstr "獲取授權知識工作空間"
-
-#: apps/shared/views/shared_knowledge.py:326
-#: apps/shared/views/shared_knowledge.py:327
-#: apps/shared/views/shared_knowledge.py:328
-msgid "Create shared base knowledge"
-msgstr "創建共享知識庫"
-
-#: apps/shared/views/shared_knowledge.py:349
-#: apps/shared/views/shared_knowledge.py:350
-#: apps/shared/views/shared_knowledge.py:351
-msgid "Create shared web knowledge"
-msgstr "創建 web 知識庫"
-
-#: apps/shared/views/shared_knowledge.py:381
-#: apps/shared/views/shared_knowledge.py:382
-#: apps/shared/views/shared_knowledge.py:383
-msgid "Get shared workspace knowledge"
-msgstr "獲取共享工作空間知識庫"
-
-#: apps/shared/views/shared_knowledge.py:402
-#: apps/shared/views/shared_knowledge.py:403
-#: apps/shared/views/shared_knowledge.py:404
-msgid "Get shared workspace knowledge list by pagination"
-msgstr "獲取共享工作空間知識庫分頁列表"
-
-#: apps/shared/views/shared_model.py:213 apps/shared/views/shared_model.py:215
-msgid "Authorization model workspace"
-msgstr "授權模型工作空間"
-
-#: apps/shared/views/shared_model.py:214
-msgid "Authorization model workspace "
-msgstr "授權模型工作空間"
-
-#: apps/shared/views/shared_model.py:229 apps/shared/views/shared_model.py:230
-#: apps/shared/views/shared_model.py:231
-msgid "Get Authorization model workspace"
-msgstr "獲取授權模型工作空間"
-
-#: apps/shared/views/shared_model.py:248 apps/shared/views/shared_model.py:249
-#: apps/shared/views/shared_model.py:250
-msgid "Get Share model by workspace id"
-msgstr "獲取共享模型工作空間 ID"
-
-#: apps/shared/views/shared_model.py:265 apps/shared/views/shared_model.py:266
-#: apps/shared/views/shared_model.py:267
-msgid "Get Share model by workspace id with pagination"
-msgstr "獲取共享模型工作空間 ID 分頁列表"
-
-#: apps/shared/views/shared_paragraph.py:24
-#: apps/shared/views/shared_paragraph.py:25
-#: apps/shared/views/shared_paragraph.py:26
-msgid "Shared paragraph list"
-msgstr "共享段落列表"
-
-#: apps/shared/views/shared_paragraph.py:29
-#: apps/shared/views/shared_paragraph.py:50
-#: apps/shared/views/shared_paragraph.py:76
-#: apps/shared/views/shared_paragraph.py:93
-#: apps/shared/views/shared_paragraph.py:125
-#: apps/shared/views/shared_paragraph.py:151
-#: apps/shared/views/shared_paragraph.py:179
-#: apps/shared/views/shared_paragraph.py:201
-#: apps/shared/views/shared_paragraph.py:233
-#: apps/shared/views/shared_paragraph.py:259
-#: apps/shared/views/shared_paragraph.py:283
-#: apps/shared/views/shared_paragraph.py:314
-#: apps/shared/views/shared_paragraph.py:345
-#: apps/shared/views/shared_paragraph.py:371
-msgid "Shared Knowledge/Documentation/Paragraph"
-msgstr "共享知識庫/文檔/段落"
-
-#: apps/shared/views/shared_paragraph.py:45
-#: apps/shared/views/shared_paragraph.py:46
-msgid "Create shared paragraph"
-msgstr "創建段落"
-
-#: apps/shared/views/shared_paragraph.py:70
-#: apps/shared/views/shared_paragraph.py:71
-#: apps/shared/views/shared_paragraph.py:72
-msgid "Batch shared paragraph"
-msgstr "批量關聯段落"
-
-#: apps/shared/views/shared_paragraph.py:88
-#: apps/shared/views/shared_paragraph.py:89
-msgid "Migrate shared paragraphs in batches"
-msgstr "批量遷移共享段落"
-
-#: apps/shared/views/shared_paragraph.py:119
-#: apps/shared/views/shared_paragraph.py:120
-#: apps/shared/views/shared_paragraph.py:121
-msgid "Batch generate shared related"
-msgstr "批量生成相關"
-
-#: apps/shared/views/shared_paragraph.py:145
-#: apps/shared/views/shared_paragraph.py:146
-#: apps/shared/views/shared_paragraph.py:147
-msgid "Modify shared paragraph data"
-msgstr "修改段落數據"
-
-#: apps/shared/views/shared_paragraph.py:174
-#: apps/shared/views/shared_paragraph.py:175
-#: apps/shared/views/shared_paragraph.py:176
-msgid "Get shared paragraph details"
-msgstr "獲取段落詳情"
-
-#: apps/shared/views/shared_paragraph.py:196
-#: apps/shared/views/shared_paragraph.py:197
-#: apps/shared/views/shared_paragraph.py:198
-msgid "Delete shared paragraph"
-msgstr "刪除段落"
-
-#: apps/shared/views/shared_paragraph.py:227
-#: apps/shared/views/shared_paragraph.py:228
-#: apps/shared/views/shared_paragraph.py:229
-msgid "Add shared associated questions"
-msgstr "添加關聯問題"
-
-#: apps/shared/views/shared_paragraph.py:254
-#: apps/shared/views/shared_paragraph.py:255
-#: apps/shared/views/shared_paragraph.py:256
+#: apps/knowledge/views/document.py:268
+#: apps/knowledge/views/document.py:269
+#: apps/knowledge/views/document.py:270
+msgid "Get a list of segment IDs"
+msgstr "獲取分段列表"
+
+#: no source
 msgid "Get a list of shared paragraph questions"
 msgstr "獲取共享段落問題列表"
 
-#: apps/shared/views/shared_paragraph.py:277
-#: apps/shared/views/shared_paragraph.py:278
-#: apps/shared/views/shared_paragraph.py:279
-msgid "Disassociation shared issue"
-msgstr "取消關聯問題"
+#: no source
+msgid "Get a list of shared segment IDs"
+msgstr "獲取共享分段 ID 列表"
 
-#: apps/shared/views/shared_paragraph.py:308
-#: apps/shared/views/shared_paragraph.py:309
-#: apps/shared/views/shared_paragraph.py:310
-msgid "Related shared questions"
-msgstr "關聯問題"
+#: no source
+msgid "Get a list of system paragraph questions"
+msgstr "獲取段落問題列表"
 
-#: apps/shared/views/shared_paragraph.py:340
-#: apps/shared/views/shared_paragraph.py:341
-#: apps/shared/views/shared_paragraph.py:342
-msgid "Get shared paragraph list by pagination"
-msgstr "獲取段落列表"
+#: no source
+msgid "Get a list of system segment IDs"
+msgstr "獲取分段ID列表"
 
-#: apps/shared/views/shared_problem.py:23
-#: apps/shared/views/shared_problem.py:24
-#: apps/shared/views/shared_problem.py:25
-msgid "Shared question list"
-msgstr "問題列表"
+#: apps/trigger/views/trigger_task.py:78
+#: apps/trigger/views/trigger_task.py:79
+#: apps/trigger/views/trigger_task.py:80
+msgid "Get a paginated list of execution records for trigger tasks."
+msgstr "取得觸發器任務執行記錄的分頁清單。"
 
-#: apps/shared/views/shared_problem.py:28
-#: apps/shared/views/shared_problem.py:50
-#: apps/shared/views/shared_problem.py:71
-#: apps/shared/views/shared_problem.py:94
-#: apps/shared/views/shared_problem.py:115
-#: apps/shared/views/shared_problem.py:135
-#: apps/shared/views/shared_problem.py:158
-#: apps/shared/views/shared_problem.py:182
-msgid "Shared Knowledge/Documentation/Paragraph/Question"
-msgstr "知識庫/文檔/段落/問題"
+#: apps/application/views/application_chat.py:121
+#: apps/application/views/application_chat.py:122
+#: apps/application/views/application_chat.py:123
+msgid "Get a temporary session id based on the application id"
+msgstr "獲取智能體的臨時會話 ID"
 
-#: apps/shared/views/shared_problem.py:44
-#: apps/shared/views/shared_problem.py:45
-#: apps/shared/views/shared_problem.py:46
-msgid "Create shared question"
-msgstr "創建問題"
+#: apps/knowledge/views/knowledge.py:570
+#: apps/knowledge/views/knowledge.py:571
+#: apps/knowledge/views/knowledge.py:572
+msgid "Get all tags of knowledge base"
+msgstr ""
 
-#: apps/shared/views/shared_problem.py:66
-#: apps/shared/views/shared_problem.py:67
-#: apps/shared/views/shared_problem.py:68
-msgid "Get a list of associated shared paragraphs"
-msgstr "獲取關聯段落列表"
+#: apps/users/views/user.py:130
+#: apps/users/views/user.py:131
+#: apps/users/views/user.py:132
+msgid "Get all user"
+msgstr "獲取所有用戶"
 
-#: apps/shared/views/shared_problem.py:88
-#: apps/shared/views/shared_problem.py:89
-#: apps/shared/views/shared_problem.py:90
-msgid "Batch associated shared paragraphs"
-msgstr "批量關聯段落"
+#: apps/application/views/application_access_token.py:61
+#: apps/application/views/application_access_token.py:62
+#: apps/application/views/application_access_token.py:63
+msgid "Get application access restriction information"
+msgstr "獲取智能體訪問限制信息"
 
-#: apps/shared/views/shared_problem.py:109
-#: apps/shared/views/shared_problem.py:110
-#: apps/shared/views/shared_problem.py:111
-msgid "Batch deletion shared issues"
-msgstr "批量刪除問題"
+#: apps/application/views/application_api_key.py:59
+msgid "GET application ApiKey List"
+msgstr "獲取智能體的 API 密鑰列表"
 
-#: apps/shared/views/shared_problem.py:130
-#: apps/shared/views/shared_problem.py:131
-#: apps/shared/views/shared_problem.py:132
-msgid "Delete shared question"
-msgstr "刪除問題"
+#: apps/chat/views/chat.py:140
+#: apps/chat/views/chat.py:141
+#: apps/chat/views/chat.py:142
+msgid "Get application authentication information"
+msgstr "獲取智能體認證信息"
 
-#: apps/shared/views/shared_problem.py:152
-#: apps/shared/views/shared_problem.py:153
-#: apps/shared/views/shared_problem.py:154
-msgid "Modify shared question"
-msgstr "修改問題"
+#: apps/application/views/application.py:221
+#: apps/application/views/application.py:222
+#: apps/application/views/application.py:223
+msgid "Get application details"
+msgstr "獲取智能體詳情"
 
-#: apps/shared/views/shared_problem.py:177
-#: apps/shared/views/shared_problem.py:178
-#: apps/shared/views/shared_problem.py:179
-msgid "Get the list of shared questions by page"
-msgstr "分頁獲取問題列表"
+#: apps/chat/views/chat.py:123
+#: apps/chat/views/chat.py:124
+#: apps/chat/views/chat.py:125
+msgid "Get application related information"
+msgstr "獲取智能體相關信息"
 
-#: apps/shared/views/shared_tool.py:25 apps/shared/views/shared_tool.py:26
-#: apps/shared/views/shared_tool.py:27
-msgid "Get share resource tool"
-msgstr "獲取共享資源工具"
+#: no source
+msgid "Get Application Settings"
+msgstr "獲取智能體設置"
 
-#: apps/shared/views/shared_tool.py:43 apps/shared/views/shared_tool.py:44
-#: apps/shared/views/shared_tool.py:45
-msgid "Create shared tool"
-msgstr "創建共享工具"
+#: apps/application/views/application_version.py:79
+#: apps/application/views/application_version.py:80
+#: apps/application/views/application_version.py:81
+msgid "Get application version details"
+msgstr "獲取智能體版本詳情"
 
-#: apps/shared/views/shared_tool.py:62 apps/shared/views/shared_tool.py:63
-#: apps/shared/views/shared_tool.py:64
-msgid "Update shared tool"
-msgstr "更新共享工具"
+#: apps/application/views/application.py:299
+#: apps/application/views/application.py:300
+#: apps/application/views/application.py:301
+msgid "Get Appstore apps"
+msgstr ""
 
-#: apps/shared/views/shared_tool.py:78 apps/shared/views/shared_tool.py:79
-#: apps/shared/views/shared_tool.py:80
-msgid "Get shared tool"
-msgstr "獲取共享工具"
+#: apps/knowledge/views/knowledge.py:317
+#: apps/knowledge/views/knowledge.py:318
+#: apps/knowledge/views/knowledge.py:319
+#: apps/tools/views/tool.py:530
+#: apps/tools/views/tool.py:531
+#: apps/tools/views/tool.py:532
+#: apps/tools/views/tool_workflow.py:194
+#: apps/tools/views/tool_workflow.py:195
+#: apps/tools/views/tool_workflow.py:196
+msgid "Get Appstore tools"
+msgstr ""
 
-#: apps/shared/views/shared_tool.py:93 apps/shared/views/shared_tool.py:94
-#: apps/shared/views/shared_tool.py:95
-msgid "Delete shared tool"
-msgstr "刪除共享工具"
+#: no source
+msgid "Get authentication configuration"
+msgstr "獲取認證配置"
 
-#: apps/shared/views/shared_tool.py:111 apps/shared/views/shared_tool.py:112
-#: apps/shared/views/shared_tool.py:113
-msgid "Get shared tool list by pagination"
-msgstr "獲取共享工具列表"
+#: no source
+msgid "Get Authentication Configuration"
+msgstr "獲取認證配置"
 
-#: apps/shared/views/shared_tool.py:134 apps/shared/views/shared_tool.py:135
-#: apps/shared/views/shared_tool.py:136
-msgid "Import shared tool"
-msgstr "導入共享工具"
+#: no source
+msgid "Get authentication types"
+msgstr "獲取認證類型"
 
-#: apps/shared/views/shared_tool.py:152 apps/shared/views/shared_tool.py:153
-#: apps/shared/views/shared_tool.py:154
-msgid "Export shared tool"
-msgstr "導出共享工具"
+#: no source
+msgid "Get Authorization knowledge workspace"
+msgstr "獲取授權知識工作空間"
 
-#: apps/shared/views/shared_tool.py:170 apps/shared/views/shared_tool.py:171
-#: apps/shared/views/shared_tool.py:172
-msgid "Debug shared Tool"
-msgstr "調試共享工具"
+#: no source
+msgid "Get Authorization model workspace"
+msgstr "獲取授權模型工作空間"
 
-#: apps/shared/views/shared_tool.py:188 apps/shared/views/shared_tool.py:189
-#: apps/shared/views/shared_tool.py:190
-msgid "Check shared code"
-msgstr "檢查代碼"
-
-#: apps/shared/views/shared_tool.py:212 apps/shared/views/shared_tool.py:213
-#: apps/shared/views/shared_tool.py:214
-msgid "Edit shared tool icon"
-msgstr "修改共享工具圖標"
-
-#: apps/shared/views/shared_tool.py:233 apps/shared/views/shared_tool.py:235
-msgid "Authorization tool workspace"
-msgstr "授權工作空間工具"
-
-#: apps/shared/views/shared_tool.py:234
-msgid "Authorization tool workspace "
-msgstr "授權工作空間工具"
-
-#: apps/shared/views/shared_tool.py:249 apps/shared/views/shared_tool.py:250
-#: apps/shared/views/shared_tool.py:251
+#: no source
 msgid "Get Authorization tool workspace"
 msgstr "獲取授權工作空間工具"
 
-#: apps/shared/views/shared_tool.py:268 apps/shared/views/shared_tool.py:269
-#: apps/shared/views/shared_tool.py:270
-msgid "Get shared workspace tool"
-msgstr "獲取共享工作空間工具"
+#: apps/users/views/login.py:70
+#: apps/users/views/login.py:71
+#: apps/users/views/login.py:72
+msgid "Get captcha"
+msgstr "獲取驗證碼"
 
-#: apps/shared/views/shared_tool.py:289 apps/shared/views/shared_tool.py:290
-#: apps/shared/views/shared_tool.py:291
-msgid "Get shared workspace tool list by pagination"
-msgstr "獲取共享工作空間工具分頁列表"
-
-#: apps/system_manage/serializers/email_setting.py:28
-msgid "SMTP host"
+#: apps/chat/views/chat.py:204
+#: apps/chat/views/chat.py:205
+#: apps/chat/views/chat.py:206
+msgid "Get Chat captcha"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:29
-msgid "SMTP port"
+#: apps/application/views/application_chat_link.py:45
+#: apps/application/views/application_chat_link.py:46
+#: apps/application/views/application_chat_link.py:47
+msgid "Get chat record by share link"
+msgstr "透過分享連結取得聊天記錄"
+
+#: no source
+msgid "Get chat user information"
+msgstr "獲取對話用戶信息"
+
+#: no source
+msgid "Get chat user list"
+msgstr "獲取對話用戶列表"
+
+#: apps/chat/views/chat_record.py:186
+#: apps/chat/views/chat_record.py:187
+#: apps/chat/views/chat_record.py:188
+msgid "Get conversation details"
 msgstr ""
 
-#: apps/system_manage/serializers/email_setting.py:30
-#: apps/system_manage/serializers/email_setting.py:34
-msgid "Sender's email"
-msgstr "發送者郵箱"
+#: apps/application/views/application_chat_record.py:86
+#: apps/application/views/application_chat_record.py:87
+#: apps/application/views/application_chat_record.py:88
+msgid "Get conversation record details"
+msgstr "獲取對話記錄詳情"
 
-#: apps/system_manage/serializers/email_setting.py:31 apps/users/api/user.py:93
-#: apps/users/serializers/login.py:28 apps/users/serializers/user.py:57
-#: apps/users/serializers/user.py:126 apps/users/serializers/user.py:291
-#: apps/users/serializers/user.py:517 apps/xpack/api/auth_config.py:25
-#: apps/xpack/api/chat_user.py:71 apps/xpack/serializers/chat_auth.py:24
-#: apps/xpack/serializers/chat_user.py:74
-#: apps/xpack/serializers/chat_user.py:267
-#: apps/xpack/serializers/chat_user.py:601
-msgid "Password"
-msgstr "密碼"
+#: apps/users/views/user.py:68
+#: apps/users/views/user.py:69
+#: apps/users/views/user.py:70
+#: apps/users/views/user.py:82
+#: apps/users/views/user.py:83
+msgid "Get current user information"
+msgstr "獲取當前用戶信息"
 
-#: apps/system_manage/serializers/email_setting.py:32
-msgid "Whether to enable TLS"
-msgstr "是否啟用 TLS"
+#: no source
+msgid "Get current user role list"
+msgstr "獲取當前用戶角色列表"
 
-#: apps/system_manage/serializers/email_setting.py:33
-msgid "Whether to enable SSL"
-msgstr "是否啟用 SSL"
+#: apps/users/views/user.py:191
+#: apps/users/views/user.py:192
+#: apps/users/views/user.py:193
+msgid "Get default password"
+msgstr "獲取默認密碼"
 
-#: apps/system_manage/serializers/email_setting.py:49
-msgid "Email verification failed"
-msgstr "郵件認證失敗"
+#: apps/knowledge/views/document.py:87
+#: apps/knowledge/views/document.py:88
+#: apps/knowledge/views/document.py:89
+msgid "Get document"
+msgstr "獲取文檔"
 
-#: apps/system_manage/serializers/user_resource_permission.py:53
-msgid "target id"
-msgstr "當前 ID"
+#: apps/knowledge/views/document.py:840
+#: apps/knowledge/views/document.py:841
+#: apps/knowledge/views/document.py:842
+msgid "Get document by pagination"
+msgstr "分頁獲取文檔"
 
-#: apps/system_manage/serializers/user_resource_permission.py:70
-msgid "Non-existent application|knowledge base id["
-msgstr "不存在的智能體|知識庫 ID["
+#: apps/knowledge/views/document.py:127
+#: apps/knowledge/views/document.py:128
+#: apps/knowledge/views/document.py:129
+msgid "Get document details"
+msgstr "文檔文檔詳情"
 
-#: apps/system_manage/views/email_setting.py:50
-#: apps/system_manage/views/email_setting.py:51
-#: apps/system_manage/views/email_setting.py:52
-msgid "Create or update email settings"
-msgstr "創建或更新郵件設置"
+#: no source
+msgid "Get document list from lark"
+msgstr "獲取飛書文檔列表"
 
-#: apps/system_manage/views/email_setting.py:55
-#: apps/system_manage/views/email_setting.py:70
-#: apps/system_manage/views/email_setting.py:86
-msgid "Email Settings"
-msgstr "郵箱設置"
-
-#: apps/system_manage/views/email_setting.py:66
-#: apps/system_manage/views/email_setting.py:67
-msgid "Test email settings"
-msgstr "測試郵箱設置"
+#: apps/knowledge/views/document.py:1009
+#: apps/knowledge/views/document.py:1010
+#: apps/knowledge/views/document.py:1011
+msgid "Get document tags"
+msgstr ""
 
 #: apps/system_manage/views/email_setting.py:82
 #: apps/system_manage/views/email_setting.py:83
@@ -6604,2904 +3682,7456 @@ msgstr "測試郵箱設置"
 msgid "Get email settings"
 msgstr "獲取郵箱設置"
 
+#: apps/chat/views/chat_embed.py:22
+#: apps/chat/views/chat_embed.py:23
+#: apps/chat/views/chat_embed.py:24
+msgid "Get embedded js"
+msgstr "獲取嵌入式 JavaScript"
+
+#: no source
+msgid "Get embedding model for knowledge base"
+msgstr "獲取知識庫向量模型"
+
+#: no source
+msgid "Get embedding model for shared knowledge base"
+msgstr "獲取共享知識庫嵌入模型"
+
+#: no source
+msgid "Get embedding model for system knowledge base"
+msgstr "獲取系統知識庫嵌入模型"
+
+#: apps/oss/views/file.py:18
+#: apps/oss/views/file.py:19
+#: apps/oss/views/file.py:20
+msgid "Get file"
+msgstr "獲取文件"
+
+#: apps/folders/views/folder.py:126
+#: apps/folders/views/folder.py:127
+#: apps/folders/views/folder.py:128
+msgid "Get folder"
+msgstr "獲取文件夾"
+
+#: apps/folders/views/folder.py:67
+#: apps/folders/views/folder.py:68
+#: apps/folders/views/folder.py:69
+msgid "Get folder tree"
+msgstr "獲取文件夾樹"
+
+#: apps/knowledge/views/document.py:1336
+#: apps/knowledge/views/document.py:1337
+msgid "Get form template"
+msgstr "獲取表格模板"
+
+#: apps/chat/views/chat_record.py:49
+#: apps/chat/views/chat_record.py:50
+#: apps/chat/views/chat_record.py:51
+msgid "Get historical conversation"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:125
+#: apps/chat/views/chat_record.py:126
+#: apps/chat/views/chat_record.py:127
+msgid "Get historical conversation by page"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:145
+#: apps/chat/views/chat_record.py:146
+#: apps/chat/views/chat_record.py:147
+msgid "Get historical conversation records"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:166
+#: apps/chat/views/chat_record.py:167
+msgid "Get historical conversation records by page"
+msgstr ""
+
+#: apps/chat/views/chat_record.py:165
+msgid "Get historical conversation records by page "
+msgstr ""
+
+#: apps/tools/views/tool.py:482
+#: apps/tools/views/tool.py:483
+#: apps/tools/views/tool.py:484
+msgid "Get internal tool"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:119
+#: apps/knowledge/views/knowledge.py:120
+#: apps/knowledge/views/knowledge.py:121
+msgid "Get knowledge"
+msgstr "獲取知識庫"
+
+#: apps/knowledge/views/knowledge.py:37
+#: apps/knowledge/views/knowledge.py:38
+#: apps/knowledge/views/knowledge.py:39
+msgid "Get knowledge by folder"
+msgstr "根據文件夾獲取知識庫"
+
+#: apps/knowledge/views/tag.py:44
+msgid "Get Knowledge Tag"
+msgstr ""
+
+#: apps/knowledge/views/tag.py:45
+msgid "Get knowledge tag"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow_version.py:89
+#: apps/knowledge/views/knowledge_workflow_version.py:90
+#: apps/knowledge/views/knowledge_workflow_version.py:91
+msgid "Get knowledge version details"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:398
+#: apps/knowledge/views/knowledge_workflow.py:399
+#: apps/knowledge/views/knowledge_workflow.py:400
+msgid "Get knowledge workflow"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:170
+#: apps/knowledge/views/knowledge_workflow.py:171
+#: apps/knowledge/views/knowledge_workflow.py:172
+msgid "Get knowledge workflow action"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:428
+#: apps/knowledge/views/knowledge_workflow.py:429
+#: apps/knowledge/views/knowledge_workflow.py:430
+msgid "Get knowledge workflow version list"
+msgstr ""
+
+#: no source
+msgid "Get license information"
+msgstr "獲取許可證信息"
+
 #: apps/system_manage/views/system_profile.py:22
 #: apps/system_manage/views/system_profile.py:23
 msgid "Get MaxKB related information"
 msgstr "獲取 MaxKB 相關信息"
 
-#: apps/system_manage/views/system_profile.py:25
-msgid "System parameters"
-msgstr "系統參數"
+#: no source
+msgid "Get menu operate log"
+msgstr "獲取菜單操作日誌"
 
-#: apps/system_manage/views/user_resource_permission.py:40
-#: apps/system_manage/views/user_resource_permission.py:41
-msgid "Obtain resource authorization list"
-msgstr "獲取資源授權列表"
+#: apps/models_provider/views/provide.py:75
+#: apps/models_provider/views/provide.py:76
+#: apps/models_provider/views/provide.py:77
+msgid "Get model default parameters"
+msgstr "獲取模型默認參數"
 
-#: apps/system_manage/views/user_resource_permission.py:44
-#: apps/system_manage/views/user_resource_permission.py:60
-msgid "Resources authorization"
-msgstr "資源授權"
+#: apps/knowledge/views/knowledge.py:512
+#: apps/knowledge/views/knowledge.py:513
+#: apps/knowledge/views/knowledge.py:514
+msgid "Get model for knowledge base"
+msgstr "獲取知識庫模型"
 
-#: apps/system_manage/views/user_resource_permission.py:55
-#: apps/system_manage/views/user_resource_permission.py:56
-msgid "Modify the resource authorization list"
-msgstr "修改資源授權列表"
+#: no source
+msgid "Get model for shared knowledge base"
+msgstr "獲取共享知識庫模型"
 
-#: apps/tools/serializers/tool.py:118 apps/tools/serializers/tool.py:169
-msgid "variable name"
-msgstr "變量名稱"
+#: no source
+msgid "Get model for system knowledge base"
+msgstr "獲取系統知識庫模型"
 
-#: apps/tools/serializers/tool.py:122
-msgid "fields only support string|int|dict|array|float"
-msgstr "欄位僅支持字符串|整數|字典|數組|浮點數"
+#: apps/models_provider/views/model.py:181
+#: apps/models_provider/views/model.py:182
+#: apps/models_provider/views/model.py:183
+msgid "Get model parameter form"
+msgstr "獲取模型參數表單"
 
-#: apps/tools/serializers/tool.py:131
-msgid "field name"
-msgstr "欄位名稱"
+#: no source
+msgid "Get paginated operate log"
+msgstr "獲取分頁操作日誌"
 
-#: apps/tools/serializers/tool.py:132
-msgid "field label"
-msgstr "標籤"
+#: apps/knowledge/views/paragraph.py:211
+#: apps/knowledge/views/paragraph.py:212
+#: apps/knowledge/views/paragraph.py:213
+msgid "Get paragraph details"
+msgstr "獲取段落詳情"
 
-#: apps/tools/serializers/tool.py:146 apps/tools/serializers/tool.py:160
-#: apps/tools/serializers/tool.py:174
-msgid "tool content"
-msgstr "工具內容"
+#: apps/knowledge/views/paragraph.py:415
+#: apps/knowledge/views/paragraph.py:416
+#: apps/knowledge/views/paragraph.py:417
+msgid "Get paragraph list by pagination"
+msgstr "獲取段落列表"
 
-#: apps/tools/serializers/tool.py:148 apps/tools/serializers/tool.py:161
-#: apps/tools/serializers/tool.py:175
-msgid "input field list"
-msgstr "輸入欄位列表"
+#: no source
+msgid "Get platform configuration"
+msgstr "獲取平臺配置"
 
-#: apps/tools/serializers/tool.py:150 apps/tools/serializers/tool.py:162
-#: apps/tools/serializers/tool.py:176
-msgid "init field list"
-msgstr "內置欄位列表"
+#: no source
+msgid "Get platform information"
+msgstr "獲取平臺信息"
 
-#: apps/tools/serializers/tool.py:163 apps/tools/serializers/tool.py:177
-msgid "init params"
-msgstr "內置參數"
+#: no source
+msgid "Get platform status"
+msgstr "獲取平臺狀態"
 
-#: apps/tools/serializers/tool.py:170
-msgid "variable value"
-msgstr "變量名稱"
+#: apps/knowledge/views/document.py:1322
+#: apps/knowledge/views/document.py:1323
+msgid "Get QA template"
+msgstr "獲取問答模板"
 
-#: apps/tools/serializers/tool.py:182
-msgid "function content"
-msgstr "工具內容"
+#: no source
+msgid "Get Resource chat user group List"
+msgstr "獲取資源聊天用戶組列表"
 
-#: apps/tools/serializers/tool.py:238
-msgid "field has no value set"
-msgstr "欄位未設置值"
+#: no source
+msgid "Get Resource chat user group page List"
+msgstr "獲取資源聊天用戶組分頁列表"
 
-#: apps/tools/serializers/tool.py:262
-#, python-brace-format
-msgid "Field: {name} Type: {_type} Value: {value} Type conversion error"
-msgstr "欄位：{name} 類型：{_type} 值：{value} 類型轉換錯誤"
+#: no source
+msgid "Get Resource chat user List"
+msgstr "獲取資源聊天用戶列表"
 
-#: apps/tools/serializers/tool.py:275
-msgid "Tool not found"
-msgstr "工具不存在"
+#: no source
+msgid "Get Resource chat user page group List"
+msgstr "獲取資源聊天用戶分頁組列表"
 
-#: apps/tools/serializers/tool.py:388
-msgid "function ID"
-msgstr "工具 ID"
+#: no source
+msgid "Get Resource chat user page List"
+msgstr "獲取資源聊天用戶分頁列表"
 
-#: apps/tools/views/tool.py:33 apps/tools/views/tool.py:34
-#: apps/tools/views/tool.py:35
-msgid "Create tool"
-msgstr "創建工具"
+#: no source
+msgid "Get resource model list"
+msgstr "獲取資源模型列表"
 
-#: apps/tools/views/tool.py:56 apps/tools/views/tool.py:57
-#: apps/tools/views/tool.py:58
-msgid "Get tool by folder"
-msgstr "通過文件夾獲取工具"
+#: no source
+msgid "Get role list"
+msgstr "獲取角色列表"
 
-#: apps/tools/views/tool.py:77 apps/tools/views/tool.py:78
-#: apps/tools/views/tool.py:79
-msgid "Debug Tool"
-msgstr "調試工具"
+#: no source
+msgid "Get role permission"
+msgstr "獲取角色權限"
 
-#: apps/tools/views/tool.py:98 apps/tools/views/tool.py:99
-#: apps/tools/views/tool.py:100
-msgid "Update tool"
-msgstr "更新工具"
+#: no source
+msgid "Get role permission template"
+msgstr "獲取角色權限模板"
 
-#: apps/tools/views/tool.py:122 apps/tools/views/tool.py:123
-#: apps/tools/views/tool.py:124
+#: no source
+msgid "Get Share model"
+msgstr "獲取共享模型"
+
+#: apps/models_provider/views/model.py:273
+#: apps/models_provider/views/model.py:274
+#: apps/models_provider/views/model.py:275
+msgid "Get Share model by workspace id"
+msgstr "獲取共享模型工作空間 ID"
+
+#: no source
+msgid "Get Share model by workspace id with pagination"
+msgstr "獲取共享模型工作空間 ID 分頁列表"
+
+#: no source
+msgid "Get share resource knowledge"
+msgstr "獲取共享資源知識庫"
+
+#: no source
+msgid "Get share resource tool"
+msgstr "獲取共享資源工具"
+
+#: no source
+msgid "Get shared document"
+msgstr "獲取共享文檔"
+
+#: no source
+msgid "Get shared document by pagination"
+msgstr "獲取共享文檔分頁列表"
+
+#: no source
+msgid "Get shared document details"
+msgstr "文檔文檔詳情"
+
+#: no source
+msgid "Get shared form template"
+msgstr "獲取共享表格模板"
+
+#: no source
+msgid "Get shared knowledge"
+msgstr "獲取共享知識庫"
+
+#: no source
+msgid "Get shared knowledge list by pagination"
+msgstr "獲取共享知識庫分頁列表"
+
+#: no source
+msgid "Get shared paragraph details"
+msgstr "獲取段落詳情"
+
+#: no source
+msgid "Get shared paragraph list by pagination"
+msgstr "獲取段落列表"
+
+#: no source
+msgid "Get shared QA template"
+msgstr "獲取共享問答模板"
+
+#: no source
+msgid "Get shared tool"
+msgstr "獲取共享工具"
+
+#: no source
+msgid "Get shared tool list by pagination"
+msgstr "獲取共享工具列表"
+
+#: no source
+msgid "Get shared workspace knowledge"
+msgstr "獲取共享工作空間知識庫"
+
+#: no source
+msgid "Get shared workspace knowledge list by pagination"
+msgstr "獲取共享工作空間知識庫分頁列表"
+
+#: no source
+msgid "Get shared workspace tool"
+msgstr "獲取共享工作空間工具"
+
+#: no source
+msgid "Get shared workspace tool list by pagination"
+msgstr "獲取共享工作空間工具分頁列表"
+
+#: no source
+msgid "Get system document"
+msgstr "獲取文檔"
+
+#: no source
+msgid "Get system document by pagination"
+msgstr "分頁獲取文檔"
+
+#: no source
+msgid "Get system document details"
+msgstr "獲取文檔詳情"
+
+#: no source
+msgid "Get system form template"
+msgstr "獲取系統表單模板"
+
+#: no source
+msgid "Get system knowledge"
+msgstr "獲取知識庫"
+
+#: no source
+msgid "Get system knowledge list"
+msgstr "獲取系統知識庫列表"
+
+#: no source
+msgid "Get system knowledge list by pagination"
+msgstr "獲取系統知識庫分頁列表"
+
+#: no source
+msgid "Get system paragraph details"
+msgstr "獲取段落詳情"
+
+#: no source
+msgid "Get system paragraph list by pagination"
+msgstr "獲取段落列表"
+
+#: no source
+msgid "Get system QA template"
+msgstr "獲取系統問答模板"
+
+#: no source
+msgid "Get system role member list"
+msgstr "獲取系統角色成員列表"
+
+#: no source
+msgid "Get System Task source trigger details"
+msgstr "取得系統任務來源觸發器詳情"
+
+#: no source
+msgid "Get system tool"
+msgstr "獲取工具"
+
+#: no source
+msgid "Get system tool by id"
+msgstr "獲取工具"
+
+#: no source
+msgid "Get system tool list by pagination"
+msgstr "獲取工具列表"
+
+#: no source
+msgid "Get system workspace list"
+msgstr "獲取系統工作空間列表"
+
+#: no source
+msgid "Get system workspace member list"
+msgstr "獲取系統工作空間成員列表"
+
+#: no source
+msgid "Get SystemAPIKey List"
+msgstr "獲取系統 API 密鑰列表"
+
+#: apps/trigger/views/trigger.py:318
+#: apps/trigger/views/trigger.py:319
+#: apps/trigger/views/trigger.py:320
+msgid "Get Task source trigger details"
+msgstr "取得資源端觸發器詳情"
+
+#: apps/application/views/application.py:75
+#: apps/application/views/application.py:76
+#: apps/application/views/application.py:77
+msgid "Get the application list"
+msgstr "獲取智能體列表"
+
+#: apps/application/views/application.py:94
+#: apps/application/views/application.py:95
+#: apps/application/views/application.py:96
+msgid "Get the application list by page"
+msgstr "分頁獲取智能體列表"
+
+#: apps/application/views/application_version.py:30
+#: apps/application/views/application_version.py:31
+#: apps/application/views/application_version.py:32
+msgid "Get the application version list"
+msgstr "獲取智能體版本列表"
+
+#: apps/application/views/application_chat.py:44
+#: apps/application/views/application_chat.py:45
+#: apps/application/views/application_chat.py:46
+msgid "Get the conversation list"
+msgstr "獲取對話列表"
+
+#: apps/application/views/application_chat.py:69
+#: apps/application/views/application_chat.py:70
+#: apps/application/views/application_chat.py:71
+msgid "Get the conversation list by page"
+msgstr "分頁獲取對話列表"
+
+#: apps/application/views/application_chat_record.py:31
+#: apps/application/views/application_chat_record.py:32
+#: apps/application/views/application_chat_record.py:33
+msgid "Get the conversation record list"
+msgstr "獲取對話記錄列表"
+
+#: apps/application/views/application_chat_record.py:57
+#: apps/application/views/application_chat_record.py:58
+#: apps/application/views/application_chat_record.py:59
+msgid "Get the conversation record list by page"
+msgstr "分頁獲取對話記錄列表"
+
+#: apps/knowledge/views/knowledge.py:220
+#: apps/knowledge/views/knowledge.py:221
+#: apps/knowledge/views/knowledge.py:222
+msgid "Get the knowledge base paginated list"
+msgstr "獲取知識庫分頁列表"
+
+#: apps/knowledge/views/knowledge_workflow_version.py:40
+#: apps/knowledge/views/knowledge_workflow_version.py:41
+#: apps/knowledge/views/knowledge_workflow_version.py:42
+msgid "Get the knowledge version list"
+msgstr ""
+
+#: apps/application/views/application_version.py:54
+#: apps/application/views/application_version.py:55
+#: apps/application/views/application_version.py:56
+msgid "Get the list of application versions by page"
+msgstr "分頁獲取智能體版本列表"
+
+#: apps/knowledge/views/knowledge_workflow_version.py:64
+#: apps/knowledge/views/knowledge_workflow_version.py:65
+#: apps/knowledge/views/knowledge_workflow_version.py:66
+msgid "Get the list of knowledge versions by page"
+msgstr ""
+
+#: apps/application/views/application_chat_record.py:140
+#: apps/application/views/application_chat_record.py:141
+#: apps/application/views/application_chat_record.py:142
+msgid "Get the list of marked paragraphs"
+msgstr "獲取標記段落列表"
+
+#: apps/tools/views/tool_workflow.py:158
+#: apps/tools/views/tool_workflow.py:159
+#: apps/tools/views/tool_workflow.py:160
+msgid "Get the list of MCP tools"
+msgstr ""
+
+#: apps/knowledge/views/problem.py:232
+#: apps/knowledge/views/problem.py:233
+#: apps/knowledge/views/problem.py:234
+msgid "Get the list of questions by page"
+msgstr "分頁獲取問題列表"
+
+#: no source
+msgid "Get the list of shared questions by page"
+msgstr "分頁獲取問題列表"
+
+#: no source
+msgid "Get the list of system questions by page"
+msgstr "分頁獲取問題列表"
+
+#: apps/knowledge/views/termbase.py:238
+#: apps/knowledge/views/termbase.py:239
+#: apps/knowledge/views/termbase.py:240
+msgid "Get the list of termbase by page"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:65
+#: apps/tools/views/tool_workflow_version.py:66
+#: apps/tools/views/tool_workflow_version.py:67
+msgid "Get the list of tool versions by page"
+msgstr ""
+
+#: apps/models_provider/views/provide.py:92
+#: apps/models_provider/views/provide.py:93
+#: apps/models_provider/views/provide.py:94
+msgid "Get the model creation form"
+msgstr "獲取模型創建表單"
+
+#: apps/chat/views/chat.py:184
+#: apps/chat/views/chat.py:185
+#: apps/chat/views/chat.py:186
+msgid "Get the session id according to the application id"
+msgstr "根據智能體 ID 獲取會話 ID"
+
+#: no source
+msgid "Get the System trigger list of source"
+msgstr "取得來源的系統觸發器清單"
+
+#: apps/trigger/views/trigger_task.py:28
+#: apps/trigger/views/trigger_task.py:29
+#: apps/trigger/views/trigger_task.py:30
+msgid "Get the task list of triggers"
+msgstr "取得觸發器任務清單"
+
+#: apps/tools/views/tool_workflow_version.py:41
+#: apps/tools/views/tool_workflow_version.py:42
+#: apps/tools/views/tool_workflow_version.py:43
+msgid "Get the tool version list"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:79
+#: apps/trigger/views/trigger.py:80
+#: apps/trigger/views/trigger.py:81
+msgid "Get the trigger list"
+msgstr "取得觸發器清單"
+
+#: apps/trigger/views/trigger.py:227
+#: apps/trigger/views/trigger.py:228
+#: apps/trigger/views/trigger.py:229
+msgid "Get the trigger list by page"
+msgstr "分頁取得觸發器清單"
+
+#: apps/trigger/views/trigger.py:290
+#: apps/trigger/views/trigger.py:291
+#: apps/trigger/views/trigger.py:292
+msgid "Get the trigger list of source"
+msgstr "取得資源端觸發器清單"
+
+#: apps/tools/views/tool.py:149
+#: apps/tools/views/tool.py:150
+#: apps/tools/views/tool.py:151
 msgid "Get tool"
 msgstr "獲取工具"
 
-#: apps/tools/views/tool.py:141 apps/tools/views/tool.py:142
-#: apps/tools/views/tool.py:143
-msgid "Delete tool"
-msgstr "刪除工具"
+#: apps/tools/views/tool.py:68
+#: apps/tools/views/tool.py:69
+#: apps/tools/views/tool.py:70
+msgid "Get tool by folder"
+msgstr "通過文件夾獲取工具"
 
-#: apps/tools/views/tool.py:167 apps/tools/views/tool.py:168
-#: apps/tools/views/tool.py:169
+#: apps/tools/views/tool.py:314
+#: apps/tools/views/tool.py:315
+msgid "Get tool list"
+msgstr "獲取工具列表"
+
+#: apps/tools/views/tool.py:313
+msgid "Get tool list "
+msgstr ""
+
+#: apps/tools/views/tool.py:282
+#: apps/tools/views/tool.py:283
+#: apps/tools/views/tool.py:284
 msgid "Get tool list by pagination"
 msgstr "獲取工具列表"
 
-#: apps/tools/views/tool.py:195 apps/tools/views/tool.py:196
-#: apps/tools/views/tool.py:197
+#: apps/tools/views/tool.py:640
+#: apps/tools/views/tool.py:641
+#: apps/tools/views/tool.py:642
+msgid "Get tool record"
+msgstr ""
+
+#: apps/tools/views/tool.py:611
+#: apps/tools/views/tool.py:612
+#: apps/tools/views/tool.py:613
+msgid "Get tool records"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:90
+#: apps/tools/views/tool_workflow_version.py:91
+#: apps/tools/views/tool_workflow_version.py:92
+msgid "Get tool version details"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:100
+#: apps/tools/views/tool_workflow.py:101
+#: apps/tools/views/tool_workflow.py:102
+msgid "Get tool workflow"
+msgstr ""
+
+#: apps/trigger/views/trigger.py:105
+#: apps/trigger/views/trigger.py:106
+#: apps/trigger/views/trigger.py:107
+msgid "Get trigger details"
+msgstr "取得觸發器詳情"
+
+#: apps/oss/views/file.py:76
+#: apps/oss/views/file.py:78
+#: apps/oss/views/file.py:79
+msgid "Get url"
+msgstr ""
+
+#: apps/system_manage/views/user_resource_permission.py:110
+#: apps/system_manage/views/user_resource_permission.py:111
+#: apps/system_manage/views/user_resource_permission.py:112
+msgid "Get user authorization status of resource"
+msgstr "獲取資源對用戶的授權狀態"
+
+#: apps/system_manage/views/user_resource_permission.py:176
+#: apps/system_manage/views/user_resource_permission.py:177
+#: apps/system_manage/views/user_resource_permission.py:178
+msgid "Get user authorization status of resource by page"
+msgstr "分頁獲取資源對用戶的授權狀態"
+
+#: no source
+msgid "Get user group list"
+msgstr "獲取用戶組列表"
+
+#: apps/users/views/user.py:219
+#: apps/users/views/user.py:220
+#: apps/users/views/user.py:221
+msgid "Get user information"
+msgstr "獲取用戶信息"
+
+#: no source
+msgid "Get user list by group"
+msgstr "獲取用戶組列表"
+
+#: apps/users/views/user.py:146
+#: apps/users/views/user.py:147
+#: apps/users/views/user.py:148
+msgid "Get user list under workspace"
+msgstr "獲取工作空間下用戶列表"
+
+#: apps/users/views/user.py:161
+#: apps/users/views/user.py:162
+#: apps/users/views/user.py:163
+msgid "Get user member under workspace"
+msgstr "獲取工作空間下用戶成員"
+
+#: apps/users/views/user.py:284
+#: apps/users/views/user.py:285
+#: apps/users/views/user.py:286
+msgid "Get user paginated list"
+msgstr "獲取用戶分頁列表"
+
+#: apps/system_manage/views/valid.py:25
+#: apps/system_manage/views/valid.py:26
+#: apps/system_manage/views/valid.py:27
+msgid "Get verification results"
+msgstr "獲取驗證結果"
+
+#: no source
+msgid "Get workspace list"
+msgstr "獲取工作空間列表"
+
+#: no source
+msgid "Get workspace list by current user"
+msgstr "獲取當前用戶工作空間列表"
+
+#: no source
+msgid "Get workspace list by user"
+msgstr "根據用戶獲取工作空間列表"
+
+#: no source
+msgid "Get workspace member list"
+msgstr "獲取工作空間成員列表"
+
+#: no source
+msgid "Get Workspace role list"
+msgstr "獲取工作空間角色列表"
+
+#: no source
+msgid "Get workspace role member list"
+msgstr "獲取工作空間角色成員列表"
+
+#: apps/chat/serializers/chat.py:91
+msgid "Global variables"
+msgstr "全局變量"
+
+#: no source
+msgid "Good at common conversational tasks, supports 32K contexts"
+msgstr "擅長通用對話任務，支持 32K 上下文"
+
+#: no source
+msgid "Good at handling programming tasks, supports 16K contexts"
+msgstr "擅長處理編程任務，支持 16K 上下文"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:53
+msgid "gpt-3.5-turbo snapshot on January 25, 2024, supporting context length 16,385 tokens"
+msgstr "2024年1月25日的gpt-3.5-turbo快照，支持上下文長度16,385 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:57
+msgid "gpt-3.5-turbo snapshot on November 6, 2023, supporting context length 16,385 tokens"
+msgstr "2023年11月6日的gpt-3.5-turbo快照，支持上下文長度16,385 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:69
+msgid "gpt-4-turbo snapshot on April 9, 2024, supporting context length 128,000 tokens"
+msgstr "2024年4月9日的gpt-4-turbo快照，支持上下文長度128,000 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:72
+msgid "gpt-4-turbo snapshot on January 25, 2024, supporting context length 128,000 tokens"
+msgstr "2024年1月25日的gpt-4-turbo快照，支持上下文長度128,000 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:75
+msgid "gpt-4-turbo snapshot on November 6, 2023, supporting context length 128,000 tokens"
+msgstr "2023年11月6日的gpt-4-turbo快照，支持上下文長度128,000 tokens"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:65
+msgid "gpt-4o snapshot on May 13, 2024, supporting context length 128,000 tokens"
+msgstr "2024年5月13日的gpt-4o快照，支持上下文長度128,000 tokens"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:19
+msgid "Group id"
+msgstr ""
+
+#: no source
+msgid "Group ID"
+msgstr "用戶組 ID"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:20
+msgid "group_name"
+msgstr ""
+
+#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:34
+msgid "Have strong multi-modal understanding capabilities. Able to understand up to five images simultaneously and supports video content understanding"
+msgstr "具有強大的多模態理解能力。能夠同時理解多達五張圖像，並支持視頻內容理解"
+
+#: no source
+msgid "header font color"
+msgstr "標題字體顏色"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/embedding.py:71
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:73
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:76
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:73
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:73
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tti.py:61
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py:44
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:52
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:56
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:33
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:53
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:46
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:50
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:36
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:55
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:68
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:54
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:54
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:52
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/gemini_model_provider/model/stt.py:48
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:56
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:35
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:47
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:47
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/minimax_model_provider/model/tts.py:44
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:37
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:54
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:54
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:36
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:55
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:54
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:47
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:22
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:56
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/tencent_model_provider/model/tti.py:56
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:49
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:44
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:52
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:56
+#: apps/models_provider/impl/volcanic_engine_model_provider/model/tts.py:79
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:46
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:66
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:43
+#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:75
+#: apps/models_provider/impl/xf_model_provider/model/tts/super_humanoid_tts.py:101
+#: apps/models_provider/impl/xf_model_provider/model/tts/tts.py:103
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:31
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:52
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:44
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:44
+#: apps/models_provider/impl/xinference_model_provider/model/tts.py:48
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:52
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:55
+#: apps/models_provider/impl/zhipu_model_provider/model/tti.py:54
+msgid "Hello"
+msgstr "你好"
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:48
+msgid "High-speed version of M2.7 for low-latency scenarios. 204K context window"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:22
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:17
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:16
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:15
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:14
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:18
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:18
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:16
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:16
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:13
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:18
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:19
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:18
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:23
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:14
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:16
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:16
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:41
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:16
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:16
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:16
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:22
+msgid "Higher values make the output more random, while lower values make it more focused and deterministic"
+msgstr "較高的數值會使輸出更加隨機，而較低的數值會使其更加集中和確定"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:34
+msgid "Hindi"
+msgstr "印地語"
+
+#: apps/application/serializers/application.py:350
+#: apps/application/serializers/application.py:597
+msgid "Historical chat records"
+msgstr "歷史聊天記錄"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:32
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:27
+msgid "History Questions"
+msgstr "歷史問題"
+
+#: apps/knowledge/serializers/document.py:170
+#: apps/knowledge/serializers/document.py:248
+#: apps/knowledge/serializers/document.py:478
+msgid "hit handling method"
+msgstr "命中處理方法"
+
+#: apps/knowledge/serializers/knowledge.py:770
+msgid "Hit handling method"
+msgstr "命中處理方式"
+
+#: apps/knowledge/serializers/document.py:1505
+msgid "Hit handling method is required"
+msgstr "命中處理方法是必需的"
+
+#: apps/knowledge/views/knowledge.py:284
+#: apps/knowledge/views/knowledge.py:285
+#: apps/knowledge/views/knowledge.py:286
+msgid "Hit test list"
+msgstr "命中測試列表"
+
+#: apps/common/constants/permission_constants.py:360
+#: apps/common/constants/permission_constants.py:418
+#: apps/common/constants/permission_constants.py:428
+msgid "Hit-Test"
+msgstr "命中測試"
+
+#: apps/common/constants/permission_constants.py:409
+#: apps/homepage/views/homepage.py:38
+#: apps/homepage/views/homepage.py:63
+#: apps/homepage/views/homepage.py:88
+#: apps/homepage/views/homepage.py:113
+#: apps/homepage/views/homepage.py:138
+#: apps/homepage/views/homepage.py:163
+#: apps/homepage/views/homepage.py:188
+#: apps/homepage/views/homepage.py:212
+#: apps/homepage/views/homepage.py:237
+#: apps/homepage/views/homepage.py:264
+#: apps/homepage/views/homepage.py:285
+#: apps/homepage/views/homepage.py:306
+#: apps/homepage/views/homepage.py:327
+msgid "Home page"
+msgstr "首頁"
+
+#: apps/chat/api/chat_embed_api.py:24
+msgid "host"
+msgstr ""
+
+#: apps/chat/serializers/chat_embed_serializers.py:25
+msgid "Host"
+msgstr ""
+
+#: apps/oss/serializers/file.py:99
+msgid "HTTP Range"
+msgstr ""
+
+#: apps/oss/serializers/file.py:100
+msgid "HTTP Range header for partial content requests, e.g., \"bytes=0-1023\""
+msgstr ""
+
+#: no source
+msgid "HttpClient query failed: "
+msgstr "HttpClient 查詢失敗: "
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:102
+msgid "Hunyuan graph model"
+msgstr "混元生圖模型"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:71
+msgid "Hunyuan's latest code generation model, after training the base model with 200B high-quality code data, and iterating on high-quality SFT data for half a year, the context long window length has been increased to 8K, and it ranks among the top in the automatic evaluation indicators of code generation in the five major languages; the five major languages In the manual high-quality evaluation of 10 comprehensive code tasks that consider all aspects, the performance is in the first echelon."
+msgstr "混元最新代碼生成模型，經過 200B 高質量代碼數據增訓基座模型，迭代半年高質量 SFT 數據訓練，上下文長窗口長度增大到 8K，五大語言代碼生成自動評測指標上位居前列；五大語言10項考量各方面綜合代碼任務人工高質量評測上，性能處於第一梯隊"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:65
+msgid "Hunyuan's latest MOE architecture FunctionCall model has been trained with high-quality FunctionCall data and has a context window of 32K, leading in multiple dimensions of evaluation indicators."
+msgstr "混元最新 MOE 架構 FunctionCall 模型，經過高質量的 FunctionCall 數據訓練，上下文窗口達 32K，在多個維度的評測指標上處於領先。"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:59
+msgid "Hunyuan's latest version of the role-playing model, a role-playing model launched by Hunyuan's official fine-tuning training, is based on the Hunyuan model combined with the role-playing scene data set for additional training, and has better basic effects in role-playing scenes."
+msgstr "混元最新版角色扮演模型，混元官方精調訓練推出的角色扮演模型，基於混元模型結合角色扮演場景數據集進行增訓，在角色扮演場景具有更好的基礎效果"
+
+#: apps/application/serializers/application.py:611
+msgid "Icon"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:19
+#: apps/tools/serializers/tool.py:1379
+msgid "icon"
+msgstr "圖標"
+
+#: no source
+msgid "icon url"
+msgstr "圖標"
+
+#: apps/knowledge/serializers/knowledge.py:1360
+#: apps/knowledge/serializers/knowledge.py:1505
+#: apps/users/api/user.py:76
+msgid "id"
+msgstr "ID"
+
+#: apps/knowledge/serializers/knowledge.py:1280
+#: apps/knowledge/serializers/knowledge.py:1386
+msgid "id does not exist"
+msgstr "知識庫 ID 不存在"
+
+#: apps/knowledge/serializers/common.py:52
+#: apps/knowledge/serializers/document.py:124
+#: apps/knowledge/serializers/document.py:231
+#: apps/knowledge/serializers/document.py:247
+#: apps/trigger/serializers/trigger.py:32
+msgid "id list"
+msgstr "ID 列表"
+
+#: apps/application/serializers/application.py:1754
+msgid "id list cannot be empty"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:114
+msgid "Ideal for content creation, conversational AI, language understanding, R&D, and enterprise applications"
+msgstr "非常適合內容創作、對話式人工智慧、語言理解、研發和企業智能體"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:120
+msgid "Ideal for limited computing power and resources, edge devices, and faster training times."
+msgstr "非常適合有限的計算能力和資源、邊緣設備和更快的訓練時間。"
+
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:17
+msgid "If not passed, the default value is 'zh'"
+msgstr "如果未傳遞，則預設值為'zh'"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:15
+msgid "If not passed, the default value is 16000"
+msgstr "如果未傳入，則預設值為 16000"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:12
+msgid "If not passed, the default value is 16k_zh (Chinese universal)"
+msgstr "如果未傳遞，默認值為 16k_zh（中文通用）"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:13
+msgid "If not passed, the default value is 201 (Japanese anime style)"
+msgstr "如果未傳遞，則默認值為201（日本動漫風格）"
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:19
+msgid "If not passed, the default value is iat"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:24
+msgid "If not passed, the default value is mandarin"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:14
+msgid "If not passed, the default value is streaming_asr_demo"
+msgstr "如果未傳入，則預設值為 streaming_asr_demo"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:13
+msgid "If not passed, the default value is What is this audio saying? Only answer the audio content"
+msgstr "如果未傳遞，預設值為這段音訊在說什麼，只回答音訊的內容"
+
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:14
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:14
+msgid "If not passed, the default value is zh"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:14
+msgid "If not passed, the default value is zh_cn"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:49
+msgid "If not transmitted, the default value is 768:768."
+msgstr "不傳默認使用768:768。"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:16
+msgid "If the gap between width, height and 512 is too large, the picture rendering effect will be poor and the probability of excessive delay will increase significantly. Recommended ratio and corresponding width and height before super score: width*height"
+msgstr "寬、高與512差距過大，則出圖效果不佳、延遲過長概率顯著增加。超分前建議比例及對應寬高：width*height"
+
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:85
+msgid "iFlytek Spark"
+msgstr "訊飛星火"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:23
+msgid "iFlytek Xiaojing"
+msgstr "訊飛小婧"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:22
+msgid "iFlytek Xiaoping"
+msgstr "訊飛小萍"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:20
+msgid "iFlytek Xiaoyan"
+msgstr "訊飛小燕"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:21
+msgid "iFlytek Xujiu"
+msgstr "訊飛許久"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:24
+msgid "iFlytek Xuxiaobao"
+msgstr "訊飛許小寶"
+
+#: apps/application/serializers/application.py:684
+#: apps/application/serializers/application.py:1454
+#: apps/knowledge/serializers/knowledge_workflow.py:381
+#: apps/knowledge/serializers/knowledge_workflow.py:628
+#: apps/tools/serializers/tool.py:496
+#: apps/tools/serializers/tool_workflow.py:362
+msgid "Illegal download callback url"
+msgstr ""
+
+#: apps/application/serializers/application.py:660
+#: apps/application/serializers/application.py:1395
+#: apps/knowledge/serializers/knowledge_workflow.py:367
+#: apps/knowledge/serializers/knowledge_workflow.py:614
+#: apps/tools/serializers/tool.py:481
+#: apps/tools/serializers/tool.py:1319
+#: apps/tools/serializers/tool_workflow.py:346
+msgid "Illegal download url"
+msgstr ""
+
+#: apps/chat/serializers/chat_authentication.py:120
+msgid "Illegal User"
+msgstr "非法用戶"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:25
+msgid "illustration"
+msgstr "插圖"
+
+#: no source
+msgid "Image download failed, check network"
+msgstr "圖片下載失敗，請檢查網絡"
+
+#: apps/models_provider/base_model_provider.py:152
+msgid "Image Generation"
+msgstr "圖片生成"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:15
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:14
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:14
+msgid "Image size"
+msgstr "图片尺寸"
+
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:15
+msgid "Image size, only cogview-3-plus supports this parameter. Optional range: [1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440], the default is 1024x1024."
+msgstr "圖片尺寸，僅 cogview-3-plus 支持該參數。可選範圍：[1024x1024,768x1344,864x1152,1344x768,1152x864,1440x720,720x1440]，默認是1024x1024。"
+
+#: apps/models_provider/base_model_provider.py:156
+msgid "Image to Video"
+msgstr "圖生視頻"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:24
+msgid "impasto style"
+msgstr "厚塗風格"
+
+#: apps/common/constants/permission_constants.py:361
+msgid "Import"
+msgstr "導入"
+
+#: apps/application/views/application.py:115
+#: apps/application/views/application.py:116
+#: apps/application/views/application.py:117
+msgid "Import Application"
+msgstr "導入智能體"
+
+#: no source
+msgid "Import documents to the lark knowledge base"
+msgstr "導入文檔到飛書知識庫"
+
+#: apps/knowledge/views/knowledge.py:448
+#: apps/knowledge/views/knowledge.py:449
+#: apps/knowledge/views/knowledge.py:450
+msgid "Import knowledge bundle"
+msgstr "匯入知識庫"
+
+#: apps/knowledge/views/knowledge_workflow.py:325
+#: apps/knowledge/views/knowledge_workflow.py:326
+#: apps/knowledge/views/knowledge_workflow.py:327
+msgid "Import knowledge workflow"
+msgstr "匯入知識工作流"
+
+#: apps/knowledge/views/document.py:1239
+#: apps/knowledge/views/document.py:1240
+#: apps/knowledge/views/document.py:1241
+msgid "Import QA and create documentation"
+msgstr "導入問答並創建文檔"
+
+#: no source
+msgid "Import QA and create shared documentation"
+msgstr "導入問答並創建文檔"
+
+#: no source
+msgid "Import shared tool"
+msgstr "導入共享工具"
+
+#: apps/knowledge/views/document.py:1281
+#: apps/knowledge/views/document.py:1282
+#: apps/knowledge/views/document.py:1283
+msgid "Import tables and create documents"
+msgstr "導入表格並創建文檔"
+
+#: no source
+msgid "Import tables and create shared documents"
+msgstr "導入表格並創建文檔"
+
+#: apps/tools/views/tool.py:345
+#: apps/tools/views/tool.py:346
+#: apps/tools/views/tool.py:347
 msgid "Import tool"
 msgstr "導入工具"
 
-#: apps/tools/views/tool.py:218 apps/tools/views/tool.py:219
-#: apps/tools/views/tool.py:220
-msgid "Export tool"
-msgstr "導出工具"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:27
+msgid "Impressionism 1 (Monet)"
+msgstr "印象派1（莫奈）"
 
-#: apps/tools/views/tool.py:244 apps/tools/views/tool.py:245
-#: apps/tools/views/tool.py:246
-msgid "Check code"
-msgstr "檢查代碼"
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:28
+msgid "Impressionism 2"
+msgstr "印象派2"
 
-#: apps/tools/views/tool.py:268 apps/tools/views/tool.py:269
-#: apps/tools/views/tool.py:270
-msgid "Edit tool icon"
-msgstr "修改工具圖標"
+#: apps/application/serializers/application_chat.py:173
+msgid "inaccurate"
+msgstr "內容不準確"
 
-#: apps/users/api/user.py:154
-msgid "Email or Username"
-msgstr "郵箱或用戶名"
+#: apps/homepage/api/home_page_api.py:386
+msgid "Inactive model count"
+msgstr "停用模型數量"
+
+#: apps/homepage/api/home_page_api.py:349
+msgid "Inactive tool count"
+msgstr "停用工具數量"
+
+#: apps/application/serializers/application_chat.py:173
+msgid "incomplete"
+msgstr "內容不完善"
+
+#: apps/trigger/serializers/task_source_trigger.py:51
+msgid "Incorrect trigger task"
+msgstr "觸發器任務不正確"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:27
+msgid "Indonesian language"
+msgstr "印尼語"
+
+#: apps/tools/serializers/tool.py:291
+#: apps/tools/serializers/tool.py:307
+#: apps/tools/serializers/tool.py:330
+msgid "init field list"
+msgstr "內置欄位列表"
+
+#: apps/tools/serializers/tool.py:1574
+msgid "Init Field List"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:308
+#: apps/tools/serializers/tool.py:331
+msgid "init params"
+msgstr "內置參數"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:18
+msgid "ink painting"
+msgstr "水墨畫"
+
+#: apps/tools/serializers/tool.py:289
+#: apps/tools/serializers/tool.py:306
+#: apps/tools/serializers/tool.py:329
+msgid "input field list"
+msgstr "輸入欄位列表"
+
+#: apps/tools/serializers/tool.py:1575
+msgid "Input Field List"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:34
+#: apps/tools/serializers/tool.py:275
+msgid "input type"
+msgstr "輸入類型"
+
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:14
+#: apps/application/flow/step_node/variable_splitting_node/i_variable_splitting_node.py:14
+msgid "input variable"
+msgstr ""
+
+#: no source
+msgid "input_field_list must be a dict"
+msgstr "input_field_list 必須是字典類型"
+
+#: apps/maxkb/settings/base/model.py:99
+#: apps/maxkb/settings/base/web.py:116
+msgid "Intelligent customer service platform"
+msgstr "强大易用的企業級智能體平臺"
+
+#: no source
+msgid "Internal role"
+msgstr "內置角色"
+
+#: apps/trigger/serializers/trigger.py:220
+msgid "interval_unit must be one of %s"
+msgstr "interval_unit 必須是以下值之一: %s"
+
+#: apps/trigger/serializers/trigger.py:215
+msgid "interval_value must be an integer greater than or equal to 1"
+msgstr "interval_value 必須是大於或等於 1 的整數"
+
+#: apps/users/serializers/login.py:291
+msgid "Invalid access token"
+msgstr "無效的訪問令牌"
+
+#: apps/chat/serializers/chat_authentication.py:49
+#: apps/chat/serializers/chat_authentication.py:60
+#: apps/chat/serializers/chat_authentication.py:62
+msgid "Invalid access_token"
+msgstr "access_token 無效"
+
+#: apps/application/serializers/application_chat_link.py:79
+msgid "Invalid chat record ids"
+msgstr "無效的聊天記錄ID"
+
+#: apps/trigger/serializers/trigger.py:236
+msgid "Invalid cron expression: %s"
+msgstr "Cron 表達式不合法：%s"
+
+#: apps/users/serializers/login.py:112
+#: apps/users/serializers/user.py:551
+#: apps/users/views/user.py:396
+msgid "Invalid encrypted data"
+msgstr ""
+
+#: no source
+msgid "Invalid json format."
+msgstr "json 格式無效。"
+
+#: no source
+msgid "Invalid license file format"
+msgstr "無效的 license 文件格式"
+
+#: no source
+msgid "Invalid role type"
+msgstr "無效的角色類型"
+
+#: no source
+msgid "Invalid Slack request"
+msgstr "Slack 請求無效"
+
+#: no source
+msgid "Invalid source type"
+msgstr "無效的來源類型"
+
+#: apps/trigger/serializers/trigger.py:162
+msgid "Invalid time format: %s, must be HH:MM (e.g., 09:00)"
+msgstr "時間格式無效: %s，必須是 HH:MM 格式 (例如: 09:00)"
+
+#: apps/application/serializers/application_chat.py:221
+msgid "Ip Address"
+msgstr "IP位址"
+
+#: apps/chat/serializers/chat.py:221
+#: apps/chat/serializers/chat.py:292
+#: apps/chat/serializers/chat.py:537
+msgid "IP Address"
+msgstr ""
+
+#: no source
+msgid "ip_address"
+msgstr "IP 地址"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:43
+#: apps/knowledge/serializers/knowledge.py:772
+#: apps/knowledge/serializers/paragraph.py:76
+#: apps/tools/serializers/tool.py:293
+#: apps/tools/serializers/tool.py:311
+#: apps/trigger/serializers/trigger.py:255
+#: apps/trigger/serializers/trigger.py:277
+#: apps/trigger/serializers/trigger.py:312
+#: apps/trigger/serializers/trigger.py:641
+#: apps/users/serializers/user.py:253
+msgid "Is active"
+msgstr "是否啟用"
+
+#: apps/users/serializers/user.py:408
+msgid "Is Active"
+msgstr "是否啟用"
+
+#: no source
+msgid "Is Append"
+msgstr "是否追加"
+
+#: no source
+msgid "is auth"
+msgstr "是否認證"
+
+#: no source
+msgid "Is auth"
+msgstr "是否授權"
+
+#: apps/application/serializers/application_api_key.py:26
+msgid "Is cross-domain allowed"
+msgstr "是否允許跨域"
+
+#: apps/application/serializers/application_chat.py:39
+msgid "Is delete"
+msgstr "刪除"
+
+#: apps/users/serializers/user.py:56
+msgid "Is Edit Password"
+msgstr "是否編輯密碼"
+
+#: no source
+msgid "Is Exist"
+msgstr "是否存在"
+
+#: apps/application/serializers/application_access_token.py:26
+msgid "Is it enabled"
+msgstr "是否開啟"
+
+#: apps/application/api/application_chat_record.py:53
+#: apps/application/serializers/application_chat_record.py:94
+msgid "Is it in order"
+msgstr "是否有序"
+
+#: apps/application/serializers/application_api_key.py:32
+msgid "Is permanent"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:77
+msgid "Is the answer in streaming mode"
+msgstr "是否流式回答"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:25
+msgid "Is this field required"
+msgstr "{keys} 是必填項"
+
+#: apps/trigger/serializers/trigger.py:33
+msgid "is_active"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:23
+msgid "Japanese"
+msgstr "日語"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:37
+msgid "Japanese animation"
+msgstr "日系動漫"
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:22
+msgid "Japanese male"
+msgstr "日語男"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:14
+msgid "Key"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:341
+#: apps/common/constants/permission_constants.py:354
+#: apps/common/constants/permission_constants.py:412
+#: apps/common/constants/permission_constants.py:422
+#: apps/common/constants/permission_constants.py:435
+#: apps/knowledge/views/knowledge_workflow.py:259
+msgid "Knowledge"
+msgstr "知識庫"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:267
+msgid "knowledge action id"
+msgstr ""
+
+#: apps/knowledge/views/knowledge.py:42
+#: apps/knowledge/views/knowledge.py:71
+#: apps/knowledge/views/knowledge.py:98
+#: apps/knowledge/views/knowledge.py:124
+#: apps/knowledge/views/knowledge.py:149
+#: apps/knowledge/views/knowledge.py:187
+#: apps/knowledge/views/knowledge.py:225
+#: apps/knowledge/views/knowledge.py:255
+#: apps/knowledge/views/knowledge.py:290
+#: apps/knowledge/views/knowledge.py:340
+#: apps/knowledge/views/knowledge.py:367
+#: apps/knowledge/views/knowledge.py:394
+#: apps/knowledge/views/knowledge.py:421
+#: apps/knowledge/views/knowledge.py:454
+#: apps/knowledge/views/knowledge.py:488
+#: apps/knowledge/views/knowledge.py:517
+#: apps/knowledge/views/knowledge.py:575
+#: apps/knowledge/views/knowledge.py:600
+#: apps/knowledge/views/knowledge.py:628
+#: apps/knowledge/views/knowledge_workflow.py:82
+#: apps/knowledge/views/knowledge_workflow.py:116
+#: apps/knowledge/views/knowledge_workflow.py:146
+#: apps/knowledge/views/knowledge_workflow.py:175
+#: apps/knowledge/views/knowledge_workflow.py:204
+#: apps/knowledge/views/knowledge_workflow.py:234
+#: apps/knowledge/views/knowledge_workflow.py:298
+#: apps/knowledge/views/knowledge_workflow.py:331
+#: apps/knowledge/views/knowledge_workflow.py:372
+#: apps/knowledge/views/knowledge_workflow.py:403
+#: apps/knowledge/views/knowledge_workflow.py:433
+#: apps/knowledge/views/knowledge_workflow.py:464
+msgid "Knowledge Base"
+msgstr "知識庫"
+
+#: no source
+msgid "knowledge Base"
+msgstr "知識庫"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:89
+msgid "knowledge base data"
+msgstr ""
+
+#: apps/application/serializers/application.py:231
+#: apps/application/serializers/application_chat_record.py:250
+#: apps/application/serializers/application_chat_record.py:376
+#: apps/application/serializers/application_chat_record.py:476
+msgid "Knowledge base id"
+msgstr "知識庫"
+
+#: apps/application/serializers/application.py:232
+msgid "Knowledge Base List"
+msgstr "知識庫列表"
+
+#: no source
+msgid "Knowledge base name duplicate!"
+msgstr "知識庫名稱重複！"
+
+#: no source
+msgid "Knowledge base not found!"
+msgstr "知識庫未找到！"
+
+#: apps/knowledge/serializers/common.py:125
+#: apps/knowledge/serializers/common.py:161
+msgid "Knowledge base setting error, please reset the knowledge base"
+msgstr "知識庫設置錯誤，請重置知識庫"
+
+#: apps/knowledge/views/document.py:59
+#: apps/knowledge/views/document.py:92
+#: apps/knowledge/views/document.py:132
+#: apps/knowledge/views/document.py:158
+#: apps/knowledge/views/document.py:191
+#: apps/knowledge/views/document.py:230
+#: apps/knowledge/views/document.py:273
+#: apps/knowledge/views/document.py:293
+#: apps/knowledge/views/document.py:331
+#: apps/knowledge/views/document.py:369
+#: apps/knowledge/views/document.py:407
+#: apps/knowledge/views/document.py:444
+#: apps/knowledge/views/document.py:481
+#: apps/knowledge/views/document.py:519
+#: apps/knowledge/views/document.py:559
+#: apps/knowledge/views/document.py:599
+#: apps/knowledge/views/document.py:638
+#: apps/knowledge/views/document.py:677
+#: apps/knowledge/views/document.py:716
+#: apps/knowledge/views/document.py:754
+#: apps/knowledge/views/document.py:845
+#: apps/knowledge/views/document.py:890
+#: apps/knowledge/views/document.py:923
+#: apps/knowledge/views/document.py:956
+#: apps/knowledge/views/document.py:981
+#: apps/knowledge/views/document.py:1014
+#: apps/knowledge/views/document.py:1044
+#: apps/knowledge/views/document.py:1078
+#: apps/knowledge/views/document.py:1159
+#: apps/knowledge/views/document.py:1203
+#: apps/knowledge/views/document.py:1245
+#: apps/knowledge/views/document.py:1287
+#: apps/knowledge/views/document.py:1326
+#: apps/knowledge/views/document.py:1340
+msgid "Knowledge Base/Documentation"
+msgstr "知識庫/文檔"
+
+#: apps/knowledge/views/paragraph.py:29
+#: apps/knowledge/views/paragraph.py:55
+#: apps/knowledge/views/paragraph.py:87
+#: apps/knowledge/views/paragraph.py:110
+#: apps/knowledge/views/paragraph.py:149
+#: apps/knowledge/views/paragraph.py:181
+#: apps/knowledge/views/paragraph.py:216
+#: apps/knowledge/views/paragraph.py:244
+#: apps/knowledge/views/paragraph.py:282
+#: apps/knowledge/views/paragraph.py:315
+#: apps/knowledge/views/paragraph.py:345
+#: apps/knowledge/views/paragraph.py:383
+#: apps/knowledge/views/paragraph.py:420
+#: apps/knowledge/views/paragraph.py:452
+msgid "Knowledge Base/Documentation/Paragraph"
+msgstr "知識庫/文檔/段落"
+
+#: apps/knowledge/views/problem.py:28
+#: apps/knowledge/views/problem.py:56
+#: apps/knowledge/views/problem.py:84
+#: apps/knowledge/views/problem.py:113
+#: apps/knowledge/views/problem.py:143
+#: apps/knowledge/views/problem.py:172
+#: apps/knowledge/views/problem.py:204
+#: apps/knowledge/views/problem.py:237
+msgid "Knowledge Base/Documentation/Paragraph/Question"
+msgstr "知識庫/文檔/段落/問題"
+
+#: apps/knowledge/views/termbase.py:33
+#: apps/knowledge/views/termbase.py:64
+#: apps/knowledge/views/termbase.py:99
+#: apps/knowledge/views/termbase.py:134
+#: apps/knowledge/views/termbase.py:168
+#: apps/knowledge/views/termbase.py:205
+#: apps/knowledge/views/termbase.py:243
+msgid "Knowledge Base/Documentation/Termbase"
+msgstr ""
+
+#: apps/knowledge/views/document.py:1119
+#: apps/knowledge/views/tag.py:25
+#: apps/knowledge/views/tag.py:49
+#: apps/knowledge/views/tag.py:78
+#: apps/knowledge/views/tag.py:105
+#: apps/knowledge/views/tag.py:132
+msgid "Knowledge Base/Tag"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:280
+#: apps/homepage/views/homepage.py:281
+msgid "Knowledge data aggregation"
+msgstr "知識庫資料彙總"
+
+#: apps/knowledge/serializers/knowledge.py:111
+#: apps/knowledge/serializers/knowledge.py:122
+#: apps/knowledge/serializers/knowledge.py:130
+#: apps/knowledge/serializers/knowledge.py:182
+msgid "knowledge description"
+msgstr "知識庫描述"
+
+#: apps/knowledge/task/embedding.py:121
+msgid "Knowledge documentation: {document_names}"
+msgstr "知識庫文檔: {document_names}"
+
+#: no source
+msgid "Knowledge does not exist"
+msgstr "知識庫不存在"
+
+#: apps/knowledge/serializers/knowledge.py:112
+#: apps/knowledge/serializers/knowledge.py:123
+msgid "knowledge embedding"
+msgstr "知識庫向量"
+
+#: apps/application/api/application_chat_record.py:129
+#: apps/knowledge/serializers/knowledge.py:1472
+#: apps/knowledge/serializers/knowledge_version.py:45
+#: apps/knowledge/serializers/knowledge_version.py:82
+#: apps/knowledge/serializers/tag.py:47
+#: apps/knowledge/serializers/tag.py:94
+#: apps/knowledge/serializers/tag.py:168
+#: apps/knowledge/serializers/tag.py:202
+msgid "Knowledge ID"
+msgstr "知識庫 ID"
+
+#: apps/knowledge/serializers/document.py:355
+#: apps/knowledge/serializers/document.py:473
+#: apps/knowledge/serializers/document.py:587
+#: apps/knowledge/serializers/document.py:686
+#: apps/knowledge/serializers/document.py:1207
+#: apps/knowledge/serializers/document.py:1293
+#: apps/knowledge/serializers/document.py:1315
+#: apps/knowledge/serializers/document.py:1652
+#: apps/knowledge/serializers/document.py:1698
+#: apps/knowledge/serializers/document.py:1773
+#: apps/knowledge/serializers/document.py:1814
+#: apps/knowledge/serializers/document.py:1843
+#: apps/knowledge/serializers/document.py:1879
+#: apps/knowledge/serializers/knowledge.py:316
+#: apps/knowledge/serializers/knowledge.py:1256
+#: apps/knowledge/serializers/knowledge_workflow.py:114
+#: apps/knowledge/serializers/knowledge_workflow.py:266
+#: apps/knowledge/serializers/knowledge_workflow.py:391
+#: apps/knowledge/serializers/knowledge_workflow.py:518
+#: apps/knowledge/serializers/knowledge_workflow.py:568
+#: apps/knowledge/serializers/knowledge_workflow.py:646
+#: apps/knowledge/serializers/paragraph.py:108
+#: apps/knowledge/serializers/paragraph.py:204
+#: apps/knowledge/serializers/paragraph.py:339
+#: apps/knowledge/serializers/paragraph.py:437
+#: apps/knowledge/serializers/paragraph.py:473
+#: apps/knowledge/serializers/paragraph.py:553
+#: apps/knowledge/serializers/paragraph.py:602
+#: apps/knowledge/serializers/paragraph.py:779
+#: apps/knowledge/serializers/problem.py:64
+#: apps/knowledge/serializers/problem.py:138
+#: apps/knowledge/serializers/problem.py:198
+#: apps/knowledge/serializers/problem.py:235
+#: apps/knowledge/serializers/termbase.py:36
+#: apps/knowledge/serializers/termbase.py:66
+#: apps/knowledge/serializers/termbase.py:104
+#: apps/knowledge/serializers/termbase.py:140
+msgid "knowledge id"
+msgstr "知識庫 ID"
+
+#: no source
+msgid "Knowledge id"
+msgstr "知識庫 ID"
+
+#: apps/application/serializers/application_chat_record.py:396
+#: apps/knowledge/serializers/document.py:368
+#: apps/knowledge/serializers/document.py:373
+#: apps/knowledge/serializers/document.py:597
+#: apps/knowledge/serializers/document.py:695
+#: apps/knowledge/serializers/document.py:1216
+#: apps/knowledge/serializers/document.py:1325
+#: apps/knowledge/serializers/document.py:1661
+#: apps/knowledge/serializers/document.py:1709
+#: apps/knowledge/serializers/document.py:1786
+#: apps/knowledge/serializers/document.py:1827
+#: apps/knowledge/serializers/document.py:1853
+#: apps/knowledge/serializers/document.py:1890
+#: apps/knowledge/serializers/knowledge.py:333
+#: apps/knowledge/serializers/knowledge.py:1277
+#: apps/knowledge/serializers/knowledge.py:1384
+#: apps/knowledge/serializers/knowledge_version.py:92
+#: apps/knowledge/serializers/knowledge_workflow.py:657
+#: apps/knowledge/serializers/paragraph.py:119
+#: apps/knowledge/serializers/paragraph.py:215
+#: apps/knowledge/serializers/paragraph.py:449
+#: apps/knowledge/serializers/paragraph.py:488
+#: apps/knowledge/serializers/paragraph.py:563
+#: apps/knowledge/serializers/paragraph.py:619
+#: apps/knowledge/serializers/paragraph.py:790
+#: apps/knowledge/serializers/problem.py:73
+#: apps/knowledge/serializers/problem.py:148
+#: apps/knowledge/serializers/problem.py:207
+#: apps/knowledge/serializers/problem.py:245
+#: apps/knowledge/serializers/tag.py:57
+#: apps/knowledge/serializers/tag.py:104
+#: apps/knowledge/serializers/tag.py:178
+#: apps/knowledge/serializers/tag.py:212
+#: apps/knowledge/serializers/termbase.py:45
+#: apps/knowledge/serializers/termbase.py:76
+#: apps/knowledge/serializers/termbase.py:113
+#: apps/knowledge/serializers/termbase.py:150
+msgid "Knowledge id does not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:14
+msgid "knowledge id list"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1008
+msgid "knowledge id not exist"
+msgstr "知識庫 ID 不存在"
+
+#: apps/knowledge/serializers/common.py:249
+#: apps/knowledge/serializers/common.py:274
+msgid "Knowledge ID or Document ID must be provided"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1505
+msgid "knowledge ids"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1486
+msgid "Knowledge is already a workflow"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:109
+#: apps/knowledge/serializers/knowledge.py:120
+#: apps/knowledge/serializers/knowledge.py:129
+#: apps/knowledge/serializers/knowledge.py:178
+msgid "knowledge name"
+msgstr "知識庫名稱"
+
+#: apps/knowledge/serializers/knowledge.py:1484
+msgid "Knowledge not found"
+msgstr ""
+
+#: no source
+msgid "Knowledge Resource"
+msgstr "知識庫資源"
+
+#: apps/knowledge/serializers/knowledge.py:189
+msgid "knowledge scope"
+msgstr "知識庫範圍"
+
+#: apps/knowledge/serializers/knowledge.py:125
+msgid "knowledge selector"
+msgstr "知識庫選擇器"
+
+#: apps/knowledge/serializers/knowledge_version.py:83
+msgid "Knowledge version ID"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:110
+#: apps/knowledge/views/knowledge_workflow.py:111
+#: apps/knowledge/views/knowledge_workflow.py:112
+msgid "Knowledge workflow debug"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow.py:76
+#: apps/knowledge/views/knowledge_workflow.py:77
+#: apps/knowledge/views/knowledge_workflow.py:78
+msgid "Knowledge workflow upload document"
+msgstr ""
+
+#: apps/knowledge/views/knowledge_workflow_version.py:45
+#: apps/knowledge/views/knowledge_workflow_version.py:69
+#: apps/knowledge/views/knowledge_workflow_version.py:94
+#: apps/knowledge/views/knowledge_workflow_version.py:116
+msgid "Knowledge/Version"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:24
+msgid "Korean"
+msgstr "韓語"
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:26
+msgid "Korean female"
+msgstr "韓語女"
+
+#: apps/models_provider/api/provide.py:35
+msgid "label"
+msgstr "標籤"
+
+#: apps/application/serializers/application_access_token.py:40
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:14
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:14
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:16
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:14
+#: apps/users/serializers/user.py:1188
+msgid "language"
+msgstr "語言"
 
 #: apps/users/api/user.py:224
 msgid "Language"
 msgstr "語言"
 
-#: apps/users/serializers/login.py:29 apps/users/serializers/login.py:69
-msgid "captcha"
-msgstr "驗證碼"
-
-#: apps/users/serializers/login.py:50
-#: apps/xpack/serializers/chat_user_serializer.py:120
-msgid "Captcha code error or expiration"
-msgstr "驗證碼錯誤或過期"
-
-#: apps/users/serializers/login.py:55
-#: apps/xpack/serializers/auth_config_serializer.py:192
-#: apps/xpack/serializers/chat_user_serializer.py:125
-#: apps/xpack/serializers/qr_login/qr_login.py:37
-msgid "The user has been disabled, please contact the administrator!"
-msgstr "用戶已被禁用，請聯繫管理員！"
-
-#: apps/users/serializers/user.py:47
-msgid "Is Edit Password"
-msgstr "是否編輯密碼"
-
-#: apps/users/serializers/user.py:48
-msgid "permissions"
-msgstr "無權限訪問"
-
-#: apps/users/serializers/user.py:58 apps/users/serializers/user.py:106
-#: apps/users/serializers/user.py:250 apps/users/serializers/user.py:557
-#: apps/users/serializers/user.py:641 apps/xpack/api/chat_user.py:107
-#: apps/xpack/serializers/chat_user.py:54
-#: apps/xpack/serializers/chat_user.py:227
-msgid "Email"
-msgstr "郵箱"
-
-#: apps/users/serializers/user.py:59 apps/users/serializers/user.py:140
-#: apps/xpack/serializers/chat_user.py:88
-msgid "Nick name"
-msgstr "暱稱"
-
-#: apps/users/serializers/user.py:60 apps/users/serializers/user.py:145
-#: apps/users/serializers/user.py:263 apps/xpack/api/chat_user.py:108
-#: apps/xpack/serializers/chat_user.py:93
-#: apps/xpack/serializers/chat_user.py:240
-msgid "Phone"
-msgstr "手機"
-
-#: apps/users/serializers/user.py:120 apps/xpack/serializers/chat_user.py:68
-msgid "Username must be 4-64 characters long"
-msgstr "用戶名必須為4-64個字符"
-
-#: apps/users/serializers/user.py:133 apps/users/serializers/user.py:298
-#: apps/xpack/serializers/chat_user.py:81
-#: apps/xpack/serializers/chat_user.py:274
-msgid ""
-"The password must be 6-20 characters long and must be a combination of "
-"letters, numbers, and special characters."
-msgstr "密碼必須為6-20個字符，且必須包含大小写字母、數字和特殊字符。"
-
-#: apps/users/serializers/user.py:170
-msgid "Email or username"
-msgstr "郵箱或用戶名"
-
-#: apps/users/serializers/user.py:226
-msgid ""
-"The community version supports up to 2 users. If you need more users, please "
-"contact us (https://fit2cloud.com/)."
-msgstr ""
-"社區版支持最多2個用戶，如需更多用戶，請聯繫我們（https://fit2cloud.com/）。"
-
-#: apps/users/serializers/user.py:270 apps/xpack/api/auth_config.py:31
-#: apps/xpack/api/chat_user.py:109 apps/xpack/serializers/chat_user.py:247
-msgid "Is Active"
-msgstr "是否啟用"
-
-#: apps/users/serializers/user.py:281 apps/xpack/serializers/chat_user.py:262
-msgid "Nickname is already in use"
-msgstr "Nickname已被使用"
-
-#: apps/users/serializers/user.py:286
-msgid "Email is already in use"
-msgstr "郵箱已被使用"
-
-#: apps/users/serializers/user.py:305 apps/xpack/serializers/chat_user.py:281
-msgid "Re Password"
-msgstr "確認密碼"
-
-#: apps/users/serializers/user.py:310 apps/users/serializers/user.py:522
-#: apps/users/serializers/user.py:529 apps/xpack/serializers/chat_user.py:286
-#: apps/xpack/serializers/chat_user.py:606
-#: apps/xpack/serializers/chat_user.py:613
-msgid ""
-"The confirmation password must be 6-20 characters long and must be a "
-"combination of letters, numbers, and special characters."
-msgstr "確認密碼必須為6-20個字符，且必須包含字母、數字和特殊字符。"
-
-#: apps/users/serializers/user.py:333 apps/xpack/serializers/chat_user.py:309
-msgid "User does not exist"
-msgstr "用戶不存在"
-
-#: apps/users/serializers/user.py:348
-msgid "Unable to delete administrator"
-msgstr "無法刪除管理員"
-
-#: apps/users/serializers/user.py:366
-msgid "Cannot modify administrator status"
-msgstr "不能修改管理員狀態"
-
-#: apps/users/serializers/user.py:478 apps/xpack/serializers/chat_user.py:164
-#: apps/xpack/serializers/chat_user.py:192
-#: apps/xpack/serializers/chat_user.py:512
-msgid "User IDs cannot be empty"
-msgstr "用戶 ID 不能為空"
-
-#: apps/users/serializers/user.py:524 apps/xpack/serializers/chat_user.py:608
-msgid "Confirm Password"
-msgstr "確認密碼"
-
-#: apps/users/serializers/user.py:561 apps/users/serializers/user.py:647
-#: apps/xpack/api/knowledge_lark.py:26
-msgid "Type"
-msgstr "類型"
-
-#: apps/users/serializers/user.py:563 apps/users/serializers/user.py:651
-msgid "The type only supports register|reset_password"
-msgstr "類型僅支持 register|reset_password"
-
-#: apps/users/serializers/user.py:581
-#, python-brace-format
-msgid "Do not send emails again within {seconds} seconds"
-msgstr "不要在 {seconds} 秒內再次發送郵件"
-
-#: apps/users/serializers/user.py:611
-msgid ""
-"The email service has not been set up. Please contact the administrator to "
-"set up the email service in [Email Settings]."
-msgstr "郵箱服務尚未設置，請聯繫管理員在 [郵箱設置] 中設置郵箱服務。"
-
-#: apps/users/serializers/user.py:622
-#, python-brace-format
-msgid "【Intelligent knowledge base question and answer system-{action}】"
-msgstr "【智能知識庫問答系統-{action}】"
-
-#: apps/users/serializers/user.py:623
-msgid "User registration"
-msgstr "用戶註冊"
-
-#: apps/users/serializers/user.py:623 apps/users/views/user.py:248
-#: apps/users/views/user.py:249 apps/users/views/user.py:250
-#: apps/users/views/user.py:283 apps/users/views/user.py:284
-#: apps/users/views/user.py:285
-msgid "Change password"
-msgstr "修改密碼"
-
-#: apps/users/serializers/user.py:644
-msgid "Verification code"
-msgstr "驗證碼"
-
-#: apps/users/serializers/user.py:672
+#: apps/users/serializers/user.py:1198
 msgid "language only support:"
 msgstr "語言僅支持："
 
-#: apps/users/views/login.py:38 apps/users/views/login.py:39
-#: apps/users/views/login.py:40 apps/xpack/views/chat_user_auth.py:184
-#: apps/xpack/views/chat_user_auth.py:185
-#: apps/xpack/views/chat_user_auth.py:186
-msgid "Log in"
-msgstr "登錄"
-
-#: apps/users/views/login.py:55 apps/users/views/login.py:56
-#: apps/users/views/login.py:57 apps/xpack/views/chat_user_auth.py:203
-#: apps/xpack/views/chat_user_auth.py:204
-#: apps/xpack/views/chat_user_auth.py:205
-msgid "Sign out"
-msgstr "登出"
-
-#: apps/users/views/user.py:60 apps/users/views/user.py:61
-#: apps/users/views/user.py:62 apps/users/views/user.py:74
-#: apps/users/views/user.py:75 apps/xpack/views/system_chat_user.py:359
-#: apps/xpack/views/system_chat_user.py:360
-#: apps/xpack/views/system_chat_user.py:361
-msgid "Get current user information"
-msgstr "獲取當前用戶信息"
-
-#: apps/users/views/user.py:120 apps/users/views/user.py:121
-#: apps/users/views/user.py:122
-msgid "Get all user"
-msgstr "獲取所有用戶"
-
-#: apps/users/views/user.py:133 apps/users/views/user.py:134
-#: apps/users/views/user.py:135
-msgid "Get user list under workspace"
-msgstr "獲取工作空間下用戶列表"
-
-#: apps/users/views/user.py:147 apps/users/views/user.py:148
-#: apps/users/views/user.py:149
-msgid "Get user member under workspace"
-msgstr "獲取工作空間下用戶成員"
-
-#: apps/users/views/user.py:161 apps/users/views/user.py:162
-#: apps/users/views/user.py:163
-msgid "Create user"
-msgstr "創建用戶"
-
-#: apps/users/views/user.py:177 apps/users/views/user.py:178
-#: apps/users/views/user.py:179
-msgid "Get default password"
-msgstr "獲取默認密碼"
-
-#: apps/users/views/user.py:190 apps/users/views/user.py:191
-#: apps/users/views/user.py:192
-msgid "Delete user"
-msgstr "刪除用戶"
-
-#: apps/users/views/user.py:203 apps/users/views/user.py:204
-#: apps/users/views/user.py:205
-msgid "Get user information"
-msgstr "獲取用戶信息"
-
-#: apps/users/views/user.py:214 apps/users/views/user.py:215
-#: apps/users/views/user.py:216
-msgid "Update user information"
-msgstr "更新當前用戶信息"
-
-#: apps/users/views/user.py:232 apps/users/views/user.py:233
-#: apps/users/views/user.py:234
-msgid "Batch delete user"
-msgstr "批量刪除用戶"
-
-#: apps/users/views/user.py:266 apps/users/views/user.py:267
-#: apps/users/views/user.py:268 apps/workspace/views/workspace_chat_user.py:168
-#: apps/workspace/views/workspace_chat_user.py:169
-#: apps/workspace/views/workspace_chat_user.py:170
-#: apps/xpack/views/system_chat_user.py:197
-#: apps/xpack/views/system_chat_user.py:198
-#: apps/xpack/views/system_chat_user.py:199
-msgid "Get user paginated list"
-msgstr "獲取用戶分頁列表"
-
-#: apps/users/views/user.py:300 apps/users/views/user.py:301
-#: apps/users/views/user.py:302
-msgid "Send email"
-msgstr "發送郵件"
-
-#: apps/users/views/user.py:318 apps/users/views/user.py:319
-#: apps/users/views/user.py:320
-msgid "Check whether the verification code is correct"
-msgstr "檢查驗證碼是否正確"
-
-#: apps/users/views/user.py:335 apps/users/views/user.py:336
-#: apps/users/views/user.py:337
-msgid "Send email to current user"
-msgstr "發送郵件給當前用戶"
-
-#: apps/users/views/user.py:353 apps/users/views/user.py:354
-#: apps/users/views/user.py:355 apps/xpack/views/system_chat_user.py:336
-#: apps/xpack/views/system_chat_user.py:337
-#: apps/xpack/views/system_chat_user.py:338
-msgid "Modify current user password"
-msgstr "修改當前用戶密碼"
-
-#: apps/users/views/user.py:368 apps/xpack/views/system_chat_user.py:352
-msgid "Failed to change password"
-msgstr "修改密碼失敗"
-
-#: apps/workspace/api/workspace.py:73
-#: apps/workspace/serializers/workspace_serializers.py:213
-msgid "User Relation ID"
-msgstr "用戶關係 ID"
-
-#: apps/workspace/api/workspace.py:87
-msgid "Role Name"
-msgstr "角色名稱"
-
-#: apps/workspace/serializers/workspace_serializers.py:42
-#: apps/workspace/serializers/workspace_serializers.py:95
-#: apps/workspace/serializers/workspace_serializers.py:110
-#: apps/workspace/serializers/workspace_serializers.py:177
-#: apps/workspace/serializers/workspace_serializers.py:219
-#: apps/workspace/serializers/workspace_serializers.py:246
-msgid "Workspace does not exist"
-msgstr "工作空間不存在"
-
-#: apps/workspace/serializers/workspace_serializers.py:49
-msgid "Workspace name already exists"
-msgstr "工作空間名稱已存在"
-
-#: apps/workspace/serializers/workspace_serializers.py:97
-#: apps/workspace/serializers/workspace_serializers.py:112
-msgid "Default workspace cannot be deleted"
-msgstr "默認工作空間不能被刪除"
-
-#: apps/workspace/serializers/workspace_serializers.py:122
-msgid "Applications Resource"
-msgstr "智能體資源"
-
-#: apps/workspace/serializers/workspace_serializers.py:124
-msgid "Knowledge Resource"
-msgstr "知識庫資源"
-
-#: apps/workspace/serializers/workspace_serializers.py:130
-msgid "This workspace contains %s, cannot be deleted."
-msgstr "此工作空間包含 %s，不能被刪除。"
-
-#: apps/workspace/serializers/workspace_serializers.py:166
-msgid "Role IDs"
-msgstr "角色 IDs"
-
-#: apps/workspace/views/workspace.py:32 apps/workspace/views/workspace.py:33
-#: apps/workspace/views/workspace.py:34
-msgid "Create or update workspace"
-msgstr "創建或更新工作空間"
-
-#: apps/workspace/views/workspace.py:45 apps/workspace/views/workspace.py:46
-#: apps/workspace/views/workspace.py:47
-msgid "Get system workspace list"
-msgstr "獲取系統工作空間列表"
-
-#: apps/workspace/views/workspace.py:58 apps/workspace/views/workspace.py:59
-#: apps/workspace/views/workspace.py:60
-msgid "Delete workspace"
-msgstr "刪除工作空間"
-
-#: apps/workspace/views/workspace.py:75 apps/workspace/views/workspace.py:76
-#: apps/workspace/views/workspace.py:77
-msgid "Check workspace can it be deleted"
-msgstr "檢查工作空間是否可以被刪除"
-
-#: apps/workspace/views/workspace.py:95 apps/workspace/views/workspace.py:96
-#: apps/workspace/views/workspace.py:97
-msgid "Add member to system workspace"
-msgstr "系統工作空間添加成員"
-
-#: apps/workspace/views/workspace.py:114 apps/workspace/views/workspace.py:115
-#: apps/workspace/views/workspace.py:116
-msgid "Remove member from system workspace"
-msgstr "系統工作空間移除成員"
-
-#: apps/workspace/views/workspace.py:133 apps/workspace/views/workspace.py:134
-#: apps/workspace/views/workspace.py:135
-msgid "Get system workspace member list"
-msgstr "獲取系統工作空間成員列表"
-
-#: apps/workspace/views/workspace.py:151 apps/workspace/views/workspace.py:152
-#: apps/workspace/views/workspace.py:153
-msgid "Get workspace list"
-msgstr "獲取工作空間列表"
-
-#: apps/workspace/views/workspace.py:164 apps/workspace/views/workspace.py:165
-#: apps/workspace/views/workspace.py:166
-msgid "Add member to workspace"
-msgstr "工作空間添加成員"
-
-#: apps/workspace/views/workspace.py:183 apps/workspace/views/workspace.py:184
-#: apps/workspace/views/workspace.py:185
-msgid "Remove member from workspace"
-msgstr "工作空間移除成員"
-
-#: apps/workspace/views/workspace.py:202 apps/workspace/views/workspace.py:203
-#: apps/workspace/views/workspace.py:204
-msgid "Get workspace member list"
-msgstr "獲取工作空間成員列表"
-
-#: apps/workspace/views/workspace.py:219 apps/workspace/views/workspace.py:220
-#: apps/workspace/views/workspace.py:221
-msgid "Get workspace list by current user"
-msgstr "獲取當前用戶工作空間列表"
-
-#: apps/workspace/views/workspace.py:232 apps/workspace/views/workspace.py:233
-#: apps/workspace/views/workspace.py:234
-msgid "Get workspace list by user"
-msgstr "根據用戶獲取工作空間列表"
-
-#: apps/workspace/views/workspace.py:246 apps/workspace/views/workspace.py:247
-#: apps/workspace/views/workspace.py:248
-msgid "Get current user role list"
-msgstr "獲取當前用戶角色列表"
-
-#: apps/workspace/views/workspace_chat_user.py:44
-#: apps/workspace/views/workspace_chat_user.py:45
-#: apps/workspace/views/workspace_chat_user.py:46
-#: apps/workspace/views/workspace_chat_user.py:51
-#: apps/xpack/views/system_chat_user.py:57
-#: apps/xpack/views/system_chat_user.py:58
-#: apps/xpack/views/system_chat_user.py:59
-msgid "Create chat user"
-msgstr "創建對話用戶"
-
-#: apps/workspace/views/workspace_chat_user.py:47
-#: apps/workspace/views/workspace_chat_user.py:51
-#: apps/workspace/views/workspace_chat_user.py:63
-#: apps/workspace/views/workspace_chat_user.py:67
-#: apps/workspace/views/workspace_chat_user.py:76
-#: apps/workspace/views/workspace_chat_user.py:87
-#: apps/workspace/views/workspace_chat_user.py:92
-#: apps/workspace/views/workspace_chat_user.py:105
-#: apps/workspace/views/workspace_chat_user.py:120
-#: apps/workspace/views/workspace_chat_user.py:124
-#: apps/workspace/views/workspace_chat_user.py:136
-#: apps/workspace/views/workspace_chat_user.py:140
-#: apps/workspace/views/workspace_chat_user.py:152
-#: apps/workspace/views/workspace_chat_user.py:171
-msgid "Workspace/Chat user"
-msgstr "工作空間/對話用戶"
-
-#: apps/workspace/views/workspace_chat_user.py:60
-#: apps/workspace/views/workspace_chat_user.py:61
-#: apps/workspace/views/workspace_chat_user.py:62
-#: apps/workspace/views/workspace_chat_user.py:67
-#: apps/xpack/views/system_chat_user.py:86
-#: apps/xpack/views/system_chat_user.py:87
-#: apps/xpack/views/system_chat_user.py:88
-msgid "Delete chat user"
-msgstr "刪除對話用戶"
-
-#: apps/workspace/views/workspace_chat_user.py:73
-#: apps/workspace/views/workspace_chat_user.py:74
-#: apps/workspace/views/workspace_chat_user.py:75
-#: apps/xpack/views/system_chat_user.py:99
-#: apps/xpack/views/system_chat_user.py:100
-#: apps/xpack/views/system_chat_user.py:101
-msgid "Get chat user information"
-msgstr "獲取對話用戶信息"
-
-#: apps/workspace/views/workspace_chat_user.py:84
-#: apps/workspace/views/workspace_chat_user.py:85
-#: apps/workspace/views/workspace_chat_user.py:86
-#: apps/workspace/views/workspace_chat_user.py:92
-#: apps/xpack/views/system_chat_user.py:110
-#: apps/xpack/views/system_chat_user.py:111
-#: apps/xpack/views/system_chat_user.py:112
-msgid "Update chat user information"
-msgstr "更新對話用戶信息"
-
-#: apps/workspace/views/workspace_chat_user.py:102
-#: apps/workspace/views/workspace_chat_user.py:103
-#: apps/workspace/views/workspace_chat_user.py:104
-#: apps/workspace/views/workspace_chat_user.py:261
-#: apps/workspace/views/workspace_chat_user.py:262
-#: apps/workspace/views/workspace_chat_user.py:263
-#: apps/xpack/views/system_chat_user.py:128
-#: apps/xpack/views/system_chat_user.py:129
-#: apps/xpack/views/system_chat_user.py:130
-#: apps/xpack/views/system_chat_user.py:318
-#: apps/xpack/views/system_chat_user.py:319
-#: apps/xpack/views/system_chat_user.py:320
-msgid "Get user list by group"
-msgstr "獲取用戶組列表"
-
-#: apps/workspace/views/workspace_chat_user.py:117
-#: apps/workspace/views/workspace_chat_user.py:118
-#: apps/workspace/views/workspace_chat_user.py:119
-#: apps/workspace/views/workspace_chat_user.py:124
-#: apps/xpack/views/system_chat_user.py:143
-#: apps/xpack/views/system_chat_user.py:144
-#: apps/xpack/views/system_chat_user.py:145
-msgid "Batch delete chat user"
-msgstr "批量刪除對話用戶"
-
-#: apps/workspace/views/workspace_chat_user.py:133
-#: apps/workspace/views/workspace_chat_user.py:134
-#: apps/workspace/views/workspace_chat_user.py:135
-#: apps/workspace/views/workspace_chat_user.py:140
-#: apps/xpack/views/system_chat_user.py:160
-#: apps/xpack/views/system_chat_user.py:161
-#: apps/xpack/views/system_chat_user.py:162
-msgid "Batch add chat user to group"
-msgstr "批量添加對話用戶到用戶組"
-
-#: apps/workspace/views/workspace_chat_user.py:149
-#: apps/workspace/views/workspace_chat_user.py:150
-#: apps/workspace/views/workspace_chat_user.py:151
-#: apps/xpack/views/system_chat_user.py:177
-#: apps/xpack/views/system_chat_user.py:178
-#: apps/xpack/views/system_chat_user.py:179
-msgid "Change chat user password"
-msgstr "修改對話用戶密碼"
-
-#: apps/workspace/views/workspace_chat_user.py:186
-#: apps/workspace/views/workspace_chat_user.py:187
-#: apps/workspace/views/workspace_chat_user.py:188
-#: apps/xpack/views/system_chat_user.py:230
-#: apps/xpack/views/system_chat_user.py:231
-#: apps/xpack/views/system_chat_user.py:232
-msgid "Create or update Chat User Group"
-msgstr "創建或更新對話用戶組"
-
-#: apps/workspace/views/workspace_chat_user.py:191
-#: apps/workspace/views/workspace_chat_user.py:202
-#: apps/workspace/views/workspace_chat_user.py:216
-#: apps/workspace/views/workspace_chat_user.py:232
-#: apps/workspace/views/workspace_chat_user.py:249
-#: apps/workspace/views/workspace_chat_user.py:264
-msgid "Workspace/User Group"
-msgstr "工作空間/用戶組"
-
-#: apps/workspace/views/workspace_chat_user.py:198
-#: apps/workspace/views/workspace_chat_user.py:199
-#: apps/workspace/views/workspace_chat_user.py:200
-#: apps/xpack/views/system_chat_user.py:243
-#: apps/xpack/views/system_chat_user.py:244
-#: apps/xpack/views/system_chat_user.py:245
-msgid "Get user group list"
-msgstr "獲取用戶組列表"
-
-#: apps/workspace/views/workspace_chat_user.py:211
-#: apps/workspace/views/workspace_chat_user.py:212
-#: apps/workspace/views/workspace_chat_user.py:213
-#: apps/xpack/views/system_chat_user.py:256
-#: apps/xpack/views/system_chat_user.py:257
-#: apps/xpack/views/system_chat_user.py:258
-msgid "Delete chat user group"
-msgstr "刪除對話用戶組"
-
-#: apps/workspace/views/workspace_chat_user.py:226
-#: apps/workspace/views/workspace_chat_user.py:227
-#: apps/workspace/views/workspace_chat_user.py:228
-#: apps/xpack/views/system_chat_user.py:273
-#: apps/xpack/views/system_chat_user.py:274
-#: apps/xpack/views/system_chat_user.py:275
-msgid "Add member to chat user group"
-msgstr "添加成員到對話用戶組"
-
-#: apps/workspace/views/workspace_chat_user.py:243
-#: apps/workspace/views/workspace_chat_user.py:244
-#: apps/workspace/views/workspace_chat_user.py:245
-#: apps/xpack/views/system_chat_user.py:295
-#: apps/xpack/views/system_chat_user.py:296
-#: apps/xpack/views/system_chat_user.py:297
-msgid "Remove member from chat user group"
-msgstr "從對話用戶組移除成員"
-
-#: apps/xpack/api/auth_config.py:29
-msgid "Auth Type"
-msgstr "認證類型"
-
-#: apps/xpack/api/auth_config.py:30
-msgid "Config"
-msgstr "配置"
-
-#: apps/xpack/api/auth_config.py:77
-msgid "Corp ID"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:78
-msgid "Agent ID"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:79
-msgid "App Secret"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:80
-msgid "Callback URL"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:84
-msgid "Key"
-msgstr ""
-
-#: apps/xpack/api/auth_config.py:106
-msgid "Access Token"
-msgstr ""
-
-#: apps/xpack/api/chat_user.py:31 apps/xpack/api/chat_user.py:83
-#: apps/xpack/api/chat_user.py:113 apps/xpack/serializers/chat_user.py:101
-#: apps/xpack/serializers/chat_user.py:177
-#: apps/xpack/serializers/chat_user.py:252
-msgid "User Group IDs"
-msgstr "用戶組 IDs"
-
-#: apps/xpack/api/chat_user.py:118
-msgid "User Group Names"
-msgstr "用戶組名稱"
-
-#: apps/xpack/api/chat_user.py:132 apps/xpack/serializers/chat_user.py:120
-#: apps/xpack/serializers/resource_chat_user.py:37
-msgid "Username or Nickname"
-msgstr "用戶名或暱稱"
-
-#: apps/xpack/api/chat_user.py:148 apps/xpack/serializers/chat_user.py:360
-msgid "Sync Type"
-msgstr "同步類型"
-
-#: apps/xpack/api/knowledge_lark.py:25
-msgid "Token"
-msgstr "令牌"
-
-#: apps/xpack/api/knowledge_lark.py:27
-msgid "Is Exist"
-msgstr "是否存在"
-
-#: apps/xpack/api/license.py:13
-msgid "corporation"
-msgstr "公司"
-
-#: apps/xpack/api/license.py:14
-msgid "isv"
-msgstr ""
-
-#: apps/xpack/api/license.py:15
-msgid "expired"
-msgstr "過期時間"
-
-#: apps/xpack/api/license.py:16
-msgid "product"
-msgstr "產品"
-
-#: apps/xpack/api/license.py:17
-msgid "edition"
-msgstr "版本"
-
-#: apps/xpack/api/license.py:18
-msgid "license version"
-msgstr "license 版本"
-
-#: apps/xpack/api/license.py:19
-msgid "count"
-msgstr "數量"
-
-#: apps/xpack/api/license.py:20
-msgid "serial number"
-msgstr "序列號"
-
-#: apps/xpack/api/license.py:21
-msgid "remark"
-msgstr "備註"
-
-#: apps/xpack/api/license.py:26
-msgid "message"
-msgstr "消息"
-
-#: apps/xpack/api/license.py:27
-msgid "license details"
-msgstr "license 詳情"
-
-#: apps/xpack/api/license.py:36
-#: apps/xpack/serializers/license/license_serializers.py:56
-msgid "license file"
-msgstr "license 文件"
-
-#: apps/xpack/api/license.py:37
-msgid "License file is required"
-msgstr "license 文件是必需的"
-
-#: apps/xpack/api/license.py:38
-msgid "Invalid license file format"
-msgstr "無效的 license 文件格式"
-
-#: apps/xpack/api/operate_log.py:12
-#: apps/xpack/serializers/operate_log_serializer.py:57
-msgid "menu"
-msgstr "菜單"
-
-#: apps/xpack/api/operate_log.py:13
-#: apps/xpack/serializers/operate_log_serializer.py:58
-msgid "operate"
-msgstr "操作"
-
-#: apps/xpack/api/operate_log.py:14
-msgid "menu_label"
-msgstr "菜單標籤"
-
-#: apps/xpack/api/operate_log.py:15
-msgid "operate_label"
-msgstr "操作標籤"
-
-#: apps/xpack/api/platform.py:35
-msgid "Platform type"
-msgstr "平臺類型"
-
-#: apps/xpack/api/platform.py:50
-msgid "Platform configuration"
-msgstr "平臺配置"
-
-#: apps/xpack/api/resource_chat_user_group.py:40
-#: apps/xpack/serializers/resource_chat_user.py:25
-#: apps/xpack/serializers/resource_chat_user_group.py:69
-msgid "is auth"
-msgstr "是否認證"
-
-#: apps/xpack/api/user_group.py:31 apps/xpack/api/user_group.py:99
-msgid "User Group ID"
-msgstr "用戶組 ID"
-
-#: apps/xpack/api/user_group.py:54 apps/xpack/serializers/chat_user.py:406
-#: apps/xpack/serializers/chat_user.py:563
-msgid "Group ID"
-msgstr "用戶組 ID"
-
-#: apps/xpack/api/user_group.py:114 apps/xpack/serializers/chat_user.py:541
-msgid "User group relation IDs"
-msgstr "用戶組關係 ID"
-
-#: apps/xpack/serializers/application_setting_serializer.py:19
-msgid "theme color"
-msgstr "主題顏色"
-
-#: apps/xpack/serializers/application_setting_serializer.py:21
-msgid "header font color"
-msgstr "標題字體顏色"
-
-#: apps/xpack/serializers/application_setting_serializer.py:25
-msgid "float location type"
-msgstr "浮動位置類型"
-
-#: apps/xpack/serializers/application_setting_serializer.py:26
-msgid "float location value"
-msgstr "浮動位置值"
-
-#: apps/xpack/serializers/application_setting_serializer.py:30
-msgid "float location x"
-msgstr "浮動位置 X"
-
-#: apps/xpack/serializers/application_setting_serializer.py:31
-msgid "float location y"
-msgstr "浮動位置 Y"
-
-#: apps/xpack/serializers/application_setting_serializer.py:35
-msgid "show source"
-msgstr "顯示來源"
-
-#: apps/xpack/serializers/application_setting_serializer.py:36
-msgid "show exec"
-msgstr "顯示執行"
-
-#: apps/xpack/serializers/application_setting_serializer.py:38
-msgid "show history"
-msgstr "顯示歷史"
-
-#: apps/xpack/serializers/application_setting_serializer.py:39
-msgid "draggable"
-msgstr "是否可拖動"
-
-#: apps/xpack/serializers/application_setting_serializer.py:40
-msgid "show guide"
-msgstr "顯示論壇"
-
-#: apps/xpack/serializers/application_setting_serializer.py:42
-msgid "icon url"
-msgstr "圖標"
-
-#: apps/xpack/serializers/application_setting_serializer.py:43
-msgid "chat background"
-msgstr "聊天背景"
-
-#: apps/xpack/serializers/application_setting_serializer.py:44
-msgid "chat background url"
-msgstr "聊天背景地址"
-
-#: apps/xpack/serializers/application_setting_serializer.py:45
-msgid "avatar"
-msgstr "頭像"
-
-#: apps/xpack/serializers/application_setting_serializer.py:46
-msgid "avatar url"
-msgstr "頭像地址"
-
-#: apps/xpack/serializers/application_setting_serializer.py:47
-msgid "user avatar"
-msgstr "用戶頭像"
-
-#: apps/xpack/serializers/application_setting_serializer.py:48
-msgid "user avatar url"
-msgstr "用戶頭像地址"
-
-#: apps/xpack/serializers/application_setting_serializer.py:49
-msgid "float icon"
-msgstr "浮動圖標"
-
-#: apps/xpack/serializers/application_setting_serializer.py:50
-msgid "float icon url"
-msgstr "浮動圖標地址"
-
-#: apps/xpack/serializers/application_setting_serializer.py:51
-msgid "disclaimer"
-msgstr "免責申明"
-
-#: apps/xpack/serializers/application_setting_serializer.py:52
-msgid "disclaimer value"
-msgstr "免責申明內容"
-
-#: apps/xpack/serializers/application_setting_serializer.py:55
-msgid "show avatar"
-msgstr "顯示頭像"
-
-#: apps/xpack/serializers/application_setting_serializer.py:56
-msgid "show user avatar"
-msgstr "顯示用戶頭像"
-
-#: apps/xpack/serializers/application_setting_serializer.py:124
-msgid "Float location field type error"
-msgstr "浮動位置欄位類型錯誤"
-
-#: apps/xpack/serializers/application_setting_serializer.py:130
-msgid "Custom theme field type error"
-msgstr "自定義主題欄位類型錯誤"
-
-#: apps/xpack/serializers/auth_config_serializer.py:27
-#: apps/xpack/serializers/platform_serializer.py:31
-msgid "App Secret is required"
-msgstr "App Secret 是必填項"
-
-#: apps/xpack/serializers/auth_config_serializer.py:28
-#: apps/xpack/serializers/platform_serializer.py:26
-#: apps/xpack/serializers/platform_serializer.py:34
-#: apps/xpack/serializers/platform_serializer.py:40
-#: apps/xpack/serializers/platform_serializer.py:46
-msgid "Callback URL is required"
-msgstr "Callback URL 是必填項"
-
-#: apps/xpack/serializers/auth_config_serializer.py:32
-#: apps/xpack/serializers/auth_config_serializer.py:41
-msgid "Corp ID is required"
-msgstr "Corp ID 是必填項"
-
-#: apps/xpack/serializers/auth_config_serializer.py:33
-#: apps/xpack/serializers/platform_serializer.py:22
-msgid "Agent ID is required"
-msgstr "Agent ID 是必填項"
-
-#: apps/xpack/serializers/auth_config_serializer.py:37
-#: apps/xpack/serializers/auth_config_serializer.py:42
-msgid "App Key is required"
-msgstr "App Key 是必填項"
-
-#: apps/xpack/serializers/auth_config_serializer.py:53
-msgid "LDAP server cannot be empty"
-msgstr "LDAP server不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:54
-msgid "Base DN cannot be empty"
-msgstr "Base DN不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:55
-msgid "Password cannot be empty"
-msgstr "密碼不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:56
-msgid "OU cannot be empty"
-msgstr "OU不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:57
-msgid "LDAP filter cannot be empty"
-msgstr "LDAP過濾器不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:58
-msgid "LDAP mapping cannot be empty"
-msgstr "LDAP映射不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:62
-msgid "Authorization address cannot be empty"
-msgstr "認證地址不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:63
-msgid "Token address cannot be empty"
-msgstr "令牌地址不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:64
-msgid "User information address cannot be empty"
-msgstr "用戶信息地址不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:65
-msgid "Scope cannot be empty"
-msgstr "範圍不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:66
-msgid "Client ID cannot be empty"
-msgstr "客戶端 ID 不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:67
-msgid "Client secret cannot be empty"
-msgstr "客戶端密鑰不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:68
-msgid "Redirect address cannot be empty"
-msgstr "重定向地址不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:69
-msgid "Field mapping cannot be empty"
-msgstr "欄位映射不能為空"
-
-#: apps/xpack/serializers/auth_config_serializer.py:262
-msgid "Configuration information is wrong and failed to save"
-msgstr "配置信息錯誤，保存失敗"
-
-#: apps/xpack/serializers/auth_config_serializer.py:288
-msgid "Connection failed"
-msgstr "連接失敗"
-
-#: apps/xpack/serializers/auth_config_serializer.py:306
-msgid "Platform does not exist"
-msgstr "平臺不存在"
-
-#: apps/xpack/serializers/auth_config_serializer.py:316
-msgid "Unsupported platform type"
-msgstr "不支持的平臺類型"
-
-#: apps/xpack/serializers/channel/chat_manage.py:100
-msgid "Think: "
-msgstr "思考内容: "
-
-#: apps/xpack/serializers/channel/chat_manage.py:103
-#: apps/xpack/serializers/channel/chat_manage.py:105
-msgid "AI reply: "
-msgstr "AI 回復: "
-
-#: apps/xpack/serializers/channel/chat_manage.py:318
-msgid "Thinking, please wait a moment!"
-msgstr "思考中，請稍等！"
-
-#: apps/xpack/serializers/channel/ding_talk.py:19
-#: apps/xpack/serializers/channel/wechat.py:91
-#: apps/xpack/serializers/channel/wechat.py:132
-#: apps/xpack/serializers/channel/wecom.py:78
-#: apps/xpack/serializers/channel/wecom.py:259
-msgid "The corresponding platform configuration was not found"
-msgstr "未找到對應的平臺配置"
-
-#: apps/xpack/serializers/channel/ding_talk.py:27
-#: apps/xpack/serializers/channel/lark.py:117
-msgid "Currently only text messages are supported"
-msgstr "目前僅支持文本消息"
-
-#: apps/xpack/serializers/channel/ding_talk.py:91
-#: apps/xpack/serializers/channel/wechat.py:163
-#: apps/xpack/serializers/channel/wecom.py:189
-msgid "Image download failed, check network"
-msgstr "圖片下載失敗，請檢查網絡"
-
-#: apps/xpack/serializers/channel/ding_talk.py:92
-#: apps/xpack/serializers/channel/wechat.py:161
-#: apps/xpack/serializers/channel/wecom.py:185
-msgid "Please analyze the content of the image."
-msgstr "請分析圖片內容。"
-
-#: apps/xpack/serializers/channel/ding_talk.py:95
-msgid "DingTalk application: {user}"
-msgstr "釘釘智能體: {user}"
-
-#: apps/xpack/serializers/channel/ding_talk.py:106
-#: apps/xpack/serializers/channel/ding_talk.py:151
-msgid "Content generated by AI"
-msgstr "AI 生成的內容"
-
-#: apps/xpack/serializers/channel/lark.py:92
-msgid "Lark application: "
-msgstr "飛書智能體: "
-
-#: apps/xpack/serializers/channel/slack.py:116
-msgid "The corresponding platform configuration for Slack was not found"
-msgstr "Slack 的對應平臺配置未找到"
-
-#: apps/xpack/serializers/channel/slack.py:206
-msgid "Thinking..."
-msgstr "思考中..."
-
-#: apps/xpack/serializers/channel/slack.py:333
-msgid "Invalid json format."
-msgstr "json 格式無效。"
-
-#: apps/xpack/serializers/channel/slack.py:339
-msgid "Invalid Slack request"
-msgstr "Slack 請求無效"
-
-#: apps/xpack/serializers/channel/slack.py:347
-msgid "Slack application: {user}"
-msgstr "Slack 智能體: {user}"
-
-#: apps/xpack/serializers/channel/slack.py:480
-msgid "Stop"
-msgstr "停止"
-
-#: apps/xpack/serializers/channel/tools.py:58
-#, python-brace-format
-msgid ""
-"Thinking about 【{question}】...If you want me to continue answering, please "
-"reply {trigger_message}"
-msgstr "思考【{question}】...如果你想讓我繼續回答，請回復 {trigger_message}"
-
-#: apps/xpack/serializers/channel/tools.py:158
-msgid ""
-"\n"
-" ------------\n"
-"[To be continued, reply \"Continue to answer the question]"
-msgstr ""
-"\n"
-"------------\n"
-"[待續，回復 \"繼續回答問題]"
-
-#: apps/xpack/serializers/channel/tools.py:238
-#, python-brace-format
-msgid ""
-"To be continued, reply \"{trigger_message}\" to continue answering the "
-"question"
-msgstr "待續，回復 \"{trigger_message}\" 繼續回答問題"
-
-#: apps/xpack/serializers/channel/wechat.py:143
-#, python-brace-format
-msgid "WeChat Official Account: {account}"
-msgstr "微信公眾帳號: {account}"
-
-#: apps/xpack/serializers/channel/wechat.py:150
-#: apps/xpack/serializers/channel/wecom.py:171
-#: apps/xpack/serializers/channel/wecom.py:175
-msgid ""
-"The app does not enable the speech-to-text function or the speech-to-text "
-"function fails."
-msgstr "智能體未開啟語音轉文字功能或語音轉文字功能失敗。"
-
-#: apps/xpack/serializers/channel/wechat.py:189
-msgid "Message types not supported yet"
-msgstr "消息類型暫不支持"
-
-#: apps/xpack/serializers/channel/wechat.py:196
-msgid "Welcome to subscribe"
-msgstr "歡迎訂閱"
-
-#: apps/xpack/serializers/channel/wecom.py:86
-msgid "Enterprise WeChat user: "
-msgstr "企業微信用戶: "
-
-#: apps/xpack/serializers/channel/wecom.py:97
-msgid "Enterprise WeChat customer service: "
-msgstr "企業微信客服: "
-
-#: apps/xpack/serializers/channel/wecom.py:134
-#: apps/xpack/serializers/channel/wecom.py:150
-msgid "This type of message is not supported yet"
-msgstr "此類型消息暫不支持"
-
-#: apps/xpack/serializers/channel/wecom.py:254
-msgid "Signature missing"
-msgstr "籤名缺失"
-
-#: apps/xpack/serializers/channel/wecom.py:266
-#: apps/xpack/serializers/channel/wecom.py:273
-#, python-brace-format
-msgid "An error occurred while processing the GET request {e}"
-msgstr "get 請求處理時發生錯誤 {e}"
-
-#: apps/xpack/serializers/chat_auth.py:51
-msgid "The password is incorrect"
-msgstr "密碼不正確"
-
-#: apps/xpack/serializers/chat_user.py:42
-msgid "Some user groups do not exist"
-msgstr "某些用戶組不存在"
-
-#: apps/xpack/serializers/chat_user.py:181
-msgid "Is Append"
-msgstr "是否追加"
-
-#: apps/xpack/serializers/chat_user.py:194
-msgid "User Group IDs cannot be empty"
-msgstr "用戶組 IDs 不能為空"
-
-#: apps/xpack/serializers/chat_user.py:198
-msgid "Some users do not exist"
-msgstr "某些用戶不存在"
-
-#: apps/xpack/serializers/chat_user.py:361
-msgid "Sync Type: LOCAL or LDAP"
-msgstr "同步類型: LOCAL 或 LDAP"
-
-#: apps/xpack/serializers/chat_user.py:403
-msgid "Unsupported sync type"
-msgstr "不支持的同步類型"
-
-#: apps/xpack/serializers/chat_user.py:412
-#: apps/xpack/serializers/chat_user.py:444
-#: apps/xpack/serializers/chat_user.py:483
-#: apps/xpack/serializers/chat_user.py:510
-#: apps/xpack/serializers/chat_user.py:548
-#: apps/xpack/serializers/chat_user.py:570
-msgid "User group does not exist"
-msgstr "用戶組不存在"
-
-#: apps/xpack/serializers/chat_user.py:451
-msgid "User group name already exists"
-msgstr "用戶組名稱已存在"
-
-#: apps/xpack/serializers/chat_user.py:485
-msgid "Default user group cannot be deleted"
-msgstr "默認用戶組不能被刪除"
-
-#: apps/xpack/serializers/chat_user.py:550
-msgid "User group relation IDs cannot be empty"
-msgstr "用戶組關係 IDs 不能為空"
-
-#: apps/xpack/serializers/chat_user_serializer.py:75
-msgid "Invalid access token"
-msgstr "無效的訪問令牌"
-
-#: apps/xpack/serializers/chat_user_serializer.py:102
-msgid "The user does not have permission to access the application"
-msgstr "用戶沒有訪問智能體的權限"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:56
-#: apps/xpack/serializers/dataset_lark_serializer.py:299
-msgid "app id"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:57
-#: apps/xpack/serializers/dataset_lark_serializer.py:300
-msgid "app secret"
-msgstr ""
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:58
-#: apps/xpack/serializers/dataset_lark_serializer.py:105
-#: apps/xpack/serializers/dataset_lark_serializer.py:301
-msgid "folder token"
-msgstr "文件夾令牌"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:60
-msgid "embedding model"
-msgstr "向量模型"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:71
-#: apps/xpack/serializers/dataset_lark_serializer.py:311
-msgid "Network error or folder token error!"
-msgstr "網絡錯誤或文件夾令牌錯誤！"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:113
-#: apps/xpack/serializers/dataset_lark_serializer.py:155
-#: apps/xpack/task/sync.py:308
-msgid "Knowledge base not found!"
-msgstr "知識庫未找到！"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:125
-#: apps/xpack/task/sync.py:240
-msgid "Failed to get lark document list!"
-msgstr "獲取飛書文檔列表失敗！"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:147
-msgid "Knowledge id"
-msgstr "知識庫 ID"
-
-#: apps/xpack/serializers/dataset_lark_serializer.py:169
-msgid "Synchronization is only supported for lark documents"
-msgstr "僅支持飛書文檔的同步"
-
-#: apps/xpack/serializers/license/license_serializers.py:102
-#: apps/xpack/serializers/license/license_serializers.py:123
-#: apps/xpack/serializers/license/license_tools.py:111
-msgid "The license is invalid"
-msgstr "許可證無效"
-
-#: apps/xpack/serializers/license/license_tools.py:136
-msgid "License usage limit exceeded."
-msgstr "License 使用限制已超出。"
-
-#: apps/xpack/serializers/license/license_tools.py:160
-msgid "The network is busy, try again later."
-msgstr "網絡繁忙，請稍後再試。"
-
-#: apps/xpack/serializers/operate_log_serializer.py:59
-msgid "user"
-msgstr "用戶"
-
-#: apps/xpack/serializers/operate_log_serializer.py:61
-msgid "ip_address"
-msgstr "IP 地址"
-
-#: apps/xpack/serializers/operate_log_serializer.py:62
-msgid "workspace_id"
-msgstr "工作空間ID"
-
-#: apps/xpack/serializers/operate_log_serializer.py:134
-msgid "Fail"
-msgstr "失敗"
-
-#: apps/xpack/serializers/operate_log_serializer.py:171
-msgid "Menu"
-msgstr "菜單"
-
-#: apps/xpack/serializers/operate_log_serializer.py:172
-msgid "Operate"
-msgstr "操作"
-
-#: apps/xpack/serializers/operate_log_serializer.py:173
-msgid "Operate user"
-msgstr "操作用戶"
-
-#: apps/xpack/serializers/operate_log_serializer.py:175
-msgid "Ip Address"
-msgstr "IP位址"
-
-#: apps/xpack/serializers/operate_log_serializer.py:176
-msgid "API Details"
-msgstr "API詳情"
-
-#: apps/xpack/serializers/operate_log_serializer.py:177
-msgid "Operate Time"
-msgstr "操作時間"
-
-#: apps/xpack/serializers/platform_serializer.py:12
-msgid "app_id is required"
-msgstr "app_id 是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:13
-msgid "app_secret is required"
-msgstr "app_secret 是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:14
-msgid "token is required"
-msgstr "token 是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:15
-msgid "callback_url is required"
-msgstr "callback_url 是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:21
-#: apps/xpack/serializers/platform_serializer.py:30
-msgid "App ID is required"
-msgstr "App ID 是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:23
-msgid "Secret is required"
-msgstr "Secret 是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:24
-msgid "Token is required"
-msgstr "Token 是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:33
-msgid "Verification Token is required"
-msgstr "驗證令牌是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:38
-msgid "Client ID is required"
-msgstr "Client ID 是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:39
-msgid "Client Secret is required"
-msgstr "客戶端密鑰是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:44
-msgid "Signing Secret is required"
-msgstr "籤名密鑰是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:45
-msgid "Bot User Token is required"
-msgstr "機器人用戶令牌是必填項"
-
-#: apps/xpack/serializers/platform_serializer.py:66
-msgid "Check if the fields are correct"
-msgstr "檢查欄位是否正確"
-
-#: apps/xpack/serializers/platform_serializer.py:155
-#, python-brace-format
-msgid "The platform configuration corresponding to {type} was not found"
-msgstr "未找到對應 {type} 的平臺配置"
-
-#: apps/xpack/serializers/resource_chat_user.py:35
-#: apps/xpack/serializers/resource_chat_user.py:111
-#: apps/xpack/serializers/resource_chat_user_group.py:18
-#: apps/xpack/serializers/resource_chat_user_group.py:86
-msgid "Resource id"
-msgstr "資源ID"
-
-#: apps/xpack/serializers/resource_chat_user.py:38
-#: apps/xpack/serializers/resource_chat_user.py:112
-msgid "User group id"
-msgstr "用戶組ID"
-
-#: apps/xpack/serializers/resource_chat_user.py:94
-msgid "Is auth"
-msgstr "是否授權"
-
-#: apps/xpack/serializers/resource_chat_user_group.py:20
-msgid "User group name"
-msgstr "用戶名"
-
-#: apps/xpack/serializers/resource_chat_user_group.py:68
-msgid "user_group_id"
-msgstr "用戶組ID"
-
-#: apps/xpack/serializers/sso_auth/cas.py:32
-msgid "HttpClient query failed: "
-msgstr "HttpClient 查詢失敗: "
-
-#: apps/xpack/serializers/sso_auth/cas.py:58
-msgid "CAS authentication failed"
-msgstr "CAS 認證失敗"
-
-#: apps/xpack/serializers/sso_auth/oauth2.py:165
-#: apps/xpack/serializers/sso_auth/oauth2.py:184
-#: apps/xpack/serializers/sso_auth/oauth2.py:187
-msgid "Failed to obtain user information"
-msgstr "獲取用戶信息失敗"
-
-#: apps/xpack/serializers/system_api_key.py:12
-msgid "Allow cross domain"
-msgstr "允許跨域"
-
-#: apps/xpack/serializers/system_api_key.py:13
-msgid "Cross domain list"
-msgstr "跨域列表"
-
-#: apps/xpack/serializers/system_api_key.py:44
-msgid "system API key id"
-msgstr "系統 API 密鑰 ID"
-
-#: apps/xpack/serializers/system_params.py:20
-msgid "theme"
-msgstr "主題"
-
-#: apps/xpack/serializers/system_params.py:22
-msgid "login logo"
-msgstr "登錄 logo"
-
-#: apps/xpack/serializers/system_params.py:23
-msgid "login image"
-msgstr "登陸圖片"
-
-#: apps/xpack/serializers/system_params.py:24
-msgid "title"
-msgstr "標題"
-
-#: apps/xpack/serializers/system_params.py:25
-msgid "slogan"
-msgstr "標語"
-
-#: apps/xpack/serializers/system_params.py:26
-#: apps/xpack/serializers/system_params.py:27
-msgid "show user manual"
-msgstr "顯示用戶手冊"
-
-#: apps/xpack/serializers/system_params.py:28
-msgid "user manual url"
-msgstr "用戶手冊網址"
-
-#: apps/xpack/serializers/system_params.py:29
-msgid "show forum"
-msgstr "顯示論壇"
-
-#: apps/xpack/serializers/system_params.py:30
-msgid "forum url"
-msgstr "論壇網址"
-
-#: apps/xpack/serializers/system_params.py:31
-msgid "show project"
-msgstr "顯示項目"
-
-#: apps/xpack/serializers/system_params.py:32
-msgid "project url"
-msgstr "項目網址"
-
-#: apps/xpack/views/application_setting.py:24
-#: apps/xpack/views/application_setting.py:25
-#: apps/xpack/views/application_setting.py:26
-msgid "Modify Application Settings"
-msgstr "修改智能體設置"
-
-#: apps/xpack/views/application_setting.py:42
-#: apps/xpack/views/application_setting.py:43
-#: apps/xpack/views/application_setting.py:44
-msgid "Get Application Settings"
-msgstr "獲取智能體設置"
-
-#: apps/xpack/views/auth.py:52 apps/xpack/views/auth.py:53
-#: apps/xpack/views/auth.py:54 apps/xpack/views/chat_user_auth.py:46
-#: apps/xpack/views/chat_user_auth.py:47 apps/xpack/views/chat_user_auth.py:48
-msgid "Get authentication types"
-msgstr "獲取認證類型"
-
-#: apps/xpack/views/auth.py:55 apps/xpack/views/auth.py:70
-#: apps/xpack/views/auth.py:90 apps/xpack/views/auth.py:108
-#: apps/xpack/views/auth.py:223 apps/xpack/views/auth.py:235
-#: apps/xpack/views/auth.py:249
-msgid "Authentication Configuration"
-msgstr "認證配置"
-
-#: apps/xpack/views/auth.py:67 apps/xpack/views/auth.py:68
-#: apps/xpack/views/auth.py:69 apps/xpack/views/chat_user_auth.py:62
-#: apps/xpack/views/chat_user_auth.py:63 apps/xpack/views/chat_user_auth.py:64
-msgid "Test LDAP connection"
-msgstr "測試 LDAP 連接"
-
-#: apps/xpack/views/auth.py:87 apps/xpack/views/auth.py:88
-#: apps/xpack/views/auth.py:89
-msgid "Add or modify authentication configuration"
-msgstr "添加或修改認證配置"
-
-#: apps/xpack/views/auth.py:105 apps/xpack/views/auth.py:106
-#: apps/xpack/views/auth.py:107
-msgid "Get authentication configuration"
-msgstr "獲取認證配置"
-
-#: apps/xpack/views/auth.py:118 apps/xpack/views/auth.py:119
-#: apps/xpack/views/auth.py:120 apps/xpack/views/chat_user_auth.py:112
-#: apps/xpack/views/chat_user_auth.py:113
-#: apps/xpack/views/chat_user_auth.py:114
-msgid "Ldap Log in"
-msgstr "LDAP 登錄"
-
-#: apps/xpack/views/auth.py:121 apps/xpack/views/auth.py:138
-#: apps/xpack/views/auth.py:157 apps/xpack/views/auth.py:176
-#: apps/xpack/views/auth.py:194 apps/xpack/views/auth.py:208
-#: apps/xpack/views/auth.py:266 apps/xpack/views/auth.py:286
-#: apps/xpack/views/auth.py:307 apps/xpack/views/auth.py:327
-#: apps/xpack/views/auth.py:348 apps/xpack/views/auth.py:368
-msgid "Three-party login"
-msgstr "三方登錄"
-
-#: apps/xpack/views/auth.py:135 apps/xpack/views/auth.py:136
-#: apps/xpack/views/auth.py:137 apps/xpack/views/chat_user_auth.py:129
-#: apps/xpack/views/chat_user_auth.py:130
-#: apps/xpack/views/chat_user_auth.py:131
-msgid "CAS Log in"
-msgstr "CAS 登錄"
-
-#: apps/xpack/views/auth.py:154 apps/xpack/views/auth.py:155
-#: apps/xpack/views/auth.py:156 apps/xpack/views/chat_user_auth.py:148
-#: apps/xpack/views/chat_user_auth.py:149
-#: apps/xpack/views/chat_user_auth.py:150
-msgid "OIDC Log in"
-msgstr "OIDC 登錄"
-
-#: apps/xpack/views/auth.py:173 apps/xpack/views/auth.py:174
-#: apps/xpack/views/auth.py:175 apps/xpack/views/chat_user_auth.py:167
-#: apps/xpack/views/chat_user_auth.py:168
-#: apps/xpack/views/chat_user_auth.py:169
-msgid "OAuth2 Log in"
-msgstr "OAuth2 登錄"
-
-#: apps/xpack/views/auth.py:191 apps/xpack/views/auth.py:192
-#: apps/xpack/views/auth.py:193 apps/xpack/views/chat_user_auth.py:220
-#: apps/xpack/views/chat_user_auth.py:221
-#: apps/xpack/views/chat_user_auth.py:222
-msgid "Scan code login type"
-msgstr "掃碼登錄類型"
-
-#: apps/xpack/views/auth.py:205 apps/xpack/views/auth.py:206
-#: apps/xpack/views/auth.py:207 apps/xpack/views/auth.py:220
-#: apps/xpack/views/auth.py:221 apps/xpack/views/auth.py:222
-#: apps/xpack/views/chat_user_auth.py:234
-#: apps/xpack/views/chat_user_auth.py:235
-#: apps/xpack/views/chat_user_auth.py:236
-#: apps/xpack/views/chat_user_auth.py:249
-#: apps/xpack/views/chat_user_auth.py:250
-#: apps/xpack/views/chat_user_auth.py:251
-msgid "Get platform information"
-msgstr "獲取平臺信息"
-
-#: apps/xpack/views/auth.py:232 apps/xpack/views/auth.py:233
-#: apps/xpack/views/auth.py:234 apps/xpack/views/chat_user_auth.py:261
-#: apps/xpack/views/chat_user_auth.py:262
-#: apps/xpack/views/chat_user_auth.py:263
-msgid "Modify platform information"
-msgstr "修改平臺信息"
-
-#: apps/xpack/views/auth.py:246 apps/xpack/views/auth.py:247
-#: apps/xpack/views/auth.py:248 apps/xpack/views/chat_user_auth.py:275
-#: apps/xpack/views/chat_user_auth.py:276
-#: apps/xpack/views/chat_user_auth.py:277
-msgid "Test platform connection"
-msgstr "測試平臺連接"
-
-#: apps/xpack/views/auth.py:263 apps/xpack/views/auth.py:264
-#: apps/xpack/views/auth.py:265 apps/xpack/views/chat_user_auth.py:292
-#: apps/xpack/views/chat_user_auth.py:293
-#: apps/xpack/views/chat_user_auth.py:294
-msgid "DingTalk callback"
-msgstr "釘釘回調"
-
-#: apps/xpack/views/auth.py:283 apps/xpack/views/auth.py:284
-#: apps/xpack/views/auth.py:285 apps/xpack/views/chat_user_auth.py:312
-#: apps/xpack/views/chat_user_auth.py:313
-#: apps/xpack/views/chat_user_auth.py:314
-msgid "DingTalk OAuth2 callback"
-msgstr "釘釘 OAuth2 回調"
-
-#: apps/xpack/views/auth.py:304 apps/xpack/views/auth.py:305
-#: apps/xpack/views/auth.py:306 apps/xpack/views/chat_user_auth.py:333
-#: apps/xpack/views/chat_user_auth.py:334
-#: apps/xpack/views/chat_user_auth.py:335
-msgid "WeCom callback"
-msgstr "企業微信回調"
-
-#: apps/xpack/views/auth.py:324 apps/xpack/views/auth.py:325
-#: apps/xpack/views/auth.py:326 apps/xpack/views/chat_user_auth.py:353
-#: apps/xpack/views/chat_user_auth.py:354
-#: apps/xpack/views/chat_user_auth.py:355
-msgid "WeCom OAuth2 callback"
-msgstr "企業微信 OAuth2 回調"
-
-#: apps/xpack/views/auth.py:345 apps/xpack/views/auth.py:346
-#: apps/xpack/views/auth.py:347 apps/xpack/views/chat_user_auth.py:374
-#: apps/xpack/views/chat_user_auth.py:375
-#: apps/xpack/views/chat_user_auth.py:376
-msgid "Lark callback"
-msgstr "飛書回調"
-
-#: apps/xpack/views/auth.py:365 apps/xpack/views/auth.py:366
-#: apps/xpack/views/auth.py:367 apps/xpack/views/chat_user_auth.py:394
-#: apps/xpack/views/chat_user_auth.py:395
-#: apps/xpack/views/chat_user_auth.py:396
-msgid "Lark OAuth2 callback"
-msgstr "飛書 OAuth2 回調"
-
-#: apps/xpack/views/chat_user_auth.py:49 apps/xpack/views/chat_user_auth.py:65
-#: apps/xpack/views/chat_user_auth.py:85 apps/xpack/views/chat_user_auth.py:252
-#: apps/xpack/views/chat_user_auth.py:264
-#: apps/xpack/views/chat_user_auth.py:278
-msgid "Chat User/Authentication Configuration"
-msgstr "對話用戶/認證配置"
-
-#: apps/xpack/views/chat_user_auth.py:82 apps/xpack/views/chat_user_auth.py:83
-#: apps/xpack/views/chat_user_auth.py:84
-msgid "Add or modify Chat/Authentication Configuration"
-msgstr "添加或修改對話/認證配置"
-
-#: apps/xpack/views/chat_user_auth.py:99 apps/xpack/views/chat_user_auth.py:100
-#: apps/xpack/views/chat_user_auth.py:101
-msgid "Get Authentication Configuration"
-msgstr "獲取認證配置"
-
-#: apps/xpack/views/chat_user_auth.py:102
-msgid "Chat User/login authentication"
-msgstr "對話用戶/登錄認證"
-
-#: apps/xpack/views/chat_user_auth.py:115
-#: apps/xpack/views/chat_user_auth.py:132
-#: apps/xpack/views/chat_user_auth.py:151
-#: apps/xpack/views/chat_user_auth.py:170
-#: apps/xpack/views/chat_user_auth.py:223
-#: apps/xpack/views/chat_user_auth.py:237
-#: apps/xpack/views/chat_user_auth.py:295
-#: apps/xpack/views/chat_user_auth.py:315
-#: apps/xpack/views/chat_user_auth.py:336
-#: apps/xpack/views/chat_user_auth.py:356
-#: apps/xpack/views/chat_user_auth.py:377
-#: apps/xpack/views/chat_user_auth.py:397
-msgid "Chat User/Three-party login"
-msgstr "對話用戶/三方登錄"
-
-#: apps/xpack/views/chat_user_auth.py:187
-msgid "Chat User/login"
-msgstr "對話用戶/登錄"
-
-#: apps/xpack/views/chat_user_auth.py:414
-#: apps/xpack/views/chat_user_auth.py:415
-#: apps/xpack/views/chat_user_auth.py:416
-msgid "Application Password Certification"
-msgstr "智能體密碼認證"
-
-#: apps/xpack/views/license.py:31 apps/xpack/views/license.py:32
-#: apps/xpack/views/license.py:33
-msgid "Get license information"
-msgstr "獲取許可證信息"
-
-#: apps/xpack/views/license.py:42 apps/xpack/views/license.py:44
-msgid "Update license information"
-msgstr "更新許可證信息"
-
-#: apps/xpack/views/license.py:43
-msgid "Update license information by uploading a new license file"
-msgstr "通過上傳新許可證文件更新許可證信息"
-
-#: apps/xpack/views/operate_log.py:21 apps/xpack/views/operate_log.py:22
-#: apps/xpack/views/operate_log.py:23
-msgid "Get menu operate log"
-msgstr "獲取菜單操作日誌"
-
-#: apps/xpack/views/operate_log.py:25 apps/xpack/views/operate_log.py:41
-#: apps/xpack/views/operate_log.py:57
-msgid "System operate log"
-msgstr "系統操作日誌"
-
-#: apps/xpack/views/operate_log.py:36 apps/xpack/views/operate_log.py:37
-#: apps/xpack/views/operate_log.py:38
-msgid "Get paginated operate log"
-msgstr "獲取分頁操作日誌"
-
-#: apps/xpack/views/operate_log.py:54 apps/xpack/views/operate_log.py:55
-#: apps/xpack/views/operate_log.py:56
-msgid "Export operate log"
-msgstr "導出操作日誌"
-
-#: apps/xpack/views/platform.py:60 apps/xpack/views/platform.py:61
-#: apps/xpack/views/platform.py:62
-msgid "Get platform configuration"
-msgstr "獲取平臺配置"
-
-#: apps/xpack/views/platform.py:65 apps/xpack/views/platform.py:79
-msgid "Application/application access"
-msgstr "智能體/智能體訪問"
-
-#: apps/xpack/views/platform.py:73 apps/xpack/views/platform.py:74
-#: apps/xpack/views/platform.py:75
-msgid "Update platform configuration"
-msgstr "更新平臺配置"
-
-#: apps/xpack/views/platform.py:94 apps/xpack/views/platform.py:95
-#: apps/xpack/views/platform.py:96
-msgid "Get platform status"
-msgstr "獲取平臺狀態"
-
-#: apps/xpack/views/platform.py:98 apps/xpack/views/platform.py:118
-msgid "Application/Get platform status"
-msgstr "智能體/獲取平臺狀態"
-
-#: apps/xpack/views/platform.py:113 apps/xpack/views/platform.py:114
-#: apps/xpack/views/platform.py:115
-msgid "Update platform status"
-msgstr "更新平臺狀態"
-
-#: apps/xpack/views/resource_chat_user.py:27
-#: apps/xpack/views/resource_chat_user.py:28
-#: apps/xpack/views/resource_chat_user.py:29
-msgid "Get Resource chat user List"
-msgstr "獲取資源聊天用戶列表"
-
-#: apps/xpack/views/resource_chat_user.py:32
-#: apps/xpack/views/resource_chat_user.py:54
-#: apps/xpack/views/resource_chat_user.py:77
-#: apps/xpack/views/system_chat_user_group.py:24
-#: apps/xpack/views/system_chat_user_group.py:45
-#: apps/xpack/views/system_chat_user_group.py:67
-msgid "Chat user"
-msgstr "聊天用戶"
-
-#: apps/xpack/views/resource_chat_user.py:48
-#: apps/xpack/views/resource_chat_user.py:49
-#: apps/xpack/views/resource_chat_user.py:50
-msgid "Edit Resource chat user List"
-msgstr "編輯資源聊天用戶列表"
-
-#: apps/xpack/views/resource_chat_user.py:72
-#: apps/xpack/views/resource_chat_user.py:73
-#: apps/xpack/views/resource_chat_user.py:74
-msgid "Get Resource chat user page List"
-msgstr "獲取資源聊天用戶分頁列表"
-
-#: apps/xpack/views/system_api_key.py:19 apps/xpack/views/system_api_key.py:20
-#: apps/xpack/views/system_api_key.py:21
-msgid "Create SystemAPIKey"
-msgstr "創建系統 API 密鑰"
-
-#: apps/xpack/views/system_api_key.py:34 apps/xpack/views/system_api_key.py:35
-#: apps/xpack/views/system_api_key.py:36
-msgid "Get SystemAPIKey List"
-msgstr "獲取系統 API 密鑰列表"
-
-#: apps/xpack/views/system_api_key.py:50 apps/xpack/views/system_api_key.py:51
-#: apps/xpack/views/system_api_key.py:52
-msgid "Update SystemAPIKey"
-msgstr "更新系統 API 密鑰"
-
-#: apps/xpack/views/system_api_key.py:66 apps/xpack/views/system_api_key.py:67
-#: apps/xpack/views/system_api_key.py:68
-msgid "Delete SystemAPIKey"
-msgstr "刪除系統 API 密鑰"
-
-#: apps/xpack/views/system_chat_user.py:60
-#: apps/xpack/views/system_chat_user.py:76
-#: apps/xpack/views/system_chat_user.py:89
-#: apps/xpack/views/system_chat_user.py:102
-#: apps/xpack/views/system_chat_user.py:113
-#: apps/xpack/views/system_chat_user.py:131
-#: apps/xpack/views/system_chat_user.py:146
-#: apps/xpack/views/system_chat_user.py:163
-#: apps/xpack/views/system_chat_user.py:180
-#: apps/xpack/views/system_chat_user.py:200
-#: apps/xpack/views/system_chat_user.py:217
-msgid "System/Chat user"
-msgstr "系統/對話用戶"
-
-#: apps/xpack/views/system_chat_user.py:73
-#: apps/xpack/views/system_chat_user.py:74
-#: apps/xpack/views/system_chat_user.py:75
-msgid "Get chat user list"
-msgstr "獲取對話用戶列表"
-
-#: apps/xpack/views/system_chat_user.py:214
-#: apps/xpack/views/system_chat_user.py:216
-msgid "Sync chat users"
-msgstr "同步對話用戶"
-
-#: apps/xpack/views/system_chat_user.py:215
-msgid "Sync chat users from external source"
-msgstr "從外部源同步對話用戶"
-
-#: apps/xpack/views/system_chat_user.py:235
-#: apps/xpack/views/system_chat_user.py:247
-#: apps/xpack/views/system_chat_user.py:261
-#: apps/xpack/views/system_chat_user.py:279
-#: apps/xpack/views/system_chat_user.py:301
-#: apps/xpack/views/system_chat_user.py:321
-msgid "System/User Group"
-msgstr "系統/用戶組"
-
-#: apps/xpack/views/system_chat_user_group.py:19
-#: apps/xpack/views/system_chat_user_group.py:20
-#: apps/xpack/views/system_chat_user_group.py:21
-msgid "Get Resource chat user group List"
-msgstr "獲取資源聊天用戶組列表"
-
-#: apps/xpack/views/system_chat_user_group.py:39
-#: apps/xpack/views/system_chat_user_group.py:40
-#: apps/xpack/views/system_chat_user_group.py:41
-msgid "Edit Resource chat user group List"
-msgstr "編輯資源聊天用戶組列表"
-
-#: apps/xpack/views/system_chat_user_group.py:62
-#: apps/xpack/views/system_chat_user_group.py:64
-msgid "Get Resource chat user group page List"
-msgstr "獲取資源聊天用戶組分頁列表"
-
-#: apps/xpack/views/system_chat_user_group.py:63
-msgid "Get Resource chat user page group List"
-msgstr "獲取資源聊天用戶分頁組列表"
-
-#: apps/xpack/views/system_params.py:22 apps/xpack/views/system_params.py:23
-#: apps/xpack/views/system_params.py:24
-msgid "View appearance settings"
-msgstr "查看外觀設置"
-
-#: apps/xpack/views/system_params.py:39 apps/xpack/views/system_params.py:40
-#: apps/xpack/views/system_params.py:41
-msgid "Update appearance settings"
-msgstr "更新外觀設置"
-
-msgid "Application Access"
-msgstr "智能體介入"
-
-msgid "Display execution details"
-msgstr "是否顯示執行詳情"
-
-msgid "LOCAL"
-msgstr "帳號登入"
-
-msgid "CAS"
-msgstr "CAS"
-
-msgid "LDAP"
-msgstr "LDAP"
-
-msgid "OIDC"
-msgstr "OIDC"
-
-msgid "OAuth2"
-msgstr "OAuth2"
-
-msgid "dingtalk"
-msgstr "钉钉"
-
-msgid "wecom"
-msgstr "企业微信"
-
-msgid "lark"
-msgstr "飞书"
-
-msgid "Get tool list"
-msgstr "獲取工具列表"
-
-msgid "Setting"
-msgstr "設置"
-
-msgid "Get verification results"
-msgstr "獲取驗證結果"
-
-msgid "Validation"
-msgstr "驗證"
-
-msgid "Models Resource"
-msgstr "模型資源"
-
-msgid "Tools Resource"
-msgstr "工具資源"
-
-msgid "Get resource model list"
-msgstr "獲取資源模型列表"
-
-msgid "System Model"
-msgstr "系統模型"
-
-msgid "Dialogue users"
-msgstr "對話用戶"
-
-msgid "Conversation log"
-msgstr "對話日誌"
-
-msgid "Public access link"
-msgstr "公共訪問鏈接"
-
-msgid "User management"
-msgstr "用戶管理"
-
-msgid "Chat User/logout"
-msgstr "對話用戶/登出"
-
-msgid "Paragraph"
-msgstr "段落"
-
-msgid "User group"
-msgstr "用戶組"
-
-msgid "Remove member from user group"
-msgstr "從用戶組中移除成員"
-
-msgid "Create a web site knowledge base"
-msgstr "創建web知識庫"
-
-msgid "Modify knowledge base information"
-msgstr "修改知識庫信息"
-
-msgid "Delete knowledge base"
-msgstr "刪除知識庫"
-
-msgid "model"
-msgstr "模型"
-
-msgid "Batch add user to group"
-msgstr "批量添加用戶到組"
-
-msgid "Add internal tool"
-msgstr "添加内置工具"
-
-msgid "Batch generate related"
-msgstr "批量生成相關"
-
-msgid "Update personal system API_KEY"
-msgstr "更新個人系統 API KEY"
-
-msgid "Delete user group"
-msgstr "刪除用戶組"
-
-msgid "Add user"
-msgstr "添加用戶"
-
-msgid "folder"
-msgstr "文件夾"
-
-msgid "Create or update user group"
-msgstr "創建或更新用戶組"
-
-msgid "Edit folder"
-msgstr "編輯文件夾"
-
-msgid "Email settings"
-msgstr "郵件設置"
-
-msgid "trial listening"
-msgstr "試聽"
-
-msgid "Add member to user group"
-msgstr "添加成員到用戶組"
-
-msgid "System"
-msgstr "系統"
-
-msgid "Shared Knowledge/Document"
-msgstr "共享知識/文件"
-
-msgid "System Application"
-msgstr "系統智能體"
-
-msgid "Hit-Test"
-msgstr "命中測試"
-
-msgid "Export Application"
-msgstr "導出智能體"
-
-msgid "Add ApiKey"
-msgstr "添加 API KEY"
-
-msgid "Delete application API_KEY"
-msgstr "删除智能體 API KEY"
-
-msgid "knowledge Base"
-msgstr "知識庫"
-
-msgid "API KEY"
-msgstr "API KEY"
-
-msgid "Download"
-msgstr "下載"
-
-msgid "User"
-msgstr "用戶"
-
-msgid "Delete personal system API_KEY"
-msgstr "删除個人系統API KEY"
-
-msgid "Add personal system API_KEY"
-msgstr "添加個人系統API KEY"
-
-msgid "Generate related documents"
-msgstr "生成相關文檔"
-
-msgid "Modify application access token"
-msgstr "修改智能體程序訪問權杖"
-
-msgid "File not exist. Only manually uploaded documents are supported"
-msgstr "文件不存在, 僅支持手動上傳的文檔"
-
-msgid "Resource"
-msgstr "資源管理"
-
-msgid "LDAP configuration not found or not active"
-msgstr "LDAP 配置未找到或未激活"
-
-msgid "Lark configuration not found or not active"
-msgstr "Lark 配置未找到或未激活"
-
-msgid "Failed to get Lark collaborators"
-msgstr "獲取 Lark 協作者失敗"
-
-msgid "Failed to get Lark user details"
-msgstr "獲取 Lark 用戶詳情失敗"
-
-msgid "WeCom configuration not found or not active"
-msgstr "WeCom 配置未找到或未激活"
-
-msgid "Failed to get WeCom access token"
-msgstr "獲取 WeCom 訪問權杖失敗"
-
-msgid "Failed to get WeCom agent info"
-msgstr "獲取 WeCom 智能助手信息失敗"
-
-msgid "Failed to get WeCom department users"
-msgstr "獲取 WeCom 部門用戶失敗"
-
-msgid "Failed to get WeCom user info"
-msgstr "獲取 WeCom 用戶詳情失敗"
-
-msgid "Publish status"
-msgstr "發佈狀態"
-
-msgid "Unpublished"
-msgstr "未發佈"
-
-msgid "Published"
-msgstr "已發佈"
-
-msgid "users_permission"
-msgstr "用戶許可權"
-
-msgid "Get user authorization status of resource"
-msgstr "獲取資源對用戶的授權狀態"
-
-msgid "Edit user authorization status of resource"
-msgstr "修改資源對用戶的授權狀態"
-
-msgid "Get user authorization status of resource by page"
-msgstr "分頁獲取資源對用戶的授權狀態"
-
-msgid "Obtain resource authorization list by page"
-msgstr "分頁獲取資源授權清單"
-
-msgid "Engine model type"
-msgstr "引擎模型類型"
-
-msgid "If not passed, the default value is 16k_zh (Chinese universal)"
-msgstr "如果未傳遞，默認值為 16k_zh（中文通用）"
-
-msgid "Chinese telephone universal"
-msgstr "中文電話通用"
-
-msgid "English telephone universal"
-msgstr "英文電話通用"
-
-msgid "Commonly used in Chinese"
-msgstr "中文常用"
-
-msgid "Chinese, English, and Guangdong"
-msgstr "中文、英文和廣東話"
-
-msgid "Chinese medical"
-msgstr "中文醫療"
-
-msgid "English"
-msgstr "英文"
-
-msgid "Cantonese"
-msgstr "粵語"
-
-msgid "Japanese"
-msgstr "日語"
-
-msgid "Korean"
-msgstr "韓語"
-
-msgid "Vietnamese"
-msgstr "越南語"
-
-msgid "Malay language"
-msgstr "馬來語"
-
-msgid "Indonesian language"
-msgstr "印尼語"
-
-msgid "Filipino language"
-msgstr "菲律賓語"
-
-msgid "Thai"
-msgstr "泰語"
-
-msgid "Portuguese"
-msgstr "葡萄牙語"
-
-msgid "Turkish"
-msgstr "土耳其語"
-
-msgid "Arabic"
-msgstr "阿拉伯語"
-
-msgid "Spanish"
-msgstr "西班牙語"
-
-msgid "Hindi"
-msgstr "印地語"
-
-msgid "French"
-msgstr "法語"
-
-msgid "German"
-msgstr "德語"
-
-msgid "Multiple dialects, supporting 23 dialects"
-msgstr "多種方言，支持 23 種方言"
-
-msgid "This interface is used to recognize short audio files within 60 seconds. Supports Mandarin Chinese, English, Cantonese, Japanese, Vietnamese, Malay, Indonesian, Filipino, Thai, Portuguese, Turkish, Arabic, Hindi, French, German, and 23 Chinese dialects."
-msgstr "本介面用於識別 60 秒之內的短音頻文件。支援中文普通話、英語、粵語、日語、越南語、馬來語、印度尼西亞語、菲律賓語、泰語、葡萄牙語、土耳其語、阿拉伯語、印地語、法語、德語及 23 種漢語方言。"
-
-msgid "CueWord"
-msgstr "提示詞"
-
-msgid "If not passed, the default value is What is this audio saying? Only answer the audio content"
-msgstr "如果未傳遞，預設值為這段音訊在說什麼，只回答音訊的內容"
-
-msgid "The Qwen Omni series model supports inputting multiple modalities of data, including video, audio, images, and text, and outputting audio and text."
-msgstr "Qwen-Omni系列模型支持輸入多種模態的數據，包括視頻、音訊、圖片、文字，並輸出音訊與文字"
-
-msgid "resource authorization"
-msgstr "資源授權"
-
-msgid "The Qwen Audio based end-to-end speech recognition model supports audio recognition within 3 minutes. At present, it mainly supports Chinese and English recognition."
-msgstr "基於Qwen-Audio的端到端語音辨識大模型，支持3分鐘以內的音訊識別，現時主要支持中英文識別。"
-
-msgid "If not passed, the default value is 'zh'"
-msgstr "如果未傳遞，則預設值為'zh'"
-
-msgid "System resources authorization"
-msgstr "系統資源授權"
-
-msgid "This folder contains resources that you dont have permission"
-msgstr "此資料夾包含您沒有許可權的資源"
-
-
-msgid "Text to Video"
-msgstr "文生視頻"
-
-msgid "Image to Video"
-msgstr "圖生視頻"
-
-msgid "Authentication failed. Please verify that the parameters are correct"
-msgstr "認證失敗，請檢查參數是否正確"
-
-msgid "Chat context"
-msgstr "聊天上下文"
-
-msgid "Prompt template"
-msgstr "提示詞範本"
-
-msgid "generate prompt"
-msgstr "生成提示詞"
-
-msgid "Watermark"
-msgstr "水印"
-
-msgid "Whether to add watermark"
-msgstr "是否添加水印"
-
-msgid "Resolution"
-msgstr "分辨率"
-
-msgid "Ratio"
-msgstr "比例"
-
-msgid "Duration"
-msgstr "時長"
-
-msgid "Failed to generate video"
-msgstr "生成視頻失敗"
-
-msgid "password"
-msgstr "密码登录"
-
-msgid "Failed to obtain the image"
-msgstr "獲取圖片失敗"
-
-msgid "Update auth setting"
-msgstr "更新認證設置"
-
-msgid "If not passed, the default value is streaming_asr_demo"
-msgstr "如果未傳入，則預設值為 streaming_asr_demo"
-
-msgid "If not passed, the default value is 16000"
-msgstr "如果未傳入，則預設值為 16000"
-
-msgid "Sample Rate"
-msgstr "採樣率"
-
-msgid "Captcha is required"
-msgstr "驗證碼是必填項"
-
-msgid "Tag"
-msgstr "標籤管理"
-
-msgid "Tag Setting"
-msgstr "標籤設定"
-
-msgid "Download Original Document"
-msgstr "下載原文件"
-
-msgid "Replace Original Document"
-msgstr "替換原文件"
-
-msgid "Update License"
-msgstr "更新許可證"
-
-msgid "Tag Key"
-msgstr "標籤"
-
-msgid "Tag Value"
-msgstr "標籤值"
-
-msgid "Tag id does not exist"
-msgstr "標籤ID不存在"
-
-msgid "Tag key already exists"
-msgstr "標籤已存在"
-
-msgid "Tag value already exists"
-msgstr "標籤值已存在"
-
-msgid "Non-existent id"
-msgstr "不存在的ID"
-
-msgid "No permission for the target folder"
-msgstr "沒有目標資料夾的權限"
-
-msgid "Application token usage statistics"
-msgstr "智能體令牌使用統計"
-
-msgid "Application top question statistics"
-msgstr "智能體提問次數統計"
-
-msgid "SAML2 Metadata"
-msgstr "SAML2 元數據"
-
-msgid "SAML2 Log in"
-msgstr "SAML2 登入"
-
-msgid "SAML2 SSO"
-msgstr "SAML2 單點登入"
-
-msgid "Workflow"
-msgstr "工作流"
-
-msgid "Web source url"
-msgstr "Web 根地址"
-
-msgid "Web knowledge selector"
-msgstr "選擇器"
-
-msgid "The default is body, you can enter .classname/#idname/tagname"
-msgstr "默認為 body，可輸入 .classname/#idname/tagname"
-
-msgid "Please enter the Web root address"
-msgstr "請輸入 Web 根地址"
-
-msgid "File size exceeds limit"
-msgstr "文件大小超出限制"
-
-msgid "File upload is not enabled"
-msgstr "文件上傳未啟用"
-
-msgid "Blocked unsafe redirect to internal host"
-msgstr "阻止不安全的重定向到內部主機"
-
-msgid "Audio file recognition - Tongyi Qwen"
-msgstr "錄音文件識別-通義千問"
-
-msgid "Real-time speech recognition - Fun-ASR/Paraformer"
-msgstr "實時語音識別-Fun-ASR/Paraformer"
-
-msgid "Qwen-Omni"
-msgstr "多模態"
-
-msgid "Super-humanoid: Lingxiaoxuan Flow"
-msgstr "聆小璇"
-
-msgid "Super-humanoid: Lingyuyan Flow"
-msgstr "聆玉言"
-
-msgid "Super-humanoid: Lingfeiyi Flow"
-msgstr "聆飛逸"
-
-msgid "Super-humanoid: Lingxiaoyue Flow"
-msgstr "聆小玥"
-
-msgid "Super-humanoid: Sun Dasheng Flow"
-msgstr "孫大聖"
-
-msgid "Super-humanoid: Lingyuzhao Flow"
-msgstr "聆玉昭"
-
-msgid "Super-humanoid: Lingxiaotang Flow"
-msgstr "聆小糖"
-
-msgid "Super-humanoid: Lingxiaorong Flow"
-msgstr "聆小蓉"
-
-msgid "Super-humanoid: Xinyun Flow"
-msgstr "心雲"
-
-msgid "Super-humanoid: Grant (EN)"
-msgstr "Grant"
-
-msgid "Super-humanoid: Lila (EN)"
-msgstr "Lila"
-
-msgid "Super-humanoid: Lingwanwan Pro"
-msgstr "聆萬萬"
-
-msgid "Super-humanoid: Yiyi Pro"
-msgstr "依依"
-
-msgid "Super-humanoid: Huifangnv Pro"
-msgstr "惠芳女"
-
-msgid "Super-humanoid: Lingxiaoying Pro"
-msgstr "聆小穎"
-
-msgid "Super-humanoid: Lingfeibo Pro"
-msgstr "聆飛博"
-
-msgid "Super-humanoid: Lingyuyan Pro"
-msgstr "聆玉言"
-
-msgid "Login failed %s times, account will be locked, you have %s more chances !"
-msgstr "登录失败 %s 次，账号将被锁定，您还有 %s 次机会！"
-
-msgid "This account has been locked for %s minutes, please try again later"
-msgstr "該帳號已被鎖定 %s 分鐘，請稍後再試"
-
-msgid "User does not have permission to use API Key"
-msgstr "使用者沒有使用 API Key 的權限"
-
-msgid "Import knowledge workflow"
-msgstr "匯入知識工作流"
-
-msgid "Export knowledge workflow"
-msgstr "匯出知識工作流"
-
-msgid "Role IDs cannot be empty"
-msgstr "角色 ID 不能为空"
-
-msgid "Some roles do not exist"
-msgstr "部分角色不存在"
-
-msgid "Authorized pagination list for obtaining resources"
-msgstr "獲取資源的關係分頁清單"
-
-msgid "Resources mapping"
-msgstr "資源映射"
-
-msgid "Batch set user roles"
-msgstr "批量設置用戶角色"
-
-msgid "Role Setting cannot be empty"
-msgstr "角色設置不能為空"
-
-msgid "View related resources"
-msgstr "查看關聯資源"
-
-msgid "Feedback reason"
-msgstr "反饋理由"
-
-msgid "Other reason content"
-msgstr "其他反饋理由內容"
-
-msgid "accurate"
-msgstr "內容準確"
-
-msgid "complete"
-msgstr "內容完善"
-
-msgid "inaccurate"
-msgstr "內容不準確"
-
-msgid "incomplete"
-msgstr "內容不完善"
-
-msgid "Secret key is invalid"
-msgstr "密鑰無效"
-
-msgid "Secret key is expired"
-msgstr "密鑰已過期"
-
-msgid "Online Usage"
-msgstr "線上使用"
-
-msgid "API Call"
-msgstr "API 調用"
-
-msgid "Enterprise WeChat"
-msgstr "企業微信應用"
-
-msgid "WeChat Public Account"
-msgstr "微信公眾號"
-
+#: apps/application/serializers/application_chat.py:292
 msgid "Lark"
 msgstr "飛書應用"
 
-msgid "DingTalk"
-msgstr "釘釘應用"
-
-msgid "Enterprise WeChat Robot"
-msgstr "企業微信機器人"
-
-msgid "Trigger"
-msgstr "觸發器"
-
-msgid "Slack"
-msgstr "Slack 應用"
-
-msgid "Root Directory"
-msgstr "根目錄"
-
-msgid "Create trigger"
-msgstr "建立觸發器"
-
-msgid "Get the trigger list"
-msgstr "取得觸發器清單"
-
-msgid "Get trigger details"
-msgstr "取得觸發器詳情"
-
-msgid "Modify the trigger"
-msgstr "修改觸發器"
-
-msgid "Delete the trigger"
-msgstr "刪除觸發器"
-
-msgid "Delete trigger in batches"
-msgstr "批次刪除觸發器"
-
-msgid "Activate trigger in batches"
-msgstr "批次啟用/停用觸發器"
-
-msgid "Get the trigger list by page"
-msgstr "分頁取得觸發器清單"
-
-msgid "Create trigger in source"
-msgstr "資源端建立觸發器"
-
-msgid "Get the trigger list of source"
-msgstr "取得資源端觸發器清單"
-
-msgid "Get Task source trigger details"
-msgstr "取得資源端觸發器詳情"
-
-msgid "Delete the task source trigger"
-msgstr "刪除資源端觸發器"
-
-msgid "Get the task list of triggers"
-msgstr "取得觸發器任務清單"
-
-msgid "Retrieve detailed records of tasks executed by the trigger."
-msgstr "取得由該觸發器執行的任務詳細記錄。"
-
-msgid "Get a paginated list of execution records for trigger tasks."
-msgstr "取得觸發器任務執行記錄的分頁清單。"
-
-msgid "%s must be an array"
-msgstr "%s 必須是陣列類型"
-
-msgid "%s must not be empty"
-msgstr "%s 不能為空"
-
-msgid "%s values must be between %s and %s"
-msgstr "%s 的值必須在 %s 到 %s 之間"
-
-msgid "Invalid time format: %s, must be HH:MM (e.g., 09:00)"
-msgstr "時間格式無效: %s，必須是 HH:MM 格式 (例如: 09:00)"
-
-msgid "schedule_type must be one of %s"
-msgstr "schedule_type 必須是以下值之一: %s"
-
-msgid "interval_value must be an integer greater than or equal to 1"
-msgstr "interval_value 必須是大於或等於 1 的整數"
-
-msgid "interval_unit must be one of %s"
-msgstr "interval_unit 必須是以下值之一: %s"
-
-msgid "body must be an array"
-msgstr "body 必須是陣列類型"
-
-msgid "Error trigger type"
-msgstr "觸發器類型錯誤"
-
-msgid "The following id does not exist: %s"
-msgstr "以下 id 不存在: %s"
-
-msgid "%s must be a dict"
-msgstr "%s 必須是字典類型"
-
-msgid "input_field_list must be a dict"
-msgstr "input_field_list 必須是字典類型"
-
-msgid "%s type requires %s field"
-msgstr "%s 類型需要 %s 欄位"
-
-msgid "trigger name"
-msgstr "觸發器名稱"
-
-msgid "trigger description"
-msgstr "觸發器描述"
-
-msgid "trigger setting"
-msgstr "觸發器設定"
-
-msgid "Trigger ID"
-msgstr "觸發器ID"
-
-msgid "Trigger task can not be empty"
-msgstr "觸發器任務不能為空"
-
-msgid "%s id does not exist"
-msgstr "%s id 不存在"
-
-msgid "Trigger id does not exist"
-msgstr "觸發器 id 不存在"
-
-msgid "Trigger not found"
-msgstr "未找到觸發器"
-
-msgid "Trigger must have at least one task"
-msgstr "觸發器必須至少有一個任務"
-
-msgid "Trigger task number must be one"
-msgstr "觸發器任務數量必須為一個"
-
-msgid "Incorrect trigger task"
-msgstr "觸發器任務不正確"
-
-msgid "Trigger task ID"
-msgstr "觸發器任務ID"
-
-msgid "Trigger task record ID"
-msgstr "觸發器任務記錄ID"
-
-msgid "Trigger task record id does not exist"
-msgstr "觸發器任務記錄 id 不存在"
-
-msgid "Order field"
-msgstr "排序欄位"
-
-msgid "System Trigger"
-msgstr "系統觸發器"
-
-msgid "Get the System trigger list of source"
-msgstr "取得來源的系統觸發器清單"
-
-msgid "Get System Task source trigger details"
-msgstr "取得系統任務來源觸發器詳情"
-
-msgid "Modify the System task source trigger"
-msgstr "修改系統任務來源觸發器"
-
-msgid "Modify the task source trigger"
-msgstr "修改任務來源觸發器"
-
-msgid "Delete the System task source trigger"
-msgstr "刪除系統任務來源觸發器"
-
-msgid "Invalid source type"
-msgstr "無效的來源類型"
-
-msgid "Shared tool is not supported"
-msgstr "不支援共享工具"
-
-msgid "Read Trigger"
-msgstr "檢視觸發器"
-
-msgid "Create Trigger"
-msgstr "建立觸發器"
-
-msgid "Edit Trigger"
-msgstr "編輯觸發器"
-
-msgid "Delete Trigger"
-msgstr "刪除觸發器"
-
-msgid "Read execute record"
-msgstr "檢視執行記錄"
-
-msgid "ADMIN"
-msgstr "系統管理員"
-
-msgid "WORKSPACE_MANAGE"
-msgstr "空間管理員"
-
-msgid "USER"
-msgstr "普通用戶"
-
-msgid "Generate share link"
-msgstr "產生分享連結"
-
-msgid "Chat record link"
-msgstr "聊天記錄連結"
-
-msgid "Get chat record by share link"
-msgstr "透過分享連結取得聊天記錄"
-
-msgid "Invalid chat record ids"
-msgstr "無效的聊天記錄ID"
-
-msgid "Share link does not exist"
-msgstr "分享連結不存在"
-
-msgid "Chat has been deleted"
-msgstr "聊天記錄已被刪除"
-
-msgid "cron type requires cron_expression field"
-msgstr "cron 類型需要 cron_expression 欄位"
-
-msgid "Invalid cron expression: %s"
-msgstr "Cron 表達式不合法：%s"
-
-msgid "Batch Remove Documents from Tag"
-msgstr "批量刪除標籤下的文件"
-
-msgid "Document does not belong to current knowledge"
-msgstr "文件不屬於當前知識庫"
-
-msgid "Move an application"
-msgstr "移動應用程序"
-
-msgid "Batch delete applications"
-msgstr "批量刪除應用"
-
-msgid "Batch move applications"
-msgstr "批量移動應用"
-
-msgid "Batch delete knowledge"
-msgstr "批量刪除知識庫"
-
-msgid "Batch move knowledge"
-msgstr "批量移動知識庫"
-
-msgid "Batch delete tools"
-msgstr "批量刪除工具"
-
-msgid "Batch move tools"
-msgstr "批量移動工具"
-
-msgid "Model is not allowed to be empty"
-msgstr "模型不能为空"
-
-msgid "Not a valid zip file"
-msgstr "不是有效的 zip 檔案"
-
-msgid "Not a valid KB export file, missing knowledge.json"
-msgstr "不是有效的知識庫匯出檔案，缺少 knowledge.json"
-
-msgid "Not a valid KB export file, missing knowledge.xlsx"
-msgstr "不是有效的知識庫匯出檔案，缺少 knowledge.xlsx"
-
-msgid "Tags"
-msgstr "標籤"
-
-msgid "Hit handling method"
-msgstr "命中處理方式"
-
-msgid "Directly return similarity"
-msgstr "直接回傳相似度"
-
-msgid "Paragraph is active"
-msgstr "段落是否啟用"
-
-msgid "Document type"
-msgstr "文件類型"
-
-msgid "Document meta"
-msgstr "文件元資料"
-
-msgid "Export knowledge bundle"
-msgstr "匯出知識庫"
-
-msgid "Import knowledge bundle"
-msgstr "匯入知識庫"
-
-msgid "Export system knowledge bundle"
-msgstr "匯出系統知識庫"
-
-msgid "Export shared knowledge bundle"
-msgstr "匯出共享知識庫"
-
-msgid "Batch delete"
-msgstr "批量刪除"
-
-msgid "Batch move"
-msgstr "批量移動"
-
-msgid "There is a circular dependency in the tool workflow"
-msgstr "工具工作流存在迴圈依賴"
-
-msgid "model_params_form must be a list"
-msgstr "model_params_form 必须是一个列表"
-
-msgid "The {index}th item in model_params_form must be a dictionary"
-msgstr "model_params_form 中的第 {index} 项必须是一个字典"
-
-msgid "The label field is required for the {index}th item in model_params_form"
-msgstr "model_params_form 中的第 {index} 项的 label 字段是必填项"
-
-msgid "Publish"
-msgstr "發布"
-
-msgid "token is required for EVENT triggers"
-msgstr "事件觸發器必須設定 token"
-
-msgid "Home page"
-msgstr "首頁"
-
-msgid "Response code"
-msgstr "回應碼"
-
-msgid "Response message"
-msgstr "回應訊息"
-
-msgid "Total count"
-msgstr "總數量"
-
-msgid "Application data aggregation"
-msgstr "應用資料彙總"
-
-msgid "Knowledge data aggregation"
-msgstr "知識庫資料彙總"
-
-msgid "Tool data aggregation"
-msgstr "工具資料彙總"
-
+#: no source
+msgid "lark"
+msgstr "飞书"
+
+#: no source
+msgid "Lark application: "
+msgstr "飛書智能體: "
+
+#: no source
+msgid "Lark callback"
+msgstr "飛書回調"
+
+#: no source
+msgid "Lark configuration not found or not active"
+msgstr "Lark 配置未找到或未激活"
+
+#: no source
+msgid "Lark OAuth2 callback"
+msgstr "飛書 OAuth2 回調"
+
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:36
+msgid "Last frame url"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:33
+msgid "Latest flagship model with enhanced reasoning and coding. 204K context window"
+msgstr ""
+
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:48
+msgid "Latest Gemini 1.0 Pro model, updated with Google update"
+msgstr "最新的 Gemini 1.0 Pro 模型，更新了 Google 更新"
+
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:55
+msgid "Latest Gemini 1.0 Pro Vision model, updated with Google update"
+msgstr "最新的Gemini 1.0 Pro Vision模型，隨Google更新而更新"
+
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:65
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:72
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:82
+#: apps/models_provider/impl/gemini_model_provider/gemini_model_provider.py:89
+msgid "Latest Gemini 1.5 Flash model, updated with Google updates"
+msgstr "最新的Gemini 1.5 Flash模型，隨Google更新而更新"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:38
+msgid "Latest gpt-4, updated with OpenAI adjustments"
+msgstr "最新的gpt-4，隨OpenAI調整而更新"
+
+#: no source
+msgid "LDAP configuration not found or not active"
+msgstr "LDAP 配置未找到或未激活"
+
+#: no source
+msgid "LDAP filter cannot be empty"
+msgstr "LDAP過濾器不能為空"
+
+#: no source
+msgid "Ldap Log in"
+msgstr "LDAP 登錄"
+
+#: no source
+msgid "LDAP mapping cannot be empty"
+msgstr "LDAP映射不能為空"
+
+#: no source
+msgid "LDAP server cannot be empty"
+msgstr "LDAP server不能為空"
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:28
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:31
+msgid "Library ID"
+msgstr "工具 ID"
+
+#: no source
+msgid "license details"
+msgstr "license 詳情"
+
+#: no source
+msgid "license file"
+msgstr "license 文件"
+
+#: no source
+msgid "License file is required"
+msgstr "license 文件是必需的"
+
+#: no source
+msgid "License usage limit exceeded."
+msgstr "License 使用限制已超出。"
+
+#: no source
+msgid "license version"
+msgstr "license 版本"
+
+#: apps/chat/views/chat_record.py:29
+#: apps/chat/views/chat_record.py:30
+#: apps/chat/views/chat_record.py:31
+msgid "Like, Dislike"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:37
+#: apps/knowledge/serializers/document.py:198
+msgid "limit"
+msgstr "限制"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:43
+msgid "limit reference"
+msgstr ""
+
+#: apps/common/utils/common.py:322
+msgid "Limit {count} exceeded, please contact us (https://fit2cloud.com/)."
+msgstr "超過限制 {count}，請聯繫我們 (https://fit2cloud.com/)."
+
+#: apps/application/serializers/application_chat_link.py:119
+msgid "Link"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:33
+msgid "List of document ids to exclude"
+msgstr "排除的文檔 ID 列表"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:36
+msgid "List of exclusion vector ids"
+msgstr "排除的向量 ID 列表"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:60
+msgid "Llama 2 is a set of pretrained and fine-tuned generative text models ranging in size from 7 billion to 70 billion. This is a repository of 13B pretrained models. Links to other models can be found in the index at the bottom."
+msgstr "Llama 2 是一組經過預訓練和微調的生成文本模型，其規模從 70 億到 700 億個不等。這是 13B 預訓練模型的存儲庫。其他模型的連結可以在底部的索引中找到。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:64
+msgid "Llama 2 is a set of pretrained and fine-tuned generative text models ranging in size from 7 billion to 70 billion. This is a repository of 70B pretrained models. Links to other models can be found in the index at the bottom."
+msgstr "Llama 2 是一組經過預訓練和微調的生成文本模型，其規模從 70 億到 700 億個不等。這是 70B 預訓練模型的存儲庫。其他模型的連結可以在底部的索引中找到。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:56
+msgid "Llama 2 is a set of pretrained and fine-tuned generative text models ranging in size from 7 billion to 70 billion. This is a repository of 7B pretrained models. Links to other models can be found in the index at the bottom."
+msgstr "Llama 2 是一組經過預訓練和微調的生成文本模型，其規模從 70 億到 700 億個不等。這是 7B 預訓練模型的存儲庫。其他模型的連結可以在底部的索引中找到。"
+
+#: no source
+msgid "Llama-2-13b-chat was developed by Meta AI and is open source. It performs well in scenarios such as coding, reasoning and knowledge application. Llama-2-13b-chat is a native open source version with balanced performance and effect, suitable for conversation scenarios."
+msgstr "Llama-2-13b-chat由Meta AI研發並開源，在編碼、推理及知識智能體等場景表現優秀，Llama-2-13b-chat是性能與效果均衡的原生開源版本，適用於對話場景。"
+
+#: no source
+msgid "Llama-2-70b-chat was developed by Meta AI and is open source. It performs well in scenarios such as coding, reasoning, and knowledge application. Llama-2-70b-chat is a native open source version with high-precision effects."
+msgstr "Llama-2-70b-chat由Meta AI研發並開源，在編碼、推理及知識智能體等場景表現優秀，Llama-2-70b-chat是高精度效果的原生開源版本。"
+
+#: apps/models_provider/base_model_provider.py:147
+msgid "LLM"
+msgstr "大語言模型"
+
+#: no source
+msgid "LOCAL"
+msgstr "帳號登入"
+
+#: apps/models_provider/impl/local_model_provider/local_model_provider.py:40
+msgid "local model"
+msgstr "本地模型"
+
+#: apps/users/views/login.py:38
+#: apps/users/views/login.py:39
+#: apps/users/views/login.py:40
+msgid "Log in"
+msgstr "登錄"
+
+#: apps/common/constants/permission_constants.py:401
+msgid "Login Auth"
+msgstr "登錄認證"
+
+#: apps/common/auth/handle/impl/user_token.py:311
+msgid "Login expired"
+msgstr "登錄已過期"
+
+#: apps/users/serializers/login.py:241
+msgid "Login failed %s times, account will be locked, you have %s more chances !"
+msgstr "登录失败 %s 次，账号将被锁定，您还有 %s 次机会！"
+
+#: no source
+msgid "login image"
+msgstr "登陸圖片"
+
+#: no source
+msgid "login logo"
+msgstr "登錄 logo"
+
+#: no source
+msgid "Long Fei"
+msgstr "龍飛"
+
+#: no source
+msgid "Long Jielidou"
+msgstr "龍傑力豆"
+
+#: no source
+msgid "Long Jing"
+msgstr "龍婧"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:31
+msgid "Long Laotie"
+msgstr "龍老鐵"
+
+#: no source
+msgid "Long Miao"
+msgstr "龍妙"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:32
+msgid "Long Shu"
+msgstr "龍書"
+
+#: no source
+msgid "Long Shuo"
+msgstr "龍碩"
+
+#: no source
+msgid "Long Tong"
+msgstr "龍彤"
+
+#: no source
+msgid "Long Xiang"
+msgstr "龍祥"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:30
+msgid "Long Xiaobai"
+msgstr "龍小白"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:29
+msgid "Long Xiaochen"
+msgstr "龍小誠"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:27
+msgid "Long Xiaochun"
+msgstr "龍小淳"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:28
+msgid "Long Xiaoxia"
+msgstr "龍小夏"
+
+#: no source
+msgid "Long Yuan"
+msgstr "龍媛"
+
+#: no source
+msgid "Long Yue"
+msgstr "龍悅"
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:20
+msgid "loop_type"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:26
+msgid "Malay language"
+msgstr "馬來語"
+
+#: apps/system_manage/views/resource_mapping.py:67
+msgid "Mapping Resource"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:37
+msgid "Maximum length of the knowledge base paragraph"
+msgstr "知識庫段落的最大長度"
+
+#: apps/application/serializers/application.py:209
+msgid "Maximum number of quoted characters"
+msgstr "引用字符的最大數量"
+
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:27
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:33
+msgid "Maximum number of words in a quoted segment"
+msgstr "引用段落的最大字數"
+
+#: apps/tools/serializers/tool.py:168
+msgid "MCP configuration is invalid"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:38
+msgid "MCP Server"
+msgstr ""
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:14
+msgid "Mcp server"
+msgstr ""
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:13
+msgid "Mcp servers"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:42
+msgid "MCP Source"
+msgstr ""
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:17
+msgid "Mcp source"
+msgstr ""
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:15
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:16
+msgid "Mcp tool"
+msgstr "Mcp 工具"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:39
+msgid "MCP Tool ID"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:41
+msgid "MCP Tool IDs"
+msgstr ""
+
+#: no source
+msgid "Members"
+msgstr "成員集合"
+
+#: no source
+msgid "menu"
+msgstr "菜單"
+
+#: no source
+msgid "Menu"
+msgstr "菜單"
+
+#: no source
+msgid "menu_label"
+msgstr "菜單標籤"
+
+#: no source
+msgid "message"
+msgstr "消息"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:99
+msgid "message type error"
+msgstr "消息類型錯誤"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:36
+#: apps/common/field/common.py:24
+#: apps/common/field/common.py:37
+msgid "Message type error"
+msgstr "消息類型錯誤"
+
+#: no source
+msgid "Message types not supported yet"
+msgstr "消息類型暫不支持"
+
+#: apps/tools/serializers/tool.py:1572
+msgid "Messages"
+msgstr ""
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:76
+msgid "Meta Llama 3: The most capable public product LLM to date. 70 billion parameters."
+msgstr "Meta Llama 3：迄今為止最有能力的公開產品LLM。700億參數。"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:72
+msgid "Meta Llama 3: The most capable public product LLM to date. 8 billion parameters."
+msgstr "Meta Llama 3：迄今為止最有能力的公開產品LLM。80億參數。"
+
+#: apps/local_model/serializers/model_apply_serializers.py:105
+#: apps/models_provider/serializers/model_apply_serializers.py:42
+msgid "metadata"
+msgstr "元數據"
+
+#: apps/models_provider/api/provide.py:39
+msgid "method"
+msgstr "方法"
+
+#: apps/common/constants/permission_constants.py:368
+msgid "Migrate"
+msgstr "遷移"
+
+#: apps/knowledge/views/document.py:1154
+#: apps/knowledge/views/document.py:1155
+msgid "Migrate documents in batches"
+msgstr "批量遷移文檔"
+
+#: apps/knowledge/views/paragraph.py:105
+#: apps/knowledge/views/paragraph.py:106
+msgid "Migrate paragraphs in batches"
+msgstr "批量遷移段落"
+
+#: no source
+msgid "Migrate shared documents in batches"
+msgstr "批量遷移共享文檔"
+
+#: no source
+msgid "Migrate shared paragraphs in batches"
+msgstr "批量遷移共享段落"
+
+#: no source
+msgid "Migrate system knowledges in batches"
+msgstr "批量遷移知識庫"
+
+#: no source
+msgid "Migrate system paragraphs in batches"
+msgstr "批量遷移段落"
+
+#: apps/application/api/application_chat.py:82
+#: apps/application/serializers/application_chat.py:62
+msgid "Minimum number of clicks"
+msgstr "最小點擊數"
+
+#: apps/application/api/application_chat.py:76
+#: apps/application/serializers/application_chat.py:60
+msgid "Minimum number of likes"
+msgstr "最小點讚數"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:95
+msgid "Mixed element visual model"
+msgstr "混元視覺模型"
+
+#: apps/application/serializers/application.py:348
+#: apps/application/serializers/application.py:595
+#: apps/chat/serializers/chat.py:156
+#: apps/common/constants/permission_constants.py:342
+#: apps/common/constants/permission_constants.py:411
+#: apps/common/constants/permission_constants.py:421
+#: apps/common/constants/permission_constants.py:436
+#: apps/models_provider/views/model.py:64
+#: apps/models_provider/views/model.py:86
+#: apps/models_provider/views/model.py:99
+#: apps/models_provider/views/model.py:120
+#: apps/models_provider/views/model.py:143
+#: apps/models_provider/views/model.py:164
+#: apps/models_provider/views/model.py:186
+#: apps/models_provider/views/model.py:207
+#: apps/models_provider/views/model.py:234
+#: apps/models_provider/views/model.py:256
+#: apps/models_provider/views/model.py:301
+#: apps/models_provider/views/model_apply.py:29
+#: apps/models_provider/views/model_apply.py:41
+#: apps/models_provider/views/model_apply.py:53
+#: apps/models_provider/views/provide.py:25
+#: apps/models_provider/views/provide.py:48
+#: apps/models_provider/views/provide.py:62
+#: apps/models_provider/views/provide.py:80
+#: apps/models_provider/views/provide.py:97
+msgid "Model"
+msgstr "模型"
+
+#: no source
+msgid "model"
+msgstr "模型"
+
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:52
+#: apps/models_provider/impl/local_model_provider/credential/embedding/web.py:37
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:64
+#: apps/models_provider/impl/local_model_provider/credential/reranker/web.py:37
+msgid "Model catalog"
+msgstr "模型目錄"
+
+#: apps/homepage/views/homepage.py:322
+#: apps/homepage/views/homepage.py:323
 msgid "Model data aggregation"
 msgstr "模型資料彙總"
 
-msgid "Total application count"
-msgstr "應用總數"
+#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:65
+#: apps/application/serializers/application.py:241
+#: apps/application/serializers/application.py:1285
+#: apps/application/serializers/application.py:1291
+#: apps/application/serializers/application.py:1297
+#: apps/application/serializers/application.py:1303
+#: apps/knowledge/serializers/document.py:861
+#: apps/knowledge/serializers/knowledge.py:344
+#: apps/models_provider/serializers/model_serializer.py:140
+#: apps/models_provider/serializers/model_serializer.py:160
+#: apps/models_provider/serializers/model_serializer.py:498
+#: apps/models_provider/tools.py:116
+msgid "Model does not exist"
+msgstr "模型不存在"
 
-msgid "Published application count"
-msgstr "已發布應用數量"
+#: apps/chat/serializers/chat.py:188
+#: apps/tools/serializers/tool.py:1602
+msgid "Model does not exists or is not an LLM model"
+msgstr ""
 
-msgid "Unpublished application count"
-msgstr "未發布應用數量"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:56
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:29
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:19
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:13
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:13
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:14
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:19
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:22
+#: apps/application/flow/step_node/question_node/i_question_node.py:19
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:13
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:14
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:13
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:13
+#: apps/application/serializers/application.py:228
+#: apps/application/serializers/application.py:465
+#: apps/application/serializers/application.py:465
+#: apps/knowledge/serializers/common.py:77
+msgid "Model id"
+msgstr "模型ID"
 
-msgid "Total knowledge count"
-msgstr "知識庫總數"
+#: apps/knowledge/serializers/document.py:237
+#: apps/knowledge/serializers/paragraph.py:93
+#: apps/local_model/serializers/model_apply_serializers.py:129
+#: apps/models_provider/api/model.py:105
+#: apps/models_provider/serializers/model_apply_serializers.py:51
+#: apps/models_provider/serializers/model_serializer.py:128
+#: apps/models_provider/serializers/model_serializer.py:481
+msgid "model id"
+msgstr "模型ID"
 
-msgid "Total document count"
-msgstr "文件總數"
+#: apps/tools/serializers/tool.py:1570
+msgid "Model ID"
+msgstr ""
 
-msgid "Failed document count"
-msgstr "失敗文件數量"
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:20
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:14
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:14
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:15
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:20
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:23
+#: apps/application/flow/step_node/question_node/i_question_node.py:20
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:14
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:15
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:14
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:14
+msgid "Model id type"
+msgstr ""
 
-msgid "Total tool count"
-msgstr "工具總數"
+#: apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py:205
+#: apps/application/flow/step_node/image_generate_step_node/impl/base_image_generate_node.py:41
+#: apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py:44
+#: apps/application/flow/step_node/image_understand_step_node/impl/base_image_understand_node.py:157
+#: apps/application/flow/step_node/intent_node/impl/base_intent_node.py:67
+#: apps/application/flow/step_node/parameter_extraction_node/impl/base_parameter_extraction_node.py:99
+#: apps/application/flow/step_node/question_node/impl/base_question_node.py:98
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:77
+#: apps/application/flow/step_node/speech_to_text_step_node/impl/base_speech_to_text_node.py:39
+#: apps/application/flow/step_node/text_to_speech_step_node/impl/base_text_to_speech_node.py:63
+#: apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py:44
+#: apps/application/flow/step_node/video_understand_step_node/impl/base_video_understand_node.py:154
+msgid "Model is not allowed to be empty"
+msgstr "模型不能为空"
 
-msgid "Active tool count"
-msgstr "啟用工具數量"
+#: apps/models_provider/api/model.py:37
+#: apps/models_provider/api/provide.py:17
+#: apps/models_provider/api/provide.py:23
+#: apps/models_provider/api/provide.py:28
+#: apps/models_provider/api/provide.py:30
+#: apps/models_provider/api/provide.py:82
+#: apps/models_provider/serializers/model_serializer.py:63
+#: apps/models_provider/serializers/model_serializer.py:248
+#: apps/models_provider/serializers/model_serializer.py:285
+#: apps/models_provider/serializers/model_serializer.py:359
+#: apps/models_provider/serializers/model_serializer.py:542
+msgid "model name"
+msgstr "模型名稱"
 
-msgid "Inactive tool count"
-msgstr "停用工具數量"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:85
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:33
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:32
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:33
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:32
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:27
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:20
+#: apps/application/flow/step_node/question_node/i_question_node.py:33
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:23
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:23
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:32
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:31
+msgid "Model parameter settings"
+msgstr "模型參數設置"
 
-msgid "Total model count"
-msgstr "模型總數"
+#: apps/application/serializers/application.py:382
+#: apps/application/serializers/application.py:613
+msgid "Model parameters"
+msgstr "模型參數"
 
-msgid "Active model count"
-msgstr "啟用模型數量"
+#: apps/tools/serializers/tool.py:1573
+msgid "Model Params Setting"
+msgstr ""
 
-msgid "Inactive model count"
-msgstr "停用模型數量"
+#: apps/models_provider/serializers/model_serializer.py:349
+msgid "Model saving failed"
+msgstr "模型保存失敗"
 
-msgid "Top applications by token consumption"
-msgstr "tokens 消耗 TOP 智慧體"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:82
+msgid "Model settings"
+msgstr "模型設置"
 
-msgid "Top applications by question count"
-msgstr "提問次數 TOP 智慧體"
+#: apps/application/serializers/application.py:608
+msgid "Model setup"
+msgstr "模型設置"
 
-msgid "Top users by token consumption"
-msgstr "tokens 消耗 TOP 使用者"
+#: apps/models_provider/api/model.py:44
+#: apps/models_provider/api/provide.py:29
+#: apps/models_provider/api/provide.py:70
+#: apps/models_provider/api/provide.py:98
+#: apps/models_provider/serializers/model_serializer.py:65
+#: apps/models_provider/serializers/model_serializer.py:250
+#: apps/models_provider/serializers/model_serializer.py:287
+#: apps/models_provider/serializers/model_serializer.py:360
+#: apps/models_provider/serializers/model_serializer.py:543
+msgid "model type"
+msgstr "模型類型"
 
-msgid "Application tokens ranking list"
-msgstr "應用 tokens 消耗排行榜列表"
+#: apps/models_provider/base_model_provider.py:60
+msgid "Model type cannot be empty"
+msgstr "模型類型不能為空"
 
-msgid "Application question ranking list"
-msgstr "應用提問次數排行榜列表"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:26
+msgid "Model type error"
+msgstr "模型類型錯誤"
 
-msgid "User tokens ranking list"
-msgstr "使用者 tokens 消耗排行榜列表"
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:34
+msgid "Model type is not supported"
+msgstr ""
 
-msgid "Application name"
-msgstr "應用名稱"
+#: no source
+msgid "Models Resource"
+msgstr "模型資源"
 
-msgid "Total consumed tokens"
-msgstr "消耗 tokens 總數"
+#: apps/local_model/serializers/model_apply_serializers.py:114
+msgid "model_name"
+msgstr ""
 
-msgid "Question count"
-msgstr "提問次數"
+#: apps/models_provider/serializers/model_serializer.py:517
+msgid "model_params_form must be a list"
+msgstr "model_params_form 必须是一个列表"
 
-msgid "Chat user ID"
-msgstr "對話使用者 ID"
+#: apps/local_model/serializers/model_apply_serializers.py:116
+msgid "model_type"
+msgstr ""
 
-msgid "Chat user type"
-msgstr "對話使用者類型"
+#: apps/application/serializers/application.py:470
+#: apps/application/serializers/application.py:470
+msgid "Modification time"
+msgstr "修改時間"
 
-msgid "Asker user information"
-msgstr "提問使用者資訊"
+#: apps/application/views/application_access_token.py:38
+#: apps/application/views/application_access_token.py:39
+#: apps/application/views/application_access_token.py:40
+msgid "Modify application access restriction information"
+msgstr "修改智能體訪問限制信息"
 
-msgid "Termbase"
-msgstr "詞庫"
+#: no source
+msgid "Modify application access token"
+msgstr "修改智能體程序訪問權杖"
 
-msgid "Copy"
-msgstr "複製"
+#: apps/application/views/application_api_key.py:83
+#: apps/application/views/application_api_key.py:84
+#: apps/application/views/application_api_key.py:85
+msgid "Modify application API_KEY"
+msgstr "修改智能體 API 密鑰"
 
-msgid "ranking"
-msgstr "排名"
+#: no source
+msgid "Modify Application Settings"
+msgstr "修改智能體設置"
 
-msgid "Token consumption"
-msgstr "Token消耗"
+#: apps/application/views/application_version.py:100
+#: apps/application/views/application_version.py:101
+#: apps/application/views/application_version.py:102
+msgid "Modify application version information"
+msgstr "修改智能體版本信息"
 
-msgid "proportion"
-msgstr "占比"
+#: apps/chat/views/chat_record.py:68
+#: apps/chat/views/chat_record.py:69
+#: apps/chat/views/chat_record.py:70
+msgid "Modify conversation about"
+msgstr ""
 
+#: apps/users/views/user.py:374
+#: apps/users/views/user.py:375
+#: apps/users/views/user.py:376
+msgid "Modify current user password"
+msgstr "修改當前用戶密碼"
+
+#: apps/knowledge/views/document.py:152
+#: apps/knowledge/views/document.py:153
+#: apps/knowledge/views/document.py:154
+msgid "Modify document"
+msgstr "修改文檔"
+
+#: apps/knowledge/views/document.py:287
+#: apps/knowledge/views/document.py:288
+#: apps/knowledge/views/document.py:289
+msgid "Modify document hit processing methods in batches"
+msgstr "批量修改文檔命中處理方法"
+
+#: no source
+msgid "Modify knowledge base information"
+msgstr "修改知識庫信息"
+
+#: apps/knowledge/views/knowledge_workflow_version.py:110
+#: apps/knowledge/views/knowledge_workflow_version.py:111
+#: apps/knowledge/views/knowledge_workflow_version.py:112
+msgid "Modify knowledge version information"
+msgstr ""
+
+#: apps/knowledge/views/paragraph.py:175
+#: apps/knowledge/views/paragraph.py:176
+#: apps/knowledge/views/paragraph.py:177
+msgid "Modify paragraph data"
+msgstr "修改段落數據"
+
+#: no source
+msgid "Modify platform information"
+msgstr "修改平臺信息"
+
+#: apps/knowledge/views/problem.py:198
+#: apps/knowledge/views/problem.py:199
+#: apps/knowledge/views/problem.py:200
+msgid "Modify question"
+msgstr "修改問題"
+
+#: no source
+msgid "Modify shared document"
+msgstr "修改共享文檔"
+
+#: no source
+msgid "Modify shared document hit processing methods in batches"
+msgstr "批量修改文檔命中處理方法"
+
+#: no source
+msgid "Modify shared paragraph data"
+msgstr "修改段落數據"
+
+#: no source
+msgid "Modify shared question"
+msgstr "修改問題"
+
+#: no source
+msgid "Modify system document"
+msgstr "修改文檔"
+
+#: no source
+msgid "Modify system document hit processing methods in batches"
+msgstr "批量修改文檔命中處理方式"
+
+#: no source
+msgid "Modify system paragraph data"
+msgstr "修改段落數據"
+
+#: no source
+msgid "Modify system question"
+msgstr "修改問題"
+
+#: apps/knowledge/views/termbase.py:199
+#: apps/knowledge/views/termbase.py:200
+#: apps/knowledge/views/termbase.py:201
+msgid "Modify termbase"
+msgstr ""
+
+#: apps/application/views/application.py:195
+#: apps/application/views/application.py:196
+#: apps/application/views/application.py:197
+msgid "Modify the application"
+msgstr "修改智能體"
+
+#: apps/system_manage/views/user_resource_permission.py:61
+#: apps/system_manage/views/user_resource_permission.py:62
+msgid "Modify the resource authorization list"
+msgstr "修改資源授權列表"
+
+#: no source
+msgid "Modify the System task source trigger"
+msgstr "修改系統任務來源觸發器"
+
+#: apps/trigger/views/trigger.py:342
+#: apps/trigger/views/trigger.py:343
+#: apps/trigger/views/trigger.py:344
+msgid "Modify the task source trigger"
+msgstr "修改任務來源觸發器"
+
+#: apps/trigger/views/trigger.py:127
+#: apps/trigger/views/trigger.py:128
+#: apps/trigger/views/trigger.py:129
+msgid "Modify the trigger"
+msgstr "修改觸發器"
+
+#: apps/tools/views/tool_workflow_version.py:111
+#: apps/tools/views/tool_workflow_version.py:112
+#: apps/tools/views/tool_workflow_version.py:113
+msgid "Modify tool version information"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:38
+msgid "monster style"
+msgstr "怪獸風格"
+
+#: apps/application/views/application.py:245
+#: apps/application/views/application.py:246
+#: apps/application/views/application.py:247
+msgid "Move an application"
+msgstr "移動應用程序"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:37
+msgid "Multiple dialects, supporting 23 dialects"
+msgstr "多種方言，支持 23 種方言"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:97
+#: apps/tools/serializers/tool_workflow.py:128
+#: apps/users/serializers/user.py:396
+msgid "Name"
+msgstr "用戶名"
+
+#: no source
+msgid "Network error or folder token error!"
+msgstr "網絡錯誤或文件夾令牌錯誤！"
+
+#: no source
+msgid "New chat"
+msgstr "已生成新對話，請重新提問！"
+
+#: apps/knowledge/serializers/paragraph.py:802
+msgid "new_position must be an integer"
+msgstr "new_position 必須是整數"
+
+#: apps/users/serializers/user.py:68
+#: apps/users/serializers/user.py:199
+msgid "Nick name"
+msgstr "暱稱"
+
+#: apps/users/serializers/user.py:242
+msgid "Nick Name"
+msgstr ""
+
+#: no source
+msgid "Nickname"
+msgstr "暱稱"
+
+#: apps/users/serializers/user.py:419
+msgid "Nickname is already in use"
+msgstr "Nickname已被使用"
+
+#: apps/system_manage/api/user_resource_permission.py:117
+msgid "nick_name"
+msgstr ""
+
+#: apps/application/serializers/application.py:259
+msgid "No citation segmentation prompt"
+msgstr "無引用段落提示"
+
+#: apps/oss/views/file.py:85
+msgid "No permission"
+msgstr ""
+
+#: apps/folders/serializers/folder.py:228
+msgid "No permission for the target folder"
+msgstr "沒有目標資料夾的權限"
+
+#: apps/application/serializers/application_chat_record.py:293
+#: apps/application/serializers/application_chat_record.py:430
+#: apps/application/serializers/application_chat_record.py:504
+#: apps/common/auth/authentication.py:139
+msgid "No permission to access"
+msgstr "無權限訪問"
+
+#: no source
+msgid "No permission to use this function {name}"
+msgstr "無權限使用此工具 {name}"
+
+#: no source
+msgid "No permission to use this model {model_name}"
+msgstr "無權限使用此模型{model_name}"
+
+#: apps/application/serializers/application.py:137
+#: apps/application/serializers/application.py:788
+msgid "No permission to use tool(s): {tool_ids}"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:77
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:47
+msgid "No reference segment settings"
+msgstr "無參考段設置"
+
+#: apps/application/serializers/application.py:201
+msgid "No reference status"
+msgstr "無參考狀態"
+
+#: apps/chat/serializers/chat.py:83
+msgid "Node id"
+msgstr "節點 ID"
+
+#: apps/chat/serializers/chat.py:89
+msgid "Node parameters"
+msgstr "節點參數"
+
+#: apps/application/flow/common.py:267
+msgid "Node {node} is unavailable"
+msgstr "節點 {node} 不可用"
+
+#: no source
+msgid "Non-existent application|knowledge base id["
+msgstr "不存在的智能體|知識庫 ID["
+
+#: apps/chat/serializers/chat_record.py:178
+msgid "Non-existent chatID"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:64
+msgid "Non-existent conversation chat_record_id"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:82
+msgid "Non-existent id"
+msgstr "不存在的ID"
+
+#: apps/common/field/common.py:48
+msgid "not a function"
+msgstr "不是函數"
+
+#: apps/knowledge/serializers/knowledge.py:904
+msgid "Not a valid KB export file, missing knowledge.json"
+msgstr "不是有效的知識庫匯出檔案，缺少 knowledge.json"
+
+#: apps/knowledge/serializers/knowledge.py:906
+msgid "Not a valid KB export file, missing knowledge.xlsx"
+msgstr "不是有效的知識庫匯出檔案，缺少 knowledge.xlsx"
+
+#: apps/knowledge/serializers/knowledge.py:899
+msgid "Not a valid zip file"
+msgstr "不是有效的 zip 檔案"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:17
+msgid "Not limited to style"
+msgstr "不限於風格"
+
+#: apps/common/auth/authenticate.py:82
+#: apps/common/auth/authenticate.py:108
+#: apps/common/auth/authenticate.py:134
+msgid "Not logged in, please log in first"
+msgstr "未登錄，請先登錄"
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:24
+msgid "number"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:41
+#: apps/application/serializers/application_stats.py:28
+msgid "Number of conversations"
+msgstr "對話數量"
+
+#: apps/application/serializers/application_chat.py:42
+#: apps/application/serializers/application_stats.py:32
+msgid "Number of Likes"
+msgstr "點讚數量"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:34
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:27
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:23
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:24
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:22
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:25
+#: apps/application/flow/step_node/question_node/i_question_node.py:28
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:23
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:21
+msgid "Number of multi-round conversations"
+msgstr "多輪對話的數量"
+
+#: apps/application/serializers/application_stats.py:29
+msgid "Number of new users"
+msgstr "新用戶數量"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:35
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:39
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:20
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:42
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:41
+msgid "Number of pictures"
+msgstr "圖片數量"
+
+#: apps/homepage/serializers/homepage.py:305
+#: apps/homepage/serializers/homepage.py:490
+#: apps/homepage/serializers/homepage.py:628
 msgid "number of questions"
 msgstr "提問次數"
 
-msgid "active users"
-msgstr "活躍用戶數"
+#: apps/application/serializers/application_chat.py:44
+msgid "Number of tags"
+msgstr "標籤數量"
 
-msgid "Average tokens per request"
-msgstr "單次請求平均Token數"
+#: apps/application/serializers/application_chat.py:43
+#: apps/application/serializers/application_stats.py:34
+msgid "Number of thumbs-downs"
+msgstr "點踩數量"
 
-msgid "Average Number of Conversation Turns per Person"
-msgstr "人均對話輪次"
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:18
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:15
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:24
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:24
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:24
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:24
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:17
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:16
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:22
+msgid "Number of top documents to return after reranking"
+msgstr ""
 
+#: apps/application/flow/step_node/data_source_local_node/i_data_source_local_node.py:21
+msgid "Number of uploaded files"
+msgstr ""
+
+#: apps/application/serializers/application_access_token.py:29
+msgid "Number of visits"
+msgstr "訪問次數"
+
+#: no source
+msgid "OAuth2 Log in"
+msgstr "OAuth2 登錄"
+
+#: apps/system_manage/views/user_resource_permission.py:43
+#: apps/system_manage/views/user_resource_permission.py:44
+msgid "Obtain resource authorization list"
+msgstr "獲取資源授權列表"
+
+#: apps/system_manage/views/user_resource_permission.py:85
+#: apps/system_manage/views/user_resource_permission.py:86
+#: apps/system_manage/views/user_resource_permission.py:87
+msgid "Obtain resource authorization list by page"
+msgstr "分頁獲取資源授權清單"
+
+#: no source
+msgid "OIDC Log in"
+msgstr "OIDC 登錄"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:20
+msgid "Oil painting 1"
+msgstr "油畫1"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:21
+msgid "Oil Painting 2 (Van Gogh)"
+msgstr "油畫2（梵谷）"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:25
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:55
+msgid "Online TTS"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:288
+msgid "Online Usage"
+msgstr "線上使用"
+
+#: no source
+msgid "Only shared knowledge can be authorized"
+msgstr "僅限共享知識庫可以被授權"
+
+#: no source
+msgid "Only shared tools can be authorized"
+msgstr "僅限共享工具可以被授權"
+
+#: no source
+msgid "Only shared tools can be deleted"
+msgstr "僅限共享工具可以被刪除"
+
+#: apps/application/serializers/application.py:1013
+#: apps/common/utils/tool_code.py:385
+#: apps/knowledge/serializers/knowledge_workflow.py:666
+#: apps/tools/serializers/tool_workflow.py:396
+msgid "Only support transport=sse or transport=streamable_http"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:65
+msgid "Only supports and|or"
+msgstr "只支持 與|或"
+
+#: no source
+msgid "Only update members to normal users"
+msgstr "只能為普通用戶更新成員"
+
+#: apps/chat/views/chat.py:74
+#: apps/chat/views/chat.py:75
+#: apps/chat/views/chat.py:76
+msgid "OpenAI Interface Dialogue"
+msgstr ""
+
+#: apps/application/serializers/application.py:300
+#: apps/application/serializers/application.py:353
+#: apps/application/serializers/application.py:600
+msgid "Opening remarks"
+msgstr "開始提示"
+
+#: no source
+msgid "operate"
+msgstr "操作"
+
+#: no source
+msgid "Operate"
+msgstr "操作"
+
+#: no source
+msgid "Operate Time"
+msgstr "操作時間"
+
+#: no source
+msgid "Operate user"
+msgstr "操作用戶"
+
+#: no source
+msgid "operate_label"
+msgstr "操作標籤"
+
+#: apps/common/constants/permission_constants.py:337
+msgid "Operation Log"
+msgstr "操作日誌"
+
+#: apps/application/serializers/application_api_key.py:39
+#: apps/knowledge/serializers/document.py:483
+msgid "order by"
+msgstr "排序"
+
+#: apps/trigger/serializers/trigger_task.py:131
+msgid "Order field"
+msgstr "排序欄位"
+
+#: apps/application/serializers/application_chat.py:174
+#: apps/chat/serializers/chat.py:95
+#: apps/common/constants/permission_constants.py:338
+#: apps/common/constants/permission_constants.py:345
+msgid "Other"
+msgstr "其他"
+
+#: apps/application/serializers/application_chat.py:217
+msgid "Other reason content"
+msgstr "其他反饋理由內容"
+
+#: no source
+msgid "OU cannot be empty"
+msgstr "OU不能為空"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:30
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:29
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:24
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:23
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:26
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:42
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:26
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:24
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:24
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:21
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:29
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:26
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:27
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:26
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:31
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:24
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:24
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:49
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:24
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:24
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:24
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:30
+msgid "Output the maximum Tokens"
+msgstr "輸出最大Token數"
+
+#: apps/common/constants/permission_constants.py:395
+#: apps/common/constants/permission_constants.py:408
+#: apps/common/constants/permission_constants.py:439
+msgid "Overview"
+msgstr "概覽"
+
+#: apps/knowledge/views/knowledge_workflow.py:140
+#: apps/knowledge/views/knowledge_workflow.py:141
+#: apps/knowledge/views/knowledge_workflow.py:142
+msgid "Page Knowledge workflow action"
+msgstr ""
+
+#: apps/application/api/application_api.py:61
+#: apps/application/api/application_chat.py:117
+#: apps/application/api/application_chat_record.py:81
+#: apps/homepage/api/home_page_api.py:103
+#: apps/system_manage/api/resource_mapping.py:63
+#: apps/system_manage/api/user_resource_permission.py:214
+#: apps/system_manage/api/user_resource_permission.py:280
+#: apps/trigger/api/trigger.py:100
+#: apps/trigger/api/trigger_task.py:109
+msgid "Page size"
+msgstr "每頁大小"
+
+#: apps/common/result/api.py:45
+msgid "page size"
+msgstr "每頁大小"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:54
+msgid "painting"
+msgstr "油畫"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:13
+msgid "painting style"
+msgstr "繪畫風格"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:26
+msgid "paper cut style"
+msgstr "剪紙風格"
+
+#: no source
+msgid "Paragraph"
+msgstr "段落"
+
+#: apps/application/serializers/application_chat_record.py:241
+msgid "Paragraph content"
+msgstr "段落內容"
+
+#: apps/knowledge/serializers/paragraph.py:490
+msgid "Paragraph does not exist"
+msgstr "段落不存在"
+
+#: apps/application/api/application_chat_record.py:148
+msgid "Paragraph ID"
+msgstr "段落 ID"
+
+#: apps/application/serializers/application_chat_record.py:480
+msgid "Paragraph id"
+msgstr "段落 ID"
+
+#: apps/knowledge/serializers/paragraph.py:91
+#: apps/knowledge/serializers/paragraph.py:110
+#: apps/knowledge/serializers/paragraph.py:202
+#: apps/knowledge/serializers/paragraph.py:476
+#: apps/knowledge/serializers/paragraph.py:609
+#: apps/knowledge/serializers/paragraph.py:781
+#: apps/knowledge/serializers/problem.py:36
+#: apps/knowledge/serializers/problem.py:51
+msgid "paragraph id"
+msgstr "段落 ID"
+
+#: apps/knowledge/serializers/paragraph.py:125
+#: apps/knowledge/serializers/paragraph.py:221
+msgid "Paragraph id does not exist"
+msgstr "段落 ID 不存在"
+
+#: apps/knowledge/serializers/paragraph.py:91
+#: apps/knowledge/serializers/paragraph.py:608
+msgid "paragraph id list"
+msgstr "段落 ID 列表"
+
+#: apps/knowledge/serializers/knowledge.py:773
+msgid "Paragraph is active"
+msgstr "段落是否啟用"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:58
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:29
+msgid "Paragraph List"
+msgstr "段落列表"
+
+#: apps/knowledge/views/paragraph.py:24
+#: apps/knowledge/views/paragraph.py:25
+#: apps/knowledge/views/paragraph.py:26
+msgid "Paragraph list"
+msgstr "段落列表"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:22
+msgid "paragraph title relate problem"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:25
+msgid "paragraph title relate problem reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:18
+msgid "paragraph title relate problem type"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:67
+#: apps/models_provider/serializers/model_serializer.py:289
+msgid "parameter configuration"
+msgstr "參數配置"
+
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:40
+msgid "Parameter value error: The uploaded audio lacks file_id, and the audio upload fails"
+msgstr "參數錯誤：上傳的音頻缺少 file_id，音頻上傳失敗"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:81
+msgid "Parameter value error: The uploaded audio lacks file_id, and the audio upload fails."
+msgstr "參數值錯誤：上傳的音頻缺少 file_id，音頻上傳失敗"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:62
+msgid "Parameter value error: The uploaded document lacks file_id, and the document upload fails"
+msgstr "參數值錯誤：上傳的文檔缺少 file_id，文檔上傳失敗"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:71
+msgid "Parameter value error: The uploaded image lacks file_id, and the image upload fails"
+msgstr "參數值錯誤：上傳的圖片缺少 file_id，圖片上傳失敗"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:91
+msgid "Parameter value error: The uploaded video lacks file_id, and the video upload fails."
+msgstr ""
+
+#: apps/folders/models/folder.py:12
+#: apps/folders/models/folder.py:23
+#: apps/folders/serializers/folder.py:131
+msgid "parent id"
+msgstr "父級 ID"
+
+#: apps/system_manage/serializers/email_setting.py:34
+#: apps/users/api/login.py:27
+#: apps/users/api/user.py:93
+#: apps/users/serializers/login.py:33
+#: apps/users/serializers/user.py:66
+#: apps/users/serializers/user.py:185
+#: apps/users/serializers/user.py:429
+#: apps/users/serializers/user.py:977
+#: apps/users/serializers/user.py:1035
+msgid "Password"
+msgstr "密碼"
+
+#: no source
+msgid "password"
+msgstr "密码登录"
+
+#: apps/common/constants/exception_code_constants.py:43
+msgid "Password and confirmation password are inconsistent"
+msgstr "密碼和確認密碼不一致"
+
+#: no source
+msgid "Password cannot be empty"
+msgstr "密碼不能為空"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:53
+#: apps/knowledge/serializers/document.py:200
+#: apps/knowledge/serializers/document.py:200
+msgid "patterns"
+msgstr "分割符"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:59
+msgid "patterns reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:56
+msgid "patterns type"
+msgstr ""
+
+#: apps/models_provider/views/model.py:250
+#: apps/models_provider/views/model.py:251
+#: apps/models_provider/views/model.py:252
+msgid "Pause model download"
+msgstr "下載模型暫停"
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:56
+msgid "Peak Performance. Ultimate Value. 204K context window"
+msgstr ""
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:72
+msgid "Perfecting tonal nuances with maximized timbre similarity"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1308
+msgid "period"
+msgstr "句號"
+
+#: apps/system_manage/api/user_resource_permission.py:28
+#: apps/system_manage/api/user_resource_permission.py:119
+#: apps/system_manage/serializers/user_resource_permission.py:53
+#: apps/system_manage/serializers/user_resource_permission.py:64
+#: apps/system_manage/serializers/user_resource_permission.py:104
+#: apps/system_manage/serializers/user_resource_permission.py:302
+#: apps/system_manage/serializers/user_resource_permission.py:308
+msgid "permission"
+msgstr ""
+
+#: no source
+msgid "Permission"
+msgstr "權限"
+
+#: apps/users/serializers/user.py:57
+msgid "permissions"
+msgstr "無權限訪問"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:153
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:193
+msgid "Phi-3 Mini is Microsoft's 3.8B parameter, lightweight, state-of-the-art open model."
+msgstr "Phi-3 Mini是Microsoft的3.8B參數，輕量級，最先進的開放模型。"
+
+#: apps/users/serializers/user.py:69
+#: apps/users/serializers/user.py:204
+#: apps/users/serializers/user.py:401
+msgid "Phone"
+msgstr "手機"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:50
+msgid "photography"
+msgstr "攝影"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:54
+#: apps/application/flow/step_node/application_node/i_application_node.py:21
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:29
+#: apps/chat/serializers/chat.py:92
+#: apps/tools/serializers/tool.py:1153
+msgid "picture"
+msgstr "圖片"
+
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:27
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:28
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:28
+msgid "Picture quality"
+msgstr "圖片質量"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:23
+msgid "pixel art"
+msgstr "像素畫"
+
+#: no source
+msgid "Platform configuration"
+msgstr "平臺配置"
+
+#: no source
+msgid "Platform does not exist"
+msgstr "平臺不存在"
+
+#: no source
+msgid "Platform type"
+msgstr "平臺類型"
+
+#: apps/application/views/application.py:514
+#: apps/application/views/application.py:515
+#: apps/application/views/application.py:516
+msgid "PlayDemo"
+msgstr ""
+
+#: no source
+msgid "Please analyze the content of the image."
+msgstr "請分析圖片內容。"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:23
+msgid "Please enter the Web root address"
+msgstr "請輸入 Web 根地址"
+
+#: apps/common/constants/exception_code_constants.py:32
+msgid "Please log in first and bring the user Token"
+msgstr "請先登錄並攜帶用戶 Token"
+
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:41
+msgid "Please outline this picture"
+msgstr "請描述這張圖片"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:54
+msgid "Please select a system voice supported by Qwen-TTS"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:51
+msgid "Portraits"
+msgstr "人像寫真"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:30
+msgid "Portuguese"
+msgstr "葡萄牙語"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:65
+msgid "Post-processor"
+msgstr "後置處理器"
+
+#: apps/application/serializers/application.py:460
+#: apps/application/serializers/application.py:460
+msgid "Primary key id"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:359
+#: apps/common/constants/permission_constants.py:417
+#: apps/common/constants/permission_constants.py:427
+msgid "Problem"
+msgstr "問題"
+
+#: apps/knowledge/api/problem.py:40
+#: apps/knowledge/api/problem.py:53
+#: apps/knowledge/api/termbase.py:39
+#: apps/knowledge/api/termbase.py:46
+#: apps/knowledge/serializers/problem.py:42
+msgid "problem"
+msgstr "問題 ID"
+
+#: apps/application/serializers/application_chat.py:215
+msgid "Problem after optimization"
+msgstr "優化後的問題"
+
+#: apps/knowledge/serializers/paragraph.py:492
+msgid "Problem does not exist"
+msgstr "問題不存在"
+
+#: apps/knowledge/serializers/paragraph.py:474
+#: apps/knowledge/serializers/problem.py:27
+#: apps/knowledge/serializers/problem.py:47
+#: apps/knowledge/serializers/problem.py:57
+#: apps/knowledge/serializers/problem.py:139
+msgid "problem id"
+msgstr "問題 ID"
+
+#: apps/knowledge/serializers/paragraph.py:262
+msgid "Problem id does not exist"
+msgstr "問題 ID 不存在"
+
+#: apps/knowledge/serializers/problem.py:46
+#: apps/knowledge/serializers/problem.py:56
+msgid "problem id list"
+msgstr "問題 ID 列表"
+
+#: apps/knowledge/api/problem.py:39
+#: apps/knowledge/api/problem.py:52
+#: apps/knowledge/api/termbase.py:38
+#: apps/knowledge/api/termbase.py:45
+#: apps/knowledge/serializers/problem.py:41
+msgid "problem list"
+msgstr "問題列表"
+
+#: apps/common/utils/tool_code.py:379
+msgid "Process execution timed out after {} seconds."
+msgstr ""
+
+#: no source
+msgid "product"
+msgstr "產品"
+
+#: no source
+msgid "project url"
+msgstr "項目網址"
+
+#: apps/knowledge/serializers/document.py:238
+#: apps/knowledge/serializers/paragraph.py:95
+msgid "prompt"
+msgstr "提示詞"
+
+#: apps/tools/serializers/tool.py:1571
+msgid "Prompt"
+msgstr ""
+
+#: apps/chat/serializers/chat.py:54
+msgid "Prompt template"
+msgstr "提示詞範本"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:39
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:25
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:20
+#: apps/application/flow/step_node/question_node/i_question_node.py:25
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:19
+#: apps/application/serializers/application.py:202
+#: apps/application/serializers/application.py:253
+#: apps/knowledge/serializers/common.py:78
+msgid "Prompt word"
+msgstr "提示詞"
+
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:19
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:20
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:19
+msgid "Prompt word (negative)"
+msgstr "提示詞 (負向)"
+
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:17
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:18
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:17
+msgid "Prompt word (positive)"
+msgstr "提示詞 (正向)"
+
+#: apps/homepage/serializers/homepage.py:304
+#: apps/homepage/serializers/homepage.py:491
+#: apps/homepage/serializers/homepage.py:627
+msgid "proportion"
+msgstr "占比"
+
+#: apps/models_provider/api/provide.py:46
+msgid "props info"
+msgstr "props 信息"
+
+#: apps/chat/api/chat_embed_api.py:31
+#: apps/chat/serializers/chat_embed_serializers.py:26
+msgid "protocol"
+msgstr "協議"
+
+#: apps/models_provider/api/model.py:58
+#: apps/models_provider/api/provide.py:18
+#: apps/models_provider/api/provide.py:38
+#: apps/models_provider/api/provide.py:76
+#: apps/models_provider/api/provide.py:104
+#: apps/models_provider/api/provide.py:126
+#: apps/models_provider/serializers/model_serializer.py:64
+#: apps/models_provider/serializers/model_serializer.py:286
+#: apps/models_provider/serializers/model_serializer.py:362
+#: apps/models_provider/serializers/model_serializer.py:545
+msgid "provider"
+msgstr "供應商"
+
+#: apps/common/constants/permission_constants.py:377
+msgid "Public access link"
+msgstr "公共訪問鏈接"
+
+#: no source
+msgid "Public settings"
+msgstr "公共訪問連接"
+
+#: apps/common/constants/permission_constants.py:349
+msgid "Publish"
+msgstr "發布"
+
+#: apps/application/api/application_api.py:96
+#: apps/application/serializers/application.py:452
+msgid "Publish status"
+msgstr "發佈狀態"
+
+#: apps/application/serializers/application.py:453
+msgid "Published"
+msgstr "已發佈"
+
+#: apps/homepage/api/home_page_api.py:248
+msgid "Published application count"
+msgstr "已發布應用數量"
+
+#: apps/application/views/application.py:272
+#: apps/application/views/application.py:273
+#: apps/application/views/application.py:274
+msgid "Publishing an application"
+msgstr "發布智能體"
+
+#: apps/knowledge/views/knowledge_workflow.py:253
+#: apps/knowledge/views/knowledge_workflow.py:254
+#: apps/knowledge/views/knowledge_workflow.py:255
+msgid "Publishing an knowledge"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:29
+#: apps/tools/views/tool_workflow.py:30
+#: apps/tools/views/tool_workflow.py:31
+msgid "Publishing an tool"
+msgstr ""
+
+#: apps/local_model/serializers/model_apply_serializers.py:110
+#: apps/models_provider/serializers/model_apply_serializers.py:47
+msgid "query"
+msgstr "查詢"
+
+#: apps/models_provider/views/model.py:296
+#: apps/models_provider/views/model.py:297
+#: apps/models_provider/views/model.py:298
+msgid "Query all model list"
+msgstr ""
+
+#: apps/models_provider/views/model.py:159
+#: apps/models_provider/views/model.py:160
+#: apps/models_provider/views/model.py:161
+msgid "Query model details"
+msgstr "查詢模型詳情"
+
+#: apps/models_provider/views/model.py:94
+#: apps/models_provider/views/model.py:95
+#: apps/models_provider/views/model.py:96
+msgid "Query model list"
+msgstr "查詢模型列表"
+
+#: apps/models_provider/views/model.py:226
+#: apps/models_provider/views/model.py:228
+#: apps/models_provider/views/model.py:230
+msgid "Query model meta information, this interface does not carry authentication information"
+msgstr "查詢模型元信息，該接口不攜帶認證信息"
+
+#: apps/knowledge/serializers/knowledge.py:157
+#: apps/knowledge/serializers/knowledge.py:1362
+msgid "query text"
+msgstr "查詢文本"
+
+#: apps/common/event/listener_manage.py:114
+msgid "Query vector data: {paragraph_id_list} error {error} {traceback}"
+msgstr "查詢向量數據：{paragraph_id_list} 錯誤：{error} {traceback}"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:26
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:24
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:24
+#: apps/application/serializers/application_chat_record.py:244
+msgid "question"
+msgstr "問題"
+
+#: apps/knowledge/serializers/document.py:936
+#: apps/knowledge/serializers/knowledge.py:768
+msgid "Question (optional, one per line in the cell)"
+msgstr "問題（可選，每個單元格一行）"
+
+#: apps/application/serializers/application.py:366
+#: apps/application/serializers/application.py:610
+msgid "Question completion"
+msgstr "問題完成"
+
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:32
+#: apps/application/serializers/application.py:368
+msgid "Question completion prompt"
+msgstr "問題完成提示"
+
+#: apps/homepage/api/home_page_api.py:195
+#: apps/homepage/api/home_page_api.py:224
+msgid "Question count"
+msgstr "提問次數"
+
+#: apps/knowledge/views/problem.py:23
+#: apps/knowledge/views/problem.py:24
+#: apps/knowledge/views/problem.py:25
+msgid "Question list"
+msgstr "問題列表"
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:31
+msgid "question reference address"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:223
+msgid "Question Time"
+msgstr "提問時間"
+
+#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:46
+msgid "Quickly and accurately generate images based on user text descriptions. Resolution supports 1024x1024"
+msgstr "根據用戶文字描述快速、精準生成圖像。解析度支持1024x1024"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:25
+msgid "Qwen-Omni"
+msgstr "多模態"
+
+#: apps/homepage/serializers/homepage.py:301
+#: apps/homepage/serializers/homepage.py:488
+#: apps/homepage/serializers/homepage.py:624
+msgid "ranking"
+msgstr "排名"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:28
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:28
+msgid "Ratio"
+msgstr "比例"
+
+#: apps/users/serializers/user.py:443
+#: apps/users/serializers/user.py:991
+#: apps/users/serializers/user.py:1049
+msgid "Re Password"
+msgstr "確認密碼"
+
+#: apps/knowledge/views/knowledge.py:334
+#: apps/knowledge/views/knowledge.py:335
+#: apps/knowledge/views/knowledge.py:336
+msgid "Re-vectorize"
+msgstr "重新向量化"
+
+#: apps/common/constants/permission_constants.py:346
+msgid "Read"
+msgstr "查看"
+
+#: apps/common/constants/permission_constants.py:391
+msgid "Read execute record"
+msgstr "檢視執行記錄"
+
+#: apps/common/constants/permission_constants.py:387
+msgid "Read Trigger"
+msgstr "檢視觸發器"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:27
+msgid "Real-time speech recognition - Fun-ASR/Paraformer"
+msgstr "實時語音識別-Fun-ASR/Paraformer"
+
+#: apps/tools/serializers/tool.py:1427
+#: apps/tools/serializers/tool.py:1433
+msgid "record id"
+msgstr ""
+
+#: no source
+msgid "Redirect address cannot be empty"
+msgstr "重定向地址不能為空"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:22
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:22
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:16
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:16
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:17
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:22
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:25
+#: apps/application/flow/step_node/question_node/i_question_node.py:22
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:16
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:17
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:16
+#: apps/application/flow/step_node/variable_assign_node/i_variable_assign_node.py:14
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:16
+msgid "Reference Field"
+msgstr "引用欄位"
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:32
+msgid "Reference field cannot be empty"
+msgstr "引用欄位不能為空"
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:34
+msgid "Reference field error"
+msgstr "引用欄位錯誤"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:39
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:22
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:25
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:24
+#: apps/application/serializers/application.py:206
+#: apps/application/serializers/application_chat.py:218
+msgid "Reference segment number"
+msgstr "引用分段數"
+
+#: apps/knowledge/views/document.py:363
+#: apps/knowledge/views/document.py:364
+#: apps/knowledge/views/document.py:365
+msgid "Refresh document vector library"
+msgstr "刷新文檔向量庫"
+
+#: no source
+msgid "Refresh shared document vector library"
+msgstr "刷新共享文檔向量庫"
+
+#: no source
+msgid "Refresh system knowledge vector library"
+msgstr "刷新文檔向量庫"
+
+#: apps/chat/serializers/chat.py:213
+msgid "Regenerate"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:26
+msgid "Region Name"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:369
+msgid "Relate"
+msgstr "關聯分段"
+
+#: apps/application/serializers/application.py:359
+#: apps/application/serializers/application.py:603
+msgid "Related Knowledge Base"
+msgstr "相關知識庫"
+
+#: apps/knowledge/views/paragraph.py:377
+#: apps/knowledge/views/paragraph.py:378
+#: apps/knowledge/views/paragraph.py:379
+msgid "Related questions"
+msgstr "關聯問題"
+
+#: no source
+msgid "Related shared questions"
+msgstr "關聯問題"
+
+#: no source
+msgid "Related system questions"
+msgstr "關聯問題"
+
+#: apps/models_provider/api/provide.py:42
+msgid "relation show field dict"
+msgstr "關係顯示欄位"
+
+#: apps/models_provider/api/provide.py:43
+msgid "relation trigger field dict"
+msgstr "關係觸發欄位"
+
+#: no source
+msgid "remark"
+msgstr "備註"
+
+#: apps/common/constants/permission_constants.py:366
+msgid "Remove Member"
+msgstr "移除成員"
+
+#: no source
+msgid "Remove member from chat user group"
+msgstr "從對話用戶組移除成員"
+
+#: no source
+msgid "Remove member from system role"
+msgstr "系統角色移除成員"
+
+#: no source
+msgid "Remove member from system workspace"
+msgstr "系統工作空間移除成員"
+
+#: no source
+msgid "Remove member from user group"
+msgstr "從用戶組中移除成員"
+
+#: no source
+msgid "Remove member from workspace"
+msgstr "工作空間移除成員"
+
+#: no source
+msgid "Remove member from workspace role"
+msgstr "工作空間角色移除成員"
+
+#: apps/models_provider/views/model_apply.py:49
+#: apps/models_provider/views/model_apply.py:50
+#: apps/models_provider/views/model_apply.py:51
+msgid "Reorder documents"
+msgstr "重新排序文檔"
+
+#: apps/common/constants/permission_constants.py:385
+msgid "Replace Original Document"
+msgstr "替換原文件"
+
+#: apps/knowledge/views/document.py:977
+#: apps/knowledge/views/document.py:978
+msgid "Replace source file"
+msgstr ""
+
+#: apps/models_provider/api/provide.py:40
+#: apps/tools/serializers/tool.py:248
+#: apps/tools/serializers/tool.py:274
+msgid "required"
+msgstr "必填"
+
+#: apps/models_provider/base_model_provider.py:153
+msgid "Rerank"
+msgstr "重排模型"
+
+#: apps/application/serializers/application_access_token.py:25
+msgid "Reset Token"
+msgstr "重置令牌"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:20
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:16
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:16
+msgid "Resolution"
+msgstr "分辨率"
+
+#: apps/common/constants/permission_constants.py:446
+msgid "Resource"
+msgstr "資源管理"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:26
+#: apps/system_manage/serializers/resource_mapping_serializers.py:107
+#: apps/system_manage/serializers/user_resource_permission.py:110
+#: apps/system_manage/serializers/user_resource_permission.py:322
+msgid "resource"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:329
+msgid "Resource Application"
+msgstr "資源管理-智能體"
+
+#: apps/common/constants/permission_constants.py:383
+msgid "resource authorization"
+msgstr "資源授權"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:27
+#: apps/system_manage/serializers/resource_mapping_serializers.py:108
+msgid "resource Id"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:321
+msgid "resource id"
+msgstr ""
+
+#: no source
+msgid "Resource id"
+msgstr "資源ID"
+
+#: apps/common/constants/permission_constants.py:330
+msgid "Resource Knowledge"
+msgstr "資源管理-知識庫"
+
+#: apps/common/constants/permission_constants.py:332
+msgid "Resource Model"
+msgstr "資源管理-模型"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:28
+#: apps/system_manage/serializers/resource_mapping_serializers.py:110
+msgid "resource Name"
+msgstr ""
+
+#: apps/system_manage/serializers/user_resource_permission.py:101
+msgid "resource name"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:333
+msgid "Resource Permission"
+msgstr "資源授權"
+
+#: apps/common/constants/permission_constants.py:331
+msgid "Resource Tool"
+msgstr "資源管理-工具"
+
+#: apps/application/serializers/application.py:467
+#: apps/application/serializers/application.py:467
+msgid "Resource type"
+msgstr "資源類型"
+
+#: apps/system_manage/views/user_resource_permission.py:47
+#: apps/system_manage/views/user_resource_permission.py:66
+#: apps/system_manage/views/user_resource_permission.py:91
+#: apps/system_manage/views/user_resource_permission.py:115
+#: apps/system_manage/views/user_resource_permission.py:148
+#: apps/system_manage/views/user_resource_permission.py:181
+msgid "Resources authorization"
+msgstr "資源授權"
+
+#: apps/system_manage/views/resource_mapping.py:33
+msgid "Resources mapping"
+msgstr "資源映射"
+
+#: apps/common/result/api.py:17
+#: apps/common/result/api.py:17
+#: apps/common/result/api.py:27
+#: apps/common/result/api.py:27
+msgid "response code"
+msgstr "響應碼"
+
+#: apps/homepage/api/home_page_api.py:152
+#: apps/homepage/api/home_page_api.py:182
+#: apps/homepage/api/home_page_api.py:209
+#: apps/homepage/api/home_page_api.py:242
+#: apps/homepage/api/home_page_api.py:305
+#: apps/homepage/api/home_page_api.py:342
+#: apps/homepage/api/home_page_api.py:379
+msgid "Response code"
+msgstr "回應碼"
+
+#: apps/homepage/api/home_page_api.py:153
+#: apps/homepage/api/home_page_api.py:183
+#: apps/homepage/api/home_page_api.py:210
+#: apps/homepage/api/home_page_api.py:243
+#: apps/homepage/api/home_page_api.py:306
+#: apps/homepage/api/home_page_api.py:343
+#: apps/homepage/api/home_page_api.py:380
+msgid "Response message"
+msgstr "回應訊息"
+
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:21
+msgid "Response Type"
+msgstr "響應類型"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:46
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:31
+#: apps/application/serializers/application.py:220
+msgid "Retrieval Mode"
+msgstr "檢索模式"
+
+#: apps/trigger/views/trigger_task.py:53
+#: apps/trigger/views/trigger_task.py:54
+#: apps/trigger/views/trigger_task.py:55
+msgid "Retrieve detailed records of tasks executed by the trigger."
+msgstr "取得由該觸發器執行的任務詳細記錄。"
+
+#: apps/system_manage/views/resource_mapping.py:29
+#: apps/system_manage/views/resource_mapping.py:30
+#: apps/system_manage/views/resource_mapping.py:63
+#: apps/system_manage/views/resource_mapping.py:64
+msgid "Retrieve the pagination list of resource relationships"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:40
+msgid "retro anime"
+msgstr "復古動漫"
+
+#: apps/chat/serializers/chat.py:49
+#: apps/chat/serializers/chat.py:207
+#: apps/common/constants/permission_constants.py:327
+#: apps/common/constants/permission_constants.py:433
+msgid "Role"
+msgstr "角色"
+
+#: no source
+msgid "Role does not exist"
+msgstr "角色不存在"
+
+#: apps/users/api/user.py:26
+msgid "Role ID"
+msgstr "角色 ID"
+
+#: no source
+msgid "Role IDs"
+msgstr "角色 IDs"
+
+#: no source
+msgid "Role IDs cannot be empty"
+msgstr "角色 ID 不能为空"
+
+#: no source
+msgid "Role name"
+msgstr "角色名稱"
+
+#: no source
+msgid "Role Name"
+msgstr "角色名稱"
+
+#: no source
+msgid "Role name already exists"
+msgstr "角色名稱已存在"
+
+#: apps/application/serializers/application.py:256
+msgid "Role prompts"
+msgstr "角色提示"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:24
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:19
+#: apps/application/flow/step_node/question_node/i_question_node.py:24
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:18
+#: apps/users/api/user.py:35
+#: apps/users/api/user.py:102
+msgid "Role Setting"
+msgstr "角色設置"
+
+#: no source
+msgid "Role Setting cannot be empty"
+msgstr "角色設置不能為空"
+
+#: no source
+msgid "Role type"
+msgstr "角色類型"
+
+#: no source
+msgid "Root Directory"
+msgstr "根目錄"
+
+#: apps/chat/serializers/chat.py:86
+msgid "Runtime node id"
+msgstr "運行時節點 ID"
+
+#: apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py:64
+msgid "Same performance, faster and more agile. 204K context window"
+msgstr ""
+
+#: no source
+msgid "SAML2 Log in"
+msgstr "SAML2 登入"
+
+#: no source
+msgid "SAML2 Metadata"
+msgstr "SAML2 元數據"
+
+#: no source
+msgid "SAML2 SSO"
+msgstr "SAML2 單點登入"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:15
+msgid "Sample Rate"
+msgstr "採樣率"
+
+#: apps/models_provider/views/model.py:201
+#: apps/models_provider/views/model.py:202
+#: apps/models_provider/views/model.py:203
+msgid "Save model parameter form"
+msgstr "保存模型參數表單"
+
+#: no source
+msgid "Scan code login type"
+msgstr "掃碼登錄類型"
+
+#: apps/trigger/serializers/trigger.py:171
+msgid "schedule_type must be one of %s"
+msgstr "schedule_type 必須是以下值之一: %s"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:33
+msgid "science fiction style"
+msgstr "科幻風格"
+
+#: apps/knowledge/serializers/knowledge.py:887
+#: apps/knowledge/serializers/knowledge.py:1137
+#: apps/knowledge/serializers/knowledge_workflow.py:320
+#: apps/tools/serializers/tool.py:345
+#: apps/tools/serializers/tool.py:1690
+msgid "scope"
+msgstr "範圍"
+
+#: no source
+msgid "Scope cannot be empty"
+msgstr "範圍不能為空"
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:37
+msgid "search condition list"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:34
+msgid "search condition type"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:17
+#: apps/knowledge/serializers/knowledge.py:162
+#: apps/knowledge/serializers/knowledge.py:1367
+msgid "search mode"
+msgstr "搜索模式"
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:20
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:47
+msgid "search scope type"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:28
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:55
+msgid "search scope variable"
+msgstr ""
+
+#: apps/application/flow/step_node/search_document_node/i_search_document_node.py:25
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:52
+msgid "search scope variable type"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1700
+#: apps/knowledge/serializers/tag.py:203
+msgid "search value"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:25
+msgid "Secret Access Key"
+msgstr ""
+
+#: no source
+msgid "Secret is required"
+msgstr "Secret 是必填項"
+
+#: apps/common/auth/handle/impl/application_key.py:27
+msgid "Secret key is expired"
+msgstr "密鑰已過期"
+
+#: apps/chat/views/chat.py:84
+#: apps/common/auth/handle/impl/application_key.py:23
+#: apps/common/auth/handle/impl/application_key.py:25
+msgid "Secret key is invalid"
+msgstr "密鑰無效"
+
+#: apps/knowledge/serializers/document.py:935
+#: apps/knowledge/serializers/knowledge.py:767
+msgid "Section content (required, question answer, no more than 4096 characters)"
+msgstr "章節內容（必填，問答，不超過4096個字符）"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:40
+#: apps/knowledge/serializers/paragraph.py:73
+#: apps/knowledge/serializers/paragraph.py:81
+#: apps/knowledge/serializers/paragraph.py:84
+#: apps/knowledge/serializers/paragraph.py:102
+#: apps/knowledge/serializers/paragraph.py:104
+#: apps/knowledge/serializers/paragraph.py:439
+msgid "section title"
+msgstr "章節標題"
+
+#: apps/application/serializers/application_chat_record.py:240
+msgid "Section title"
+msgstr "章節標題"
+
+#: apps/knowledge/serializers/document.py:934
+#: apps/knowledge/serializers/knowledge.py:766
+msgid "Section title (optional)"
+msgstr "章節標題"
+
+#: apps/application/serializers/application_chat.py:219
+msgid "Section title + content"
+msgstr "分段標題 + 內容"
+
+#: apps/application/serializers/application.py:223
+msgid "Segment settings not referenced"
+msgstr "引用段設置未引用"
+
+#: apps/knowledge/views/document.py:224
+#: apps/knowledge/views/document.py:225
+#: apps/knowledge/views/document.py:226
+msgid "Segmented document"
+msgstr "分段文檔"
+
+#: no source
+msgid "Segmented shared document"
+msgstr "分段共享文檔"
+
+#: no source
+msgid "Segmented system document"
+msgstr "分段文檔"
+
+#: apps/knowledge/serializers/common.py:37
+#: apps/knowledge/serializers/document.py:211
+msgid "selector"
+msgstr "選擇器"
+
+#: apps/knowledge/serializers/document.py:1306
+msgid "semicolon"
+msgstr "分號"
+
+#: apps/users/views/user.py:321
+#: apps/users/views/user.py:322
+#: apps/users/views/user.py:323
+msgid "Send email"
+msgstr "發送郵件"
+
+#: apps/users/views/user.py:356
+#: apps/users/views/user.py:357
+#: apps/users/views/user.py:358
+msgid "Send email to current user"
+msgstr "發送郵件給當前用戶"
+
+#: apps/system_manage/serializers/email_setting.py:33
+#: apps/system_manage/serializers/email_setting.py:37
+msgid "Sender's email"
+msgstr "發送者郵箱"
+
+#: no source
+msgid "serial number"
+msgstr "序列號"
+
+#: apps/common/constants/permission_constants.py:1346
+#: apps/common/constants/permission_constants.py:1399
+msgid "Set up user groups"
+msgstr "設置用戶組"
+
+#: no source
+msgid "Setting"
+msgstr "設置"
+
+#: apps/application/serializers/application_chat_link.py:129
+msgid "Share link does not exist"
+msgstr "分享連結不存在"
+
+#: no source
+msgid "Shared generate related"
+msgstr "生成相關"
+
+#: no source
+msgid "Shared Hit test list"
+msgstr "命中測試列表"
+
+#: apps/common/constants/permission_constants.py:334
+msgid "Shared Knowledge"
+msgstr "共享資源-知識庫"
+
+#: no source
+msgid "Shared Knowledge/Document"
+msgstr "共享知識/文件"
+
+#: no source
+msgid "Shared Knowledge/Documentation"
+msgstr "共享知識庫/文檔"
+
+#: no source
+msgid "Shared Knowledge/Documentation/Paragraph"
+msgstr "共享知識庫/文檔/段落"
+
+#: no source
+msgid "Shared Knowledge/Documentation/Paragraph/Question"
+msgstr "知識庫/文檔/段落/問題"
+
+#: apps/common/constants/permission_constants.py:335
+#: apps/models_provider/views/model.py:278
+msgid "Shared Model"
+msgstr "共享資源-模型"
+
+#: apps/models_provider/serializers/model_serializer.py:142
+msgid "Shared models cannot be deleted or modified"
+msgstr "共享模型不能被刪除或修改"
+
+#: no source
+msgid "Shared paragraph list"
+msgstr "共享段落列表"
+
+#: no source
+msgid "Shared question list"
+msgstr "問題列表"
+
+#: no source
+msgid "Shared Re-vectorize"
+msgstr "重新向量化"
+
+#: apps/common/constants/permission_constants.py:336
+msgid "Shared Tool"
+msgstr "共享資源-工具"
+
+#: no source
+msgid "Shared tool is not supported"
+msgstr "不支援共享工具"
+
+#: no source
+msgid "show avatar"
+msgstr "顯示頭像"
+
+#: no source
+msgid "show exec"
+msgstr "顯示執行"
+
+#: no source
+msgid "show forum"
+msgstr "顯示論壇"
+
+#: no source
+msgid "show guide"
+msgstr "顯示論壇"
+
+#: no source
+msgid "show history"
+msgstr "顯示歷史"
+
+#: no source
+msgid "show project"
+msgstr "顯示項目"
+
+#: no source
+msgid "show source"
+msgstr "顯示來源"
+
+#: no source
+msgid "show user avatar"
+msgstr "顯示用戶頭像"
+
+#: no source
+msgid "show user manual"
+msgstr "顯示用戶手冊"
+
+#: apps/users/views/login.py:55
+#: apps/users/views/login.py:56
+#: apps/users/views/login.py:57
+msgid "Sign out"
+msgstr "登出"
+
+#: no source
+msgid "Signature missing"
+msgstr "籤名缺失"
+
+#: no source
+msgid "Signing Secret is required"
+msgstr "籤名密鑰是必填項"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:42
+msgid "Similarity"
+msgstr "相似度"
+
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:27
+#: apps/knowledge/serializers/knowledge.py:159
+#: apps/knowledge/serializers/knowledge.py:1364
+msgid "similarity"
+msgstr "相似度"
+
+#: apps/models_provider/impl/ollama_model_provider/ollama_model_provider.py:68
+msgid "Since the Chinese alignment of Llama2 itself is weak, we use the Chinese instruction set to fine-tune meta-llama/Llama-2-13b-chat-hf with LoRA so that it has strong Chinese conversation capabilities."
+msgstr "由於Llama2本身的中文對齊較弱，我們採用中文指令集，對meta-llama/Llama-2-13b-chat-hf進行LoRA微調，使其具備較強的中文對話能力。"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:56
+msgid "sketch"
+msgstr "素描"
+
+#: apps/tools/serializers/tool.py:1562
+msgid "Skill file does not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:49
+msgid "Skill IDs"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:296
+msgid "Slack"
+msgstr "Slack 應用"
+
+#: no source
+msgid "Slack application: {user}"
+msgstr "Slack 智能體: {user}"
+
+#: no source
+msgid "slogan"
+msgstr "標語"
+
+#: apps/system_manage/serializers/email_setting.py:31
+msgid "SMTP host"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:32
+msgid "SMTP port"
+msgstr ""
+
+#: no source
+msgid "Some roles do not exist"
+msgstr "部分角色不存在"
+
+#: no source
+msgid "Some user groups do not exist"
+msgstr "某些用戶組不存在"
+
+#: no source
+msgid "Some users do not exist"
+msgstr "某些用戶不存在"
+
+#: apps/application/models/application_chat.py:120
+msgid "Sorry, no relevant content was found. Please re-describe your problem or provide more information. "
+msgstr "不好意思，沒有找到相關內容。請重新描述您的問題或提供更多信息。"
+
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:498
+#: apps/application/chat_pipeline/step/chat_step/impl/base_chat_step.py:661
+msgid "Sorry, the AI model is not configured. Please go to the application to set up the AI model first."
+msgstr "抱歉，AI 模型未配置，請先前往智能體設置 AI 模型。"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:30
+#: apps/application/serializers/application_chat.py:221
+#: apps/folders/serializers/folder.py:136
+#: apps/folders/serializers/folder.py:178
+#: apps/folders/serializers/folder.py:307
+#: apps/tools/serializers/tool.py:262
+#: apps/trigger/serializers/trigger.py:47
+msgid "source"
+msgstr "來源"
+
+#: apps/chat/serializers/chat.py:222
+#: apps/chat/serializers/chat.py:293
+#: apps/chat/serializers/chat.py:538
+#: apps/users/serializers/user.py:70
+#: apps/users/serializers/user.py:211
+#: apps/users/serializers/user.py:257
+msgid "Source"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:141
+msgid "source file id"
+msgstr "源文件 ID"
+
+#: apps/oss/serializers/file.py:72
+#: apps/trigger/serializers/task_source_trigger.py:63
+#: apps/trigger/serializers/task_source_trigger.py:184
+msgid "source id"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1428
+msgid "source name"
+msgstr ""
+
+#: apps/oss/serializers/file.py:75
+#: apps/tools/serializers/tool.py:1429
+#: apps/trigger/serializers/task_source_trigger.py:62
+#: apps/trigger/serializers/task_source_trigger.py:183
+msgid "source type"
+msgstr ""
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:30
+#: apps/system_manage/serializers/resource_mapping_serializers.py:31
+msgid "source Type"
+msgstr ""
+
+#: apps/trigger/serializers/trigger_task.py:130
+msgid "Source type"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:36
+#: apps/knowledge/serializers/knowledge.py:124
+msgid "source url"
+msgstr "來源"
+
+#: apps/trigger/serializers/trigger.py:254
+#: apps/trigger/serializers/trigger.py:276
+msgid "source_id"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1305
+msgid "space"
+msgstr "空格"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:33
+msgid "Spanish"
+msgstr "西班牙語"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:18
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:14
+msgid "Speaker"
+msgstr "發音人"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:18
+msgid "Speaker selection for super-humanoid TTS service"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:15
+msgid "Speaker, optional value: Please go to the console to add a trial or purchase speaker. After adding, the speaker parameter value will be displayed."
+msgstr "發音人，可選值：請到控制臺添加試用或購買發音人，添加後即顯示發音人參數值"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:37
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:68
+msgid "Speaking speed"
+msgstr "語速"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:30
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:77
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:43
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:27
+msgid "speaking speed"
+msgstr "語速"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:31
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:25
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:24
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:23
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:27
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:43
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:27
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:25
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:25
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:22
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:27
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:28
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:32
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:27
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:32
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:25
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:24
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:25
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:31
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:25
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:25
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:25
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:31
+msgid "Specify the maximum number of tokens that the model can generate"
+msgstr "指定模型可以生成的最大 tokens 數"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:30
+msgid "Specify the maximum number of tokens that the model can generate."
+msgstr "指定模型可以生成的最大 tokens 數"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:35
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:39
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:20
+msgid "Specify the number of generated images"
+msgstr "指定生成圖片的數量"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:20
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:14
+msgid "Specify the size of the generated image, such as: 1024x1024"
+msgstr "指定生成圖片的尺寸, 如: 1024x1024"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:22
+msgid "Specify the size of the generated Video, such as: 1024x1024"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:45
+msgid "Specify the style of generated images"
+msgstr "指定生成圖片的風格"
+
+#: apps/application/serializers/application.py:394
+#: apps/application/serializers/application.py:625
+msgid "Speech recognition model ID"
+msgstr "語音識別模型 ID"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:77
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:43
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:27
+msgid "Speech speed, optional value: [0-100], default is 50"
+msgstr "語速，可選值：[0-100]，默認為50"
+
+#: apps/application/views/application.py:435
+#: apps/application/views/application.py:436
+#: apps/application/views/application.py:437
+#: apps/application/views/application.py:461
+#: apps/application/views/application.py:462
+#: apps/application/views/application.py:463
+#: apps/chat/views/chat.py:220
+#: apps/chat/views/chat.py:221
+#: apps/chat/views/chat.py:222
+#: apps/knowledge/views/knowledge_workflow.py:458
+#: apps/knowledge/views/knowledge_workflow.py:459
+#: apps/knowledge/views/knowledge_workflow.py:460
+msgid "speech to text"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:149
+msgid "Speech2Text"
+msgstr "語音識別"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:15
+msgid "split strategy"
+msgstr ""
+
+#: apps/application/flow/step_node/parameter_extraction_node/i_parameter_extraction_node.py:17
+#: apps/application/flow/step_node/variable_splitting_node/i_variable_splitting_node.py:17
+msgid "Split variables"
+msgstr ""
+
+#: apps/common/job/clean_chat_job.py:23
+msgid "start clean chat log"
+msgstr "開始清理聊天日誌"
+
+#: apps/common/job/clean_debug_file_job.py:20
+msgid "start clean debug file"
+msgstr "開始清理調試文件"
+
+#: apps/common/job/client_access_num_job.py:25
+msgid "start reset access_num"
+msgstr ""
+
+#: apps/application/serializers/application_chat.py:56
+#: apps/application/serializers/application_stats.py:40
+#: apps/homepage/serializers/homepage.py:91
+#: apps/homepage/serializers/homepage.py:152
+#: apps/homepage/serializers/homepage.py:217
+#: apps/homepage/serializers/homepage.py:390
+#: apps/homepage/serializers/homepage.py:517
+#: apps/homepage/serializers/homepage.py:657
+msgid "Start time"
+msgstr "開始時間"
+
+#: apps/common/event/listener_manage.py:377
+msgid "Start--->Embedding document: {document_id}"
+msgstr "開始--->向量文檔: {document_id}"
+
+#: apps/common/event/listener_manage.py:426
+msgid "Start--->Embedding document: {document_list}"
+msgstr "開始--->向量文檔: {document_list}"
+
+#: apps/common/event/listener_manage.py:422
+msgid "Start--->Embedding knowledge: {knowledge_id}"
+msgstr "開始--->向量知識庫: {knowledge_id}"
+
+#: apps/common/event/listener_manage.py:122
+msgid "Start--->Embedding paragraph: {paragraph_id_list}"
+msgstr "開始--->向量段落: {paragraph_id_list}"
+
+#: apps/common/event/listener_manage.py:157
+msgid "Start--->Embedding paragraph: {paragraph_id}"
+msgstr "開始--->向量段落: {paragraph_id}"
+
+#: apps/knowledge/task/sync.py:26
+#: apps/knowledge/task/sync.py:49
+msgid "Start--->Start synchronization web knowledge base:{knowledge_id}"
+msgstr "開始--->開始同步 web 知識庫:{knowledge_id}"
+
+#: apps/common/event/listener_manage.py:535
+msgid "Start--->Tokenize document: {document_id}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:217
+msgid "Start--->Tokenize paragraph: {paragraph_id}"
+msgstr ""
+
+#: apps/knowledge/task/embedding.py:115
+msgid "Start--->Vectorized knowledge: {knowledge_id}"
+msgstr "開始--->向量知識庫: {knowledge_id}"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:98
+#: apps/tools/serializers/tool_workflow.py:129
+msgid "State"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1430
+msgid "state"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:80
+#: apps/knowledge/serializers/document.py:227
+#: apps/knowledge/serializers/document.py:232
+#: apps/knowledge/serializers/document.py:239
+msgid "state list"
+msgstr "狀態列表"
+
+#: apps/knowledge/serializers/document.py:482
+msgid "status"
+msgstr "狀態"
+
+#: no source
+msgid "Stop"
+msgstr "停止"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:26
+msgid "Strategy"
+msgstr ""
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:70
+#: apps/chat/serializers/chat.py:214
+msgid "Streaming Output"
+msgstr "流式輸出"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:45
+msgid "Style"
+msgstr "風格"
+
+#: apps/common/result/result.py:31
+msgid "Success"
+msgstr "成功"
+
+#: apps/application/serializers/application_chat.py:36
+#: apps/application/serializers/application_chat.py:54
+#: apps/application/serializers/application_chat.py:214
+#: apps/application/serializers/application_version.py:23
+#: apps/knowledge/serializers/knowledge_version.py:46
+#: apps/tools/serializers/tool_version.py:36
+msgid "summary"
+msgstr "摘要"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:26
+#: apps/models_provider/impl/xf_model_provider/xf_model_provider.py:56
+msgid "Super Humanoid TTS"
+msgstr ""
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:32
+msgid "Super-humanoid: Grant (EN)"
+msgstr "Grant"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:36
+msgid "Super-humanoid: Huifangnv Pro"
+msgstr "惠芳女"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:33
+msgid "Super-humanoid: Lila (EN)"
+msgstr "Lila"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:38
+msgid "Super-humanoid: Lingfeibo Pro"
+msgstr "聆飛博"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:25
+msgid "Super-humanoid: Lingfeiyi Flow"
+msgstr "聆飛逸"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:34
+msgid "Super-humanoid: Lingwanwan Pro"
+msgstr "聆萬萬"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:30
+msgid "Super-humanoid: Lingxiaorong Flow"
+msgstr "聆小蓉"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:29
+msgid "Super-humanoid: Lingxiaotang Flow"
+msgstr "聆小糖"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:23
+msgid "Super-humanoid: Lingxiaoxuan Flow"
+msgstr "聆小璇"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:37
+msgid "Super-humanoid: Lingxiaoying Pro"
+msgstr "聆小穎"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:26
+msgid "Super-humanoid: Lingxiaoyue Flow"
+msgstr "聆小玥"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:24
+msgid "Super-humanoid: Lingyuyan Flow"
+msgstr "聆玉言"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:39
+msgid "Super-humanoid: Lingyuyan Pro"
+msgstr "聆玉言"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:28
+msgid "Super-humanoid: Lingyuzhao Flow"
+msgstr "聆玉昭"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:27
+msgid "Super-humanoid: Sun Dasheng Flow"
+msgstr "孫大聖"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:31
+msgid "Super-humanoid: Xinyun Flow"
+msgstr "心雲"
+
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:35
+msgid "Super-humanoid: Yiyi Pro"
+msgstr "依依"
+
+#: apps/common/constants/permission_constants.py:1301
+#: apps/users/views/user.py:96
+#: apps/users/views/user.py:97
+#: apps/users/views/user.py:98
+msgid "Switch Language"
+msgstr "切換語言"
+
+#: apps/common/constants/permission_constants.py:363
+msgid "Sync"
+msgstr "同步"
+
+#: no source
+msgid "Sync chat users"
+msgstr "同步對話用戶"
+
+#: no source
+msgid "Sync chat users from external source"
+msgstr "從外部源同步對話用戶"
+
+#: apps/knowledge/serializers/knowledge.py:1260
+msgid "sync type"
+msgstr "同步類型"
+
+#: no source
+msgid "Sync Type"
+msgstr "同步類型"
+
+#: no source
+msgid "Sync Type: LOCAL or LDAP"
+msgstr "同步類型: LOCAL 或 LDAP"
+
+#: no source
+msgid "Sync users"
+msgstr "同步用戶"
+
+#: no source
+msgid "Synchronization is only supported for lark documents"
+msgstr "僅支持飛書文檔的同步"
+
+#: apps/knowledge/serializers/document.py:603
+#: apps/knowledge/serializers/knowledge.py:1282
+msgid "Synchronization is only supported for web site types"
+msgstr "僅支持網站類型的同步"
+
+#: no source
+msgid "Synchronize lark document"
+msgstr "同步飛書文檔"
+
+#: no source
+msgid "Synchronize shared web site types"
+msgstr "同步共享網站類型"
+
+#: no source
+msgid "Synchronize system web site types"
+msgstr "同步網站類型"
+
+#: apps/knowledge/views/knowledge.py:249
+#: apps/knowledge/views/knowledge.py:250
+#: apps/knowledge/views/knowledge.py:251
+msgid "Synchronize the knowledge base of the website"
+msgstr "同步網站知識庫"
+
+#: no source
+msgid "Synchronize the shared knowledge base of the website"
+msgstr "同步共享知識庫網站"
+
+#: no source
+msgid "Synchronize the system knowledge base of the website"
+msgstr "同步網站知識庫"
+
+#: apps/knowledge/task/sync.py:37
+#: apps/knowledge/task/sync.py:59
+msgid "Synchronize web knowledge base:{knowledge_id} error{error}{traceback}"
+msgstr "同步 web 知識庫:{knowledge_id} 錯誤{error}{traceback}"
+
+#: apps/knowledge/views/document.py:325
+#: apps/knowledge/views/document.py:326
+#: apps/knowledge/views/document.py:327
+msgid "Synchronize web site types"
+msgstr "同步網站類型"
+
+#: no source
+msgid "System"
+msgstr "系統"
+
+#: apps/common/constants/permission_constants.py:403
+#: apps/common/constants/permission_constants.py:1312
+msgid "System API Key"
+msgstr "系統 API Key"
+
+#: no source
+msgid "system API key id"
+msgstr "系統 API 密鑰 ID"
+
+#: no source
+msgid "System Application"
+msgstr "系統智能體"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:27
+msgid "System completes question text"
+msgstr "系統完成問題文本"
+
+#: no source
+msgid "System generate related"
+msgstr "生成相關"
+
+#: no source
+msgid "System Hit test list"
+msgstr "命中測試列表"
+
+#: no source
+msgid "System Knowledge"
+msgstr "系統知識庫"
+
+#: no source
+msgid "System Knowledge/Documentation"
+msgstr "系統知識庫/文檔"
+
+#: no source
+msgid "System Knowledge/Documentation/Paragraph"
+msgstr "系統知識庫/文檔/段落"
+
+#: no source
+msgid "System Knowledge/Documentation/Paragraph/Question"
+msgstr "系統知識庫/文檔/段落/問題"
+
+#: apps/common/constants/permission_constants.py:339
+msgid "System Management"
+msgstr "系統管理"
+
+#: no source
+msgid "System Model"
+msgstr "系統模型"
+
+#: no source
+msgid "System operate log"
+msgstr "系統操作日誌"
+
+#: no source
+msgid "System paragraph list"
+msgstr "段落列表"
+
+#: apps/system_manage/views/system_profile.py:25
+msgid "System parameters"
+msgstr "系統參數"
+
+#: apps/application/chat_pipeline/step/generate_human_message_step/i_generate_human_message_step.py:41
+msgid "System prompt words (role)"
+msgstr "系統提示詞（角色）"
+
+#: no source
+msgid "System question list"
+msgstr "問題列表"
+
+#: no source
+msgid "System Re-vectorize"
+msgstr "重新向量化"
+
+#: no source
+msgid "System resources authorization"
+msgstr "系統資源授權"
+
+#: apps/common/constants/permission_constants.py:325
+msgid "System Setting"
+msgstr "系統設置"
+
+#: no source
+msgid "System Tool"
+msgstr "工具"
+
+#: no source
+msgid "System tools cannot be deleted"
+msgstr "系統工具不能被刪除"
+
+#: no source
+msgid "System Trigger"
+msgstr "系統觸發器"
+
+#: no source
+msgid "System/Chat user"
+msgstr "系統/對話用戶"
+
+#: no source
+msgid "System/User Group"
+msgstr "系統/用戶組"
+
+#: apps/common/constants/permission_constants.py:358
+#: apps/common/constants/permission_constants.py:416
+#: apps/common/constants/permission_constants.py:426
+msgid "Tag"
+msgstr "標籤管理"
+
+#: apps/knowledge/serializers/document.py:484
+msgid "tag"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1776
+#: apps/knowledge/serializers/document.py:1817
+#: apps/knowledge/serializers/document.py:1844
+msgid "tag id"
+msgstr ""
+
+#: apps/knowledge/serializers/tag.py:95
+msgid "Tag ID"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:1859
+#: apps/knowledge/serializers/tag.py:111
+#: apps/knowledge/serializers/tag.py:155
+msgid "Tag id does not exist"
+msgstr "標籤ID不存在"
+
+#: apps/knowledge/serializers/document.py:1776
+#: apps/knowledge/serializers/document.py:1817
+msgid "tag ids"
+msgstr ""
+
+#: apps/knowledge/serializers/tag.py:169
+msgid "Tag IDs"
+msgstr ""
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:48
+#: apps/knowledge/serializers/tag.py:35
+#: apps/knowledge/serializers/tag.py:40
+msgid "Tag Key"
+msgstr "標籤"
+
+#: apps/knowledge/serializers/tag.py:125
+msgid "Tag key already exists"
+msgstr "標籤已存在"
+
+#: apps/common/constants/permission_constants.py:384
+msgid "Tag Setting"
+msgstr "標籤設定"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:49
+#: apps/knowledge/serializers/tag.py:36
+#: apps/knowledge/serializers/tag.py:41
+msgid "Tag Value"
+msgstr "標籤值"
+
+#: apps/knowledge/serializers/tag.py:143
+msgid "Tag value already exists"
+msgstr "標籤值已存在"
+
+#: apps/application/flow/step_node/knowledge_write_node/impl/base_knowledge_write_node.py:56
+#: apps/knowledge/serializers/knowledge.py:769
+#: apps/knowledge/serializers/tag.py:48
+msgid "Tags"
+msgstr "標籤"
+
+#: apps/knowledge/serializers/paragraph.py:605
+msgid "target document id"
+msgstr "目標文檔 ID"
+
+#: apps/system_manage/serializers/user_resource_permission.py:61
+msgid "target id"
+msgstr "當前 ID"
+
+#: apps/knowledge/serializers/document.py:356
+#: apps/knowledge/serializers/paragraph.py:604
+msgid "target knowledge id"
+msgstr "當前知識庫 ID"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:112
+#: apps/system_manage/serializers/resource_mapping_serializers.py:113
+msgid "target Type"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:171
+msgid "Task not found"
+msgstr ""
+
+#: apps/knowledge/serializers/document.py:125
+#: apps/knowledge/serializers/document.py:145
+#: apps/knowledge/serializers/document.py:481
+msgid "task type"
+msgstr "任務類型"
+
+#: apps/knowledge/serializers/document.py:133
+#: apps/knowledge/serializers/document.py:153
+msgid "task type not support"
+msgstr "任務類型不支持"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:21
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:16
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:15
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:14
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:13
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:17
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:17
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:15
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:15
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:12
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:20
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:17
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:18
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:22
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:17
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:22
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:13
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:15
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:14
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:21
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:40
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:15
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:15
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:15
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:21
+msgid "Temperature"
+msgstr "溫度"
+
+#: apps/models_provider/impl/tencent_cloud_model_provider/tencent_cloud_model_provider.py:58
+msgid "Tencent Cloud"
+msgstr "騰訊雲"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:133
+msgid "Tencent Hunyuan"
+msgstr "騰訊混元"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:85
+msgid "Tencent's Hunyuan Embedding interface can convert text into high-quality vector data. The vector dimension is 1024 dimensions."
+msgstr "騰訊混元 Embedding 接口，可以將文本轉化為高質量的向量數據。向量維度為1024維。"
+
+#: apps/common/constants/permission_constants.py:356
+#: apps/common/constants/permission_constants.py:414
+#: apps/common/constants/permission_constants.py:424
+msgid "Termbase"
+msgstr "詞庫"
+
+#: apps/knowledge/serializers/termbase.py:21
+#: apps/knowledge/serializers/termbase.py:67
+msgid "termbase id"
+msgstr ""
+
+#: apps/knowledge/serializers/termbase.py:28
+msgid "termbase list"
+msgstr ""
+
+#: apps/knowledge/views/termbase.py:28
+#: apps/knowledge/views/termbase.py:29
+#: apps/knowledge/views/termbase.py:30
+msgid "Termbase list"
+msgstr ""
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:48
+msgid "Test"
+msgstr ""
+
+#: apps/system_manage/views/email_setting.py:66
+#: apps/system_manage/views/email_setting.py:67
+msgid "Test email settings"
+msgstr "測試郵箱設置"
+
+#: no source
+msgid "Test LDAP connection"
+msgstr "測試 LDAP 連接"
+
+#: no source
+msgid "Test platform connection"
+msgstr "測試平臺連接"
+
+#: apps/tools/views/tool.py:457
+#: apps/tools/views/tool.py:458
+#: apps/tools/views/tool.py:459
+msgid "Test tool connection"
+msgstr ""
+
+#: apps/application/serializers/application.py:972
+msgid "Text"
+msgstr ""
+
+#: apps/local_model/serializers/model_apply_serializers.py:104
+#: apps/models_provider/serializers/model_apply_serializers.py:41
+msgid "text"
+msgstr "文本"
+
+#: apps/application/flow/step_node/intent_node/i_intent_node.py:23
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:21
+msgid "Text content"
+msgstr "文本內容"
+
+#: apps/models_provider/api/provide.py:36
+msgid "text field"
+msgstr "文本欄位"
+
+#: apps/application/views/application.py:487
+#: apps/application/views/application.py:488
+#: apps/application/views/application.py:489
+#: apps/chat/views/chat.py:239
+#: apps/chat/views/chat.py:240
+#: apps/chat/views/chat.py:241
+msgid "text to speech"
+msgstr ""
+
+#: apps/application/serializers/application.py:980
+msgid "Text to speech model ID"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:155
+msgid "Text to Video"
+msgstr "文生視頻"
+
+#: apps/common/utils/common.py:156
+msgid "Text-to-speech node, the text content cannot be empty"
+msgstr "文本轉語音節點，文本內容不能為空"
+
+#: apps/common/utils/common.py:154
+msgid "Text-to-speech node, the text content must be of string type"
+msgstr "文本轉語音節點，文本內容必須是字符串類型"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:29
+msgid "Thai"
+msgstr "泰語"
+
+#: no source
+msgid "The app does not enable the speech-to-text function or the speech-to-text function fails."
+msgstr "智能體未開啟語音轉文字功能或語音轉文字功能失敗。"
+
+#: apps/application/serializers/common.py:148
+msgid "The application does not exist"
+msgstr ""
+
+#: apps/application/serializers/common.py:153
+#: apps/chat/serializers/chat.py:491
+#: apps/chat/serializers/chat.py:560
+msgid "The application has not been published. Please use it after publishing."
+msgstr "智能體未發布，請發布後使用。"
+
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:21
+msgid "The audio file cannot be empty"
+msgstr "音頻文件不能為空"
+
+#: apps/application/flow/common.py:224
+msgid "The branch {branch} of the {node} node needs to be connected"
+msgstr "需要連接 {node} 節點的 {branch} 分支"
+
+#: apps/chat/serializers/chat.py:450
+#: apps/chat/serializers/chat.py:454
+msgid "The chat user is not authorized."
+msgstr ""
+
+#: no source
+msgid "The Chinese enhanced version developed by the Qianfan team based on Llama-2-7b has performed well on Chinese knowledge bases such as CMMLU and C-EVAL."
+msgstr "千帆團隊在Llama-2-7b基礎上的中文增強版本，在CMMLU、C-EVAL等中文知識庫上表現優異。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:55
+msgid "The Claude 3 Haiku is Anthropic's fastest and most compact model, with near-instant responsiveness. The model can answer simple queries and requests quickly. Customers will be able to build seamless AI experiences that mimic human interactions. Claude 3 Haiku can process images and return text output, and provides 200K context windows."
+msgstr "Claude 3 Haiku 是 Anthropic 最快速、最緊湊的模型，具有近乎即時的響應能力。該模型可以快速回答簡單的查詢和請求。客戶將能夠構建模仿人類交互的無縫人工智能體驗。 Claude 3 Haiku 可以處理圖像和返回文本輸出，並且提供 200K 上下文窗口。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:62
+msgid "The Claude 3 Sonnet model from Anthropic strikes the ideal balance between intelligence and speed, especially when it comes to handling enterprise workloads. This model offers maximum utility while being priced lower than competing products, and it's been engineered to be a solid choice for deploying AI at scale."
+msgstr "Anthropic 推出的 Claude 3 Sonnet 模型在智能和速度之間取得理想的平衡，尤其是在處理企業工作負載方面。該模型提供最大的效用，同時價格低於競爭產品，並且其經過精心設計，是大規模部署人工智慧的可靠選擇。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:69
+msgid "The Claude 3.5 Sonnet raises the industry standard for intelligence, outperforming competing models and the Claude 3 Opus in extensive evaluations, with the speed and cost-effectiveness of our mid-range models."
+msgstr "Claude 3.5 Sonnet提高了智能的行業標準，在廣泛的評估中超越了競爭對手的型號和Claude 3 Opus，具有我們中端型號的速度和成本效益。"
+
+#: apps/system_manage/serializers/valid_serializers.py:31
+msgid "The community version supports up to 2 users. If you need more users, please contact us (https://fit2cloud.com/)."
+msgstr "社區版支持最多2個用戶，如需更多用戶，請聯繫我們（https://fit2cloud.com/）。"
+
+#: apps/system_manage/serializers/valid_serializers.py:28
+msgid "The community version supports up to 5 applications. If you need more applications, please contact us (https://fit2cloud.com/)."
+msgstr "社區版支持最多5個智能體，如需更多智能體，請聯繫我們（https://fit2cloud.com/）。"
+
+#: apps/system_manage/serializers/valid_serializers.py:25
+msgid "The community version supports up to 50 knowledge bases. If you need more knowledge bases, please contact us (https://fit2cloud.com/)."
+msgstr "社區版支持最多50個知識庫，如需更多知識庫，請聯繫我們 (https://fit2cloud.com/)."
+
+#: apps/users/serializers/user.py:447
+#: apps/users/serializers/user.py:995
+#: apps/users/serializers/user.py:1053
+msgid "The confirmation password must be 6-20 characters long and must be a combination of letters, numbers, and special characters."
+msgstr "確認密碼必須為6-20個字符，且必須包含字母、數字和特殊字符。"
+
+#: no source
+msgid "The corresponding platform configuration for Slack was not found"
+msgstr "Slack 的對應平臺配置未找到"
+
+#: no source
+msgid "The corresponding platform configuration was not found"
+msgstr "未找到對應的平臺配置"
+
+#: apps/chat/serializers/chat.py:332
+msgid "The current model is not available"
+msgstr "當前模型不可用"
+
+#: apps/models_provider/base_model_provider.py:92
+msgid "The current platform does not support downloading models"
+msgstr "當前平臺不支持下載模型"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:25
+msgid "The default is body, you can enter .classname/#idname/tagname"
+msgstr "默認為 body，可輸入 .classname/#idname/tagname"
+
+#: apps/knowledge/serializers/paragraph.py:630
+msgid "The document id does not exist [{document_id}]"
+msgstr "以下文檔ID不存在: {error_id_list}"
+
+#: apps/application/serializers/application_chat_record.py:264
+#: apps/application/serializers/application_chat_record.py:400
+#: apps/knowledge/serializers/paragraph.py:349
+msgid "The document id is incorrect"
+msgstr "文檔 ID 不正確"
+
+#: apps/knowledge/serializers/paragraph.py:626
+msgid "The document to be migrated is consistent with the target document"
+msgstr "遷移的文檔與目標文檔一致"
+
+#: apps/common/event/__init__.py:34
+msgid "The download process was interrupted, please try again"
+msgstr "下載過程被中斷，請重試"
+
+#: apps/common/constants/exception_code_constants.py:35
+msgid "The email has been registered, please log in directly"
+msgstr "該郵箱已註冊，請直接登錄"
+
+#: apps/common/constants/exception_code_constants.py:36
+msgid "The email is not registered, please register first"
+msgstr "該郵箱未註冊，請先註冊"
+
+#: apps/users/serializers/user.py:1134
+msgid "The email service has not been set up. Please contact the administrator to set up the email service in [Email Settings]."
+msgstr "郵箱服務尚未設置，請聯繫管理員在 [郵箱設置] 中設置郵箱服務。"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:32
+#: apps/tools/serializers/tool.py:265
+#: apps/trigger/serializers/trigger.py:49
+msgid "The field only supports custom|reference"
+msgstr "欄位僅支持自定義|引用"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:28
+msgid "The field only supports string|int|dict|array|float"
+msgstr "欄位僅支持字符串|整數|字典|數組|浮點數"
+
+#: apps/common/forms/base_field.py:64
+msgid "The field {field_label} is required"
+msgstr "{field_label} 欄位是必填項"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:27
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:47
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:46
+msgid "The following fields are required: {keys}"
+msgstr "以下欄位是必填項: {keys}"
+
+#: apps/trigger/serializers/trigger.py:43
+msgid "The following id does not exist: %s"
+msgstr "以下 id 不存在: %s"
+
+#: apps/knowledge/serializers/common.py:62
+msgid "The following id does not exist: {error_id_list}"
+msgstr "以下ID不存在: {error_id_list}"
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:39
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:42
+msgid "The function has been deleted"
+msgstr "工具已被刪除"
+
+#: apps/application/flow/common.py:276
+msgid "The function library for node {node} is not available"
+msgstr "工具庫 {node} 不可用"
+
+#: apps/knowledge/serializers/document.py:1507
+msgid "The hit processing method must be directly_return|optimization"
+msgstr "命中處理方法必須是直接返回|優化"
+
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:15
+msgid "The image generation endpoint allows you to create raw images based on text prompts. "
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:15
+msgid "The image generation endpoint allows you to create raw images based on text prompts. The dimensions of the image can be 1024x1024, 1024x1792, or 1792x1024 pixels."
+msgstr "圖像生成端點允許您根據文本提示創建原始圖像。圖像的尺寸可以為 1024x1024、1024x1792 或 1792x1024 像素。"
+
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:15
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:15
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:15
+msgid "The image generation endpoint allows you to create raw images based on text prompts. When using the DALL·E 3, the image size can be 1024x1024, 1024x1792 or 1792x1024 pixels."
+msgstr "圖像生成端點允許您根據文本提示創建原始圖像。使用 DALL·E 3 時，圖像的尺寸可以為 1024x1024、1024x1792 或 1792x1024 像素。"
+
+#: apps/application/serializers/application.py:248
+msgid "The knowledge base id does not exist"
+msgstr "知識庫 ID 不存在"
+
+#: apps/knowledge/serializers/common.py:123
+#: apps/knowledge/serializers/common.py:159
+msgid "The knowledge base is inconsistent with the vector model"
+msgstr "知識庫與向量模型不一致"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:42
+msgid "The knowledge base setting is wrong, please reset the knowledge base"
+msgstr "知識庫設置錯誤，請重置知識庫"
+
+#: apps/knowledge/serializers/knowledge_workflow.py:214
+msgid "The knowledge base workflow has not been published"
+msgstr ""
+
+#: apps/models_provider/serializers/model_serializer.py:530
+msgid "The label field is required for the {index}th item in model_params_form"
+msgstr "model_params_form 中的第 {index} 项的 label 字段是必填项"
+
+#: apps/models_provider/impl/docker_ai_model_provider/docker_ai_model_provider.py:73
+msgid "The latest gpt-3.5-turbo, updated with DockerAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:35
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:116
+#: apps/models_provider/impl/regolo_model_provider/regolo_model_provider.py:67
+#: apps/models_provider/impl/siliconCloud_model_provider/siliconCloud_model_provider.py:127
+msgid "The latest gpt-3.5-turbo, updated with OpenAI adjustments"
+msgstr "最新的gpt-3.5-turbo，隨OpenAI調整而更新"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:46
+msgid "The latest gpt-4-turbo, updated with OpenAI adjustments"
+msgstr "最新的gpt-4-turbo，隨OpenAI調整而更新"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:49
+msgid "The latest gpt-4-turbo-preview, updated with OpenAI adjustments"
+msgstr "最新的gpt-4-turbo-preview，隨OpenAI調整而更新"
+
+#: apps/models_provider/impl/docker_ai_model_provider/docker_ai_model_provider.py:49
+msgid "The latest GPT-4o, cheaper and faster than gpt-4-turbo, updated with DockerAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:40
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:99
+msgid "The latest GPT-4o, cheaper and faster than gpt-4-turbo, updated with OpenAI adjustments"
+msgstr "最新的GPT-4o，比gpt-4-turbo更便宜、更快，隨OpenAI調整而更新"
+
+#: apps/models_provider/impl/docker_ai_model_provider/docker_ai_model_provider.py:53
+msgid "The latest gpt-4o-mini, cheaper and faster than gpt-4o, updated with DockerAI adjustments"
+msgstr ""
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:43
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:102
+msgid "The latest gpt-4o-mini, cheaper and faster than gpt-4o, updated with OpenAI adjustments"
+msgstr "最新的gpt-4o-mini，比gpt-4o更便宜、更快，隨OpenAI調整而更新"
+
+#: apps/application/flow/common.py:273
+msgid "The library ID of node {node} cannot be empty"
+msgstr "工具庫 ID {node} 不能為空"
+
+#: no source
+msgid "The license is invalid"
+msgstr "許可證無效"
+
+#: apps/knowledge/serializers/document.py:1223
+msgid "The maximum size of the uploaded file cannot exceed {}MB"
+msgstr "上傳文件的最大大小不能超過 {}MB"
+
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:35
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:48
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:53
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:50
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:47
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:48
+msgid "The model does not exist, please download the model first"
+msgstr "模型不存在，請先下載模型"
+
+#: apps/models_provider/base_model_provider.py:230
+msgid "The model does not support"
+msgstr "模型不支持"
+
+#: apps/chat/serializers/chat.py:334
+msgid "The model is downloading, please try again later"
+msgstr "下載過程被中斷，請重試"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:40
+msgid "The most effective version of the current hybrid model, the trillion-level parameter scale MOE-32K long article model. Reaching the absolute leading level on various benchmarks, with complex instructions and reasoning, complex mathematical capabilities, support for function call, and application focus optimization in fields such as multi-language translation, finance, law, and medical care"
+msgstr "當前混元模型中效果最優版本，萬億級參數規模 MOE-32K 長文模型。在各種 benchmark 上達到絕對領先的水平，複雜指令和推理，具備複雜數學能力，支持 functioncall，在多語言翻譯、金融法律醫療等領域智能體重點優化"
+
+#: no source
+msgid "The network is busy, try again later."
+msgstr "網絡繁忙，請稍後再試。"
+
+#: apps/common/constants/exception_code_constants.py:44
+msgid "The nickname is already registered"
+msgstr "暱稱已註冊"
+
+#: apps/application/flow/common.py:257
+msgid "The node {node} model does not exist"
+msgstr "節點 {node} 模型不存在"
+
+#: apps/chat/serializers/chat.py:321
+msgid "The number of visits exceeds today's visits"
+msgstr "今天的訪問次數超過限制"
+
+#: apps/application/serializers/application_chat_record.py:517
+msgid "The paragraph id is wrong. The current conversation record does not exist. [{paragraph_id}] paragraph id"
+msgstr "段落 ID 錯誤。當前對話記錄不存在。[{paragraph_id}] 段落 ID"
+
+#: no source
+msgid "The password is incorrect"
+msgstr "密碼不正確"
+
+#: apps/users/serializers/user.py:191
+#: apps/users/serializers/user.py:435
+#: apps/users/serializers/user.py:983
+#: apps/users/serializers/user.py:1041
+msgid "The password must be 6-20 characters long and must be a combination of letters, numbers, and special characters."
+msgstr "密碼必須為6-20個字符，且必須包含大小写字母、數字和特殊字符。"
+
+#: no source
+msgid "The platform configuration corresponding to {type} was not found"
+msgstr "未找到對應 {type} 的平臺配置"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:167
+msgid "The Qwen Audio based end-to-end speech recognition model supports audio recognition within 3 minutes. At present, it mainly supports Chinese and English recognition."
+msgstr "基於Qwen-Audio的端到端語音辨識大模型，支持3分鐘以內的音訊識別，現時主要支持中英文識別。"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:149
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:158
+msgid "The Qwen Omni series model supports inputting multiple modalities of data, including video, audio, images, and text, and outputting audio and text."
+msgstr "Qwen-Omni系列模型支持輸入多種模態的數據，包括視頻、音訊、圖片、文字，並輸出音訊與文字"
+
+#: apps/application/flow/step_node/reranker_node/i_reranker_node.py:39
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:45
+msgid "The results are displayed in the knowledge sources"
+msgstr ""
+
+#: apps/application/flow/common.py:244
+msgid "The starting node is required"
+msgstr "開始節點是必需的"
+
+#: apps/application/flow/step_node/application_node/impl/base_application_node.py:194
+msgid "The sub application cannot use the current node"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:1264
+msgid "The synchronization type only supports:replace|complete"
+msgstr "同步類型僅支持:replace|complete"
+
+#: apps/knowledge/serializers/paragraph.py:640
+msgid "The target document id does not exist [{document_id}]"
+msgstr "以下目標文檔ID不存在: {error_id_list}"
+
+#: apps/knowledge/serializers/paragraph.py:598
+msgid "The task is being executed, please do not send it again."
+msgstr "任務正在執行，請勿重複發送。"
+
+#: apps/knowledge/serializers/document.py:882
+#: apps/knowledge/serializers/document.py:920
+msgid "The task is being executed, please do not send it repeatedly."
+msgstr "任務正在執行，請勿重複發送。"
+
+#: apps/knowledge/serializers/document.py:265
+msgid "The template type only supports excel|csv"
+msgstr "模板類型僅支持 excel|csv"
+
+#: apps/application/serializers/application.py:269
+msgid "The thinking process begins to mark"
+msgstr "思考過程開始標記"
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:191
+msgid "The tool has not been published. Please use it after publishing."
+msgstr ""
+
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:45
+#: apps/application/flow/step_node/search_knowledge_node/i_search_knowledge_node.py:30
+#: apps/application/serializers/application.py:216
+#: apps/knowledge/serializers/knowledge.py:166
+#: apps/knowledge/serializers/knowledge.py:1371
+msgid "The type only supports embedding|keywords|blend"
+msgstr "類型僅支持嵌入|關鍵字|混合"
+
+#: apps/knowledge/serializers/document.py:166
+#: apps/knowledge/serializers/document.py:256
+msgid "The type only supports optimization|directly_return"
+msgstr "該類型僅支持優化|直接返回"
+
+#: apps/users/serializers/user.py:1091
+#: apps/users/serializers/user.py:1173
+msgid "The type only supports register|reset_password"
+msgstr "類型僅支持 register|reset_password"
+
+#: no source
+msgid "The user does not have permission to access the application"
+msgstr "用戶沒有訪問智能體的權限"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:46
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:51
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:80
+msgid "The user goes to the model inference page of Volcano Ark to create an inference access point. Here, you need to enter ep-xxxxxxxxxx-yyyy to call it."
+msgstr "用戶前往火山方舟的模型推理頁面創建推理接入點，這裡需要輸入ep-xxxxxxxxxx-yyyy進行調用"
+
+#: apps/users/serializers/login.py:158
+msgid "The user has been disabled, please contact the administrator!"
+msgstr "用戶已被禁用，請聯繫管理員！"
+
+#: apps/common/constants/exception_code_constants.py:41
+msgid "The username cannot be empty and must be between 6 and 20 characters long."
+msgstr "用戶名不能為空，且長度在6到20個字符之間。"
+
+#: apps/common/constants/exception_code_constants.py:39
+msgid "The username has been registered, please log in directly"
+msgstr "用戶名已註冊，請直接登錄"
+
+#: apps/common/constants/exception_code_constants.py:31
+#: apps/users/serializers/login.py:150
+msgid "The username or password is incorrect"
+msgstr "用戶名或密碼不正確"
+
+#: apps/application/chat_pipeline/step/search_dataset_step/impl/base_search_dataset_step.py:40
+msgid "The vector model of the associated knowledge base is inconsistent and the segmentation cannot be recalled."
+msgstr "關聯的知識庫的向量模型不一致，無法回調分段。"
+
+#: apps/common/constants/exception_code_constants.py:38
+msgid "The verification code is incorrect or the verification code has expired"
+msgstr "驗證碼不正確或已過期"
+
+#: apps/common/forms/slider_field.py:62
+msgid "The {field_label} cannot be greater than {max}"
+msgstr "{field_label} 不能大於{max}"
+
+#: apps/common/forms/slider_field.py:56
+msgid "The {field_label} cannot be less than {min}"
+msgstr "{field_label} 不能小於{min}"
+
+#: apps/models_provider/serializers/model_serializer.py:523
+msgid "The {index}th item in model_params_form must be a dictionary"
+msgstr "model_params_form 中的第 {index} 项必须是一个字典"
+
+#: no source
+msgid "theme"
+msgstr "主題"
+
+#: no source
+msgid "theme color"
+msgstr "主題顏色"
+
+#: apps/application/flow/common.py:284
+msgid "There can only be one basic information node"
+msgstr "只能有一個基本信息節點"
+
+#: apps/application/flow/common.py:246
+msgid "There can only be one starting node"
+msgstr "只能有一個開始節點"
+
+#: apps/tools/serializers/tool_workflow.py:287
+msgid "There is a circular dependency in the tool workflow"
+msgstr "工具工作流存在迴圈依賴"
+
+#: no source
+msgid "Think: "
+msgstr "思考内容: "
+
+#: no source
+msgid "Thinking about 【{question}】...If you want me to continue answering, please reply {trigger_message}"
+msgstr "思考【{question}】...如果你想讓我繼續回答，請回復 {trigger_message}"
+
+#: apps/application/serializers/application.py:261
+msgid "Thinking process switch"
+msgstr "思考過程開關"
+
+#: no source
+msgid "Thinking, please wait a moment!"
+msgstr "思考中，請稍等！"
+
+#: no source
+msgid "Thinking..."
+msgstr "思考中..."
+
+#: apps/users/serializers/login.py:138
+#: apps/users/serializers/login.py:259
+msgid "This account has been locked for %s minutes, please try again later"
+msgstr "該帳號已被鎖定 %s 分鐘，請稍後再試"
+
+#: apps/common/handle/impl/text/pdf_split_handle.py:381
+msgid "This document has no preface and is treated as ordinary text: {e}"
+msgstr "該文檔沒有前言，視為普通文本: {e}"
+
+#: apps/folders/serializers/folder.py:276
+msgid "This folder contains resources that you dont have permission"
+msgstr "此資料夾包含您沒有許可權的資源"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:77
+msgid "This interface is used to recognize short audio files within 60 seconds. Supports Mandarin Chinese, English, Cantonese, Japanese, Vietnamese, Malay, Indonesian, Filipino, Thai, Portuguese, Turkish, Arabic, Hindi, French, German, and 23 Chinese dialects."
+msgstr "本介面用於識別 60 秒之內的短音頻文件。支援中文普通話、英語、粵語、日語、越南語、馬來語、印度尼西亞語、菲律賓語、泰語、葡萄牙語、土耳其語、阿拉伯語、印地語、法語、德語及 23 種漢語方言。"
+
+#: no source
+msgid "This type of message is not supported yet"
+msgstr "此類型消息暫不支持"
+
+#: no source
+msgid "This workspace contains %s, cannot be deleted."
+msgstr "此工作空間包含 %s，不能被刪除。"
+
+#: apps/models_provider/impl/wenxin_model_provider/wenxin_model_provider.py:74
+msgid "Thousand sails large model"
+msgstr "千帆大模型"
+
+#: no source
+msgid "Three-party login"
+msgstr "三方登錄"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:21
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:54
+msgid "Timbre"
+msgstr "音色"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:14
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:15
+msgid "timbre"
+msgstr "音色"
+
+#: apps/application/serializers/application_chat.py:222
+msgid "Time consumed (s)"
+msgstr "耗时 (s)"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:128
+msgid "Titan Embed Text is the largest embedding model in the Amazon Titan Embed series and can handle various text embedding tasks, such as text classification, text similarity calculation, etc."
+msgstr "Titan Embed Text 是 Amazon Titan Embed 系列中最大的嵌入模型，可以處理各種文本嵌入任務，如文本分類、文本相似度計算等。"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/aws_bedrock_model_provider.py:83
+msgid "Titan Text Premier is the most powerful and advanced model in the Titan Text series, designed to deliver exceptional performance for a variety of enterprise applications. With its cutting-edge features, it delivers greater accuracy and outstanding results, making it an excellent choice for organizations looking for a top-notch text processing solution."
+msgstr "Titan Text Premier 是 Titan Text 系列中功能強大且先進的型號，旨在為各種企業應用程序提供卓越的性能。憑藉其尖端功能，它提供了更高的準確性和出色的結果，使其成為尋求一流文本處理解決方案的組織的絕佳選擇。"
+
+#: no source
+msgid "title"
+msgstr "標題"
+
+#: no source
+msgid "To be continued, reply \"{trigger_message}\" to continue answering the question"
+msgstr "待續，回復 \"{trigger_message}\" 繼續回答問題"
+
+#: apps/chat/api/chat_embed_api.py:38
+#: apps/chat/serializers/chat_embed_serializers.py:27
+#: apps/users/serializers/login.py:48
+msgid "token"
+msgstr "令牌"
+
+#: no source
+msgid "Token"
+msgstr "令牌"
+
+#: no source
+msgid "Token address cannot be empty"
+msgstr "令牌地址不能為空"
+
+#: apps/homepage/serializers/homepage.py:303
+#: apps/homepage/serializers/homepage.py:626
+msgid "Token consumption"
+msgstr "Token消耗"
+
+#: no source
+msgid "token is required"
+msgstr "token 是必填項"
+
+#: no source
+msgid "Token is required"
+msgstr "Token 是必填項"
+
+#: apps/trigger/serializers/trigger.py:248
+msgid "token is required for EVENT triggers"
+msgstr "事件觸發器必須設定 token"
+
+#: apps/knowledge/views/document.py:401
+#: apps/knowledge/views/document.py:402
+#: apps/knowledge/views/document.py:403
+msgid "Tokenize document vector library"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:562
+msgid "Tokenize document: {document_id} error {error} {traceback}"
+msgstr ""
+
+#: apps/common/event/listener_manage.py:242
+msgid "Tokenize paragraph: {paragraph_id} error {error} {traceback}"
+msgstr ""
+
+#: apps/application/serializers/application_stats.py:33
+msgid "Tokens consumption"
+msgstr "消耗的令牌"
+
+#: apps/homepage/views/homepage.py:58
+#: apps/homepage/views/homepage.py:59
+msgid "Tokens data aggregation"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:184
+msgid "Tongyi Wanxiang - a large image model for text generation, supports bilingual input in Chinese and English, and supports the input of reference pictures for reference content or reference style migration. Key styles include but are not limited to watercolor, oil painting, Chinese painting, sketch, flat illustration, two-dimensional, and 3D. Cartoon."
+msgstr "通義萬相-文本生成圖像大模型，支持中英文雙語輸入，支持輸入參考圖片進行參考內容或者參考風格遷移，重點風格包括但不限於水彩、油畫、中國畫、素描、扁平插畫、二次元、3D卡通。"
+
+#: apps/chat/serializers/chat.py:62
+msgid "Too many messages"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:343
+#: apps/common/constants/permission_constants.py:410
+#: apps/common/constants/permission_constants.py:420
+#: apps/common/constants/permission_constants.py:437
+#: apps/knowledge/views/knowledge.py:321
+#: apps/tools/views/tool.py:50
+#: apps/tools/views/tool.py:73
+#: apps/tools/views/tool.py:104
+#: apps/tools/views/tool.py:127
+#: apps/tools/views/tool.py:154
+#: apps/tools/views/tool.py:180
+#: apps/tools/views/tool.py:211
+#: apps/tools/views/tool.py:249
+#: apps/tools/views/tool.py:287
+#: apps/tools/views/tool.py:318
+#: apps/tools/views/tool.py:351
+#: apps/tools/views/tool.py:379
+#: apps/tools/views/tool.py:409
+#: apps/tools/views/tool.py:434
+#: apps/tools/views/tool.py:462
+#: apps/tools/views/tool.py:487
+#: apps/tools/views/tool.py:506
+#: apps/tools/views/tool.py:534
+#: apps/tools/views/tool.py:553
+#: apps/tools/views/tool.py:583
+#: apps/tools/views/tool.py:616
+#: apps/tools/views/tool.py:645
+#: apps/tools/views/tool.py:674
+#: apps/tools/views/tool_workflow.py:35
+#: apps/tools/views/tool_workflow.py:74
+#: apps/tools/views/tool_workflow.py:105
+#: apps/tools/views/tool_workflow.py:135
+#: apps/tools/views/tool_workflow.py:164
+#: apps/tools/views/tool_workflow.py:198
+msgid "Tool"
+msgstr "工具"
+
+#: apps/tools/serializers/tool.py:287
+#: apps/tools/serializers/tool.py:303
+#: apps/tools/serializers/tool.py:328
+#: apps/tools/serializers/tool.py:551
+msgid "tool content"
+msgstr "工具內容"
+
+#: apps/homepage/views/homepage.py:301
+#: apps/homepage/views/homepage.py:302
+msgid "Tool data aggregation"
+msgstr "工具資料彙總"
+
+#: apps/tools/serializers/tool.py:285
+#: apps/tools/serializers/tool.py:300
+msgid "tool description"
+msgstr "工具描述"
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:118
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:123
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:137
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:142
+#: apps/tools/serializers/tool.py:1220
+#: apps/tools/serializers/tool.py:1387
+#: apps/tools/serializers/tool.py:1559
+msgid "Tool does not exist"
+msgstr "工具不存在"
+
+#: apps/tools/serializers/tool.py:619
+#: apps/tools/serializers/tool.py:1211
+#: apps/tools/serializers/tool.py:1309
+#: apps/tools/serializers/tool.py:1376
+#: apps/tools/serializers/tool.py:1426
+#: apps/tools/serializers/tool.py:1434
+#: apps/tools/serializers/tool.py:1546
+#: apps/tools/serializers/tool_workflow.py:146
+msgid "tool id"
+msgstr "工具 ID"
+
+#: apps/tools/serializers/tool_version.py:34
+#: apps/tools/serializers/tool_version.py:69
+msgid "Tool ID"
+msgstr ""
+
+#: apps/tools/serializers/tool_workflow.py:376
+msgid "Tool id"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:632
+#: apps/tools/serializers/tool.py:641
+#: apps/tools/serializers/tool.py:1162
+#: apps/tools/serializers/tool_version.py:80
+#: apps/tools/serializers/tool_workflow.py:155
+#: apps/tools/serializers/tool_workflow.py:387
+msgid "Tool id does not exist"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:45
+msgid "Tool IDs"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py:125
+#: apps/application/flow/step_node/tool_workflow_lib_node/impl/base_tool_workflow_lib_node.py:144
+msgid "Tool is not active"
+msgstr ""
+
+#: apps/application/serializers/application.py:919
+#: apps/knowledge/serializers/knowledge.py:1419
+#: apps/tools/serializers/tool.py:283
+#: apps/tools/serializers/tool.py:299
+#: apps/tools/serializers/tool.py:318
+#: apps/tools/serializers/tool.py:343
+#: apps/tools/serializers/tool.py:1194
+#: apps/tools/serializers/tool.py:1255
+#: apps/tools/serializers/tool.py:1688
+#: apps/tools/serializers/tool_workflow.py:413
+msgid "tool name"
+msgstr "工具名稱"
+
+#: apps/tools/serializers/tool.py:653
+msgid "Tool not found"
+msgstr "工具不存在"
+
+#: apps/application/flow/step_node/mcp_node/i_mcp_node.py:18
+msgid "Tool parameters"
+msgstr "工具參數"
+
+#: apps/tools/serializers/tool.py:1465
+msgid "Tool record does not exist"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:346
+#: apps/tools/serializers/tool.py:1691
+msgid "tool type"
+msgstr ""
+
+#: apps/tools/serializers/tool.py:1693
+msgid "tool type list"
+msgstr ""
+
+#: apps/tools/serializers/tool_version.py:71
+msgid "Tool version ID"
+msgstr ""
+
+#: apps/tools/views/tool_workflow.py:130
+#: apps/tools/views/tool_workflow.py:131
+#: apps/tools/views/tool_workflow.py:132
+msgid "tool workflow debug"
+msgstr ""
+
+#: apps/tools/views/tool_workflow_version.py:46
+#: apps/tools/views/tool_workflow_version.py:70
+#: apps/tools/views/tool_workflow_version.py:95
+#: apps/tools/views/tool_workflow_version.py:117
+msgid "Tool/Version"
+msgstr ""
+
+#: no source
+msgid "Tools Resource"
+msgstr "工具資源"
+
+#: apps/homepage/views/homepage.py:158
+#: apps/homepage/views/homepage.py:159
+msgid "Top applications by question count"
+msgstr "提問次數 TOP 智慧體"
+
+#: apps/homepage/views/homepage.py:133
+#: apps/homepage/views/homepage.py:134
+msgid "Top applications by question count export"
+msgstr ""
+
+#: apps/homepage/views/homepage.py:108
+#: apps/homepage/views/homepage.py:109
+msgid "Top applications by token consumption"
+msgstr "tokens 消耗 TOP 智慧體"
+
+#: apps/homepage/views/homepage.py:83
+#: apps/homepage/views/homepage.py:84
+msgid "Top applications by token consumption export"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:17
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:14
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:23
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:23
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:23
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:23
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:16
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:15
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:21
+msgid "Top N"
+msgstr ""
+
+#: apps/knowledge/serializers/knowledge.py:158
+#: apps/knowledge/serializers/knowledge.py:1363
+msgid "top number"
+msgstr "Top 數量"
+
+#: apps/homepage/views/homepage.py:207
+#: apps/homepage/views/homepage.py:208
+msgid "Top users by token consumption"
+msgstr "tokens 消耗 TOP 使用者"
+
+#: apps/homepage/views/homepage.py:183
+#: apps/homepage/views/homepage.py:184
+msgid "Top users by token consumption export"
+msgstr ""
+
+#: apps/homepage/api/home_page_api.py:247
+msgid "Total application count"
+msgstr "應用總數"
+
+#: apps/homepage/api/home_page_api.py:165
+#: apps/homepage/api/home_page_api.py:221
+msgid "Total consumed tokens"
+msgstr "消耗 tokens 總數"
+
+#: apps/homepage/api/home_page_api.py:157
+#: apps/homepage/api/home_page_api.py:187
+#: apps/homepage/api/home_page_api.py:212
+msgid "Total count"
+msgstr "總數量"
+
+#: apps/homepage/api/home_page_api.py:311
+msgid "Total document count"
+msgstr "文件總數"
+
+#: apps/homepage/api/home_page_api.py:310
+msgid "Total knowledge count"
+msgstr "知識庫總數"
+
+#: apps/homepage/api/home_page_api.py:384
+msgid "Total model count"
+msgstr "模型總數"
+
+#: apps/common/result/api.py:43
+msgid "total number of data"
+msgstr "總數據"
+
+#: apps/application/serializers/application_stats.py:30
+msgid "Total number of users"
+msgstr "總用戶數"
+
+#: apps/homepage/api/home_page_api.py:347
+msgid "Total tool count"
+msgstr "工具總數"
+
+#: no source
+msgid "trial listening"
+msgstr "試聽"
+
+#: apps/application/serializers/application_chat.py:295
+#: apps/common/constants/permission_constants.py:344
+#: apps/trigger/handler/impl/trigger/event_trigger.py:91
+#: apps/trigger/views/trigger.py:63
+#: apps/trigger/views/trigger.py:84
+#: apps/trigger/views/trigger.py:110
+#: apps/trigger/views/trigger.py:133
+#: apps/trigger/views/trigger.py:155
+#: apps/trigger/views/trigger.py:181
+#: apps/trigger/views/trigger.py:207
+#: apps/trigger/views/trigger.py:232
+#: apps/trigger/views/trigger.py:260
+#: apps/trigger/views/trigger.py:295
+#: apps/trigger/views/trigger.py:323
+#: apps/trigger/views/trigger.py:348
+#: apps/trigger/views/trigger.py:380
+#: apps/trigger/views/trigger_task.py:33
+#: apps/trigger/views/trigger_task.py:58
+#: apps/trigger/views/trigger_task.py:83
+msgid "Trigger"
+msgstr "觸發器"
+
+#: apps/trigger/serializers/task_source_trigger.py:31
+#: apps/trigger/serializers/trigger.py:298
+#: apps/trigger/serializers/trigger.py:308
+msgid "trigger description"
+msgstr "觸發器描述"
+
+#: apps/trigger/serializers/task_source_trigger.py:60
+#: apps/trigger/serializers/trigger.py:501
+msgid "trigger id"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:306
+#: apps/trigger/serializers/trigger_task.py:42
+#: apps/trigger/serializers/trigger_task.py:66
+#: apps/trigger/serializers/trigger_task.py:126
+msgid "Trigger ID"
+msgstr "觸發器ID"
+
+#: apps/trigger/serializers/task_source_trigger.py:72
+#: apps/trigger/serializers/trigger.py:512
+#: apps/trigger/serializers/trigger_task.py:52
+#: apps/trigger/serializers/trigger_task.py:78
+#: apps/trigger/serializers/trigger_task.py:140
+msgid "Trigger id does not exist"
+msgstr "觸發器 id 不存在"
+
+#: apps/trigger/serializers/task_source_trigger.py:134
+#: apps/trigger/serializers/task_source_trigger.py:144
+#: apps/trigger/serializers/trigger.py:542
+#: apps/trigger/serializers/trigger.py:562
+msgid "Trigger must have at least one task"
+msgstr "觸發器必須至少有一個任務"
+
+#: apps/trigger/serializers/task_source_trigger.py:30
+#: apps/trigger/serializers/trigger.py:297
+#: apps/trigger/serializers/trigger.py:307
+msgid "trigger name"
+msgstr "觸發器名稱"
+
+#: apps/trigger/serializers/trigger.py:639
+#: apps/trigger/serializers/trigger_task.py:129
+msgid "Trigger name"
+msgstr ""
+
+#: apps/trigger/serializers/task_source_trigger.py:119
+#: apps/trigger/serializers/task_source_trigger.py:167
+#: apps/trigger/serializers/trigger.py:525
+msgid "Trigger not found"
+msgstr "未找到觸發器"
+
+#: apps/trigger/serializers/task_source_trigger.py:33
+#: apps/trigger/serializers/trigger.py:300
+#: apps/trigger/serializers/trigger.py:310
+msgid "trigger setting"
+msgstr "觸發器設定"
+
+#: apps/trigger/serializers/trigger_task.py:128
+msgid "Trigger state"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:642
+msgid "Trigger task"
+msgstr ""
+
+#: apps/trigger/serializers/trigger.py:395
+msgid "Trigger task can not be empty"
+msgstr "觸發器任務不能為空"
+
+#: apps/trigger/serializers/trigger_task.py:68
+msgid "Trigger task ID"
+msgstr "觸發器任務ID"
+
+#: apps/trigger/serializers/task_source_trigger.py:46
+msgid "Trigger task number must be one"
+msgstr "觸發器任務數量必須為一個"
+
+#: apps/trigger/serializers/trigger_task.py:69
+msgid "Trigger task record ID"
+msgstr "觸發器任務記錄ID"
+
+#: apps/trigger/serializers/trigger_task.py:87
+msgid "Trigger task record id does not exist"
+msgstr "觸發器任務記錄 id 不存在"
+
+#: apps/models_provider/api/provide.py:44
+msgid "trigger type"
+msgstr "觸發類型"
+
+#: apps/trigger/serializers/trigger.py:640
+msgid "Trigger type"
+msgstr ""
+
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:16
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:16
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:16
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:16
+msgid "Try out the different sounds (Alloy, Echo, Fable, Onyx, Nova, and Sparkle) to find one that suits your desired tone and audience. The current voiceover is optimized for English."
+msgstr "嘗試不同的聲音（合金、回聲、寓言、縞瑪瑙、新星和閃光），找到一種適合您所需的音調和聽眾的聲音。當前的語音針對英語進行了優化。"
+
+#: apps/models_provider/base_model_provider.py:150
+msgid "TTS"
+msgstr "語音合成"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:31
+msgid "Turkish"
+msgstr "土耳其語"
+
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:26
+#: apps/knowledge/serializers/document.py:268
+#: apps/knowledge/serializers/knowledge_workflow.py:299
+#: apps/knowledge/serializers/knowledge_workflow.py:300
+#: apps/system_manage/serializers/valid_serializers.py:37
+#: apps/tools/serializers/tool.py:251
+msgid "type"
+msgstr "類型"
+
+#: apps/users/serializers/user.py:1089
+#: apps/users/serializers/user.py:1170
+msgid "Type"
+msgstr "類型"
+
+#: apps/common/utils/common.py:476
+#: apps/common/utils/common.py:483
+msgid "type error"
+msgstr "類型錯誤"
+
+#: apps/users/serializers/user.py:486
+msgid "Unable to delete administrator"
+msgstr "無法刪除管理員"
+
+#: no source
+msgid "Universal 1.4-Vincent Chart"
+msgstr "通用1.4-文生圖"
+
+#: no source
+msgid "Universal 2.0-Vincent Diagram"
+msgstr "通用2.0-文生圖"
+
+#: no source
+msgid "Universal 2.0Pro-Vincent Chart"
+msgstr "通用2.0Pro-文生圖"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:42
+msgid "Universal realistic style"
+msgstr "通用寫實風格"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:98
+msgid "Universal text vector is Tongyi Lab's multi-language text unified vector model based on the LLM base. It provides high-level vector services for multiple mainstream languages around the world and helps developers quickly convert text data into high-quality vector data."
+msgstr "通用文本向量，是通義實驗室基於LLM底座的多語言文本統一向量模型，面向全球多個主流語種，提供高水準的向量服務，幫助開發者將文本數據快速轉換為高質量的向量數據。"
+
+#: no source
+msgid "Unknown application id {knowledge_id}, cannot be associated"
+msgstr "未知智能體 ID {knowledge_id}，無法關聯"
+
+#: apps/common/exception/handle_exception.py:35
+#: apps/common/handle/handle_exception.py:34
+msgid "Unknown exception"
+msgstr "未知錯誤"
+
+#: apps/application/serializers/application.py:1373
+#: apps/tools/serializers/tool_workflow.py:330
+msgid "Unknown knowledge base id {dataset_id}, unable to associate"
+msgstr "未知知識庫 ID {dataset_id}，無法關聯"
+
+#: apps/application/serializers/application.py:453
+msgid "Unpublished"
+msgstr "未發佈"
+
+#: apps/homepage/api/home_page_api.py:249
+msgid "Unpublished application count"
+msgstr "未發布應用數量"
+
+#: apps/application/serializers/application.py:750
+#: apps/application/serializers/application.py:1401
+#: apps/common/handle/impl/qa/zip_parse_qa_handle.py:56
+#: apps/common/handle/impl/text/zip_split_handle.py:59
+#: apps/knowledge/serializers/document.py:1166
+#: apps/knowledge/serializers/document.py:1188
+#: apps/knowledge/serializers/knowledge_workflow.py:405
+#: apps/tools/serializers/tool.py:1070
+#: apps/tools/serializers/tool.py:1092
+#: apps/tools/serializers/tool.py:1537
+msgid "Unsupported file format"
+msgstr "不支持的文件格式"
+
+#: no source
+msgid "Unsupported platform type"
+msgstr "不支持的平臺類型"
+
+#: no source
+msgid "Unsupported sync type"
+msgstr "不支持的同步類型"
+
+#: apps/knowledge/views/tag.py:74
+msgid "Update a knowledge tag"
+msgstr ""
+
+#: no source
+msgid "Update a lark knowledge base"
+msgstr "更新飛書知識庫"
+
+#: no source
+msgid "Update appearance settings"
+msgstr "更新外觀設置"
+
+#: apps/tools/views/tool.py:577
+#: apps/tools/views/tool.py:578
+#: apps/tools/views/tool.py:579
+msgid "Update Appstore tool"
+msgstr ""
+
+#: no source
+msgid "Update auth setting"
+msgstr "更新認證設置"
+
+#: no source
+msgid "Update chat user information"
+msgstr "更新對話用戶信息"
+
+#: apps/folders/views/folder.py:93
+#: apps/folders/views/folder.py:94
+#: apps/folders/views/folder.py:95
+msgid "Update folder"
+msgstr "更新文件夾"
+
+#: apps/knowledge/views/tag.py:73
+msgid "Update Knowledge Tag"
+msgstr ""
+
+#: apps/common/constants/permission_constants.py:1296
+msgid "Update License"
+msgstr "更新許可證"
+
+#: no source
+msgid "Update license information"
+msgstr "更新許可證信息"
+
+#: no source
+msgid "Update license information by uploading a new license file"
+msgstr "通過上傳新許可證文件更新許可證信息"
+
+#: apps/models_provider/views/model.py:82
+#: apps/models_provider/views/model.py:83
+#: apps/models_provider/views/model.py:114
+#: apps/models_provider/views/model.py:115
+#: apps/models_provider/views/model.py:116
+msgid "Update model"
+msgstr "更新模型"
+
+#: no source
+msgid "Update personal system API_KEY"
+msgstr "更新個人系統 API KEY"
+
+#: no source
+msgid "Update platform configuration"
+msgstr "更新平臺配置"
+
+#: no source
+msgid "Update platform status"
+msgstr "更新平臺狀態"
+
+#: no source
+msgid "Update shared knowledge"
+msgstr "更新共享知識庫"
+
+#: no source
+msgid "Update shared tool"
+msgstr "更新共享工具"
+
+#: no source
+msgid "Update system knowledge"
+msgstr "更新系統知識庫"
+
+#: no source
+msgid "Update system tool"
+msgstr "更新工具"
+
+#: no source
+msgid "Update SystemAPIKey"
+msgstr "更新系統 API 密鑰"
+
+#: apps/tools/views/tool.py:121
+#: apps/tools/views/tool.py:122
+#: apps/tools/views/tool.py:123
+msgid "Update tool"
+msgstr "更新工具"
+
+#: apps/users/views/user.py:230
+#: apps/users/views/user.py:231
+#: apps/users/views/user.py:232
+msgid "Update user information"
+msgstr "更新當前用戶信息"
+
+#: apps/models_provider/impl/tencent_model_provider/tencent_model_provider.py:53
+msgid "Upgraded to MOE structure, the context window is 256k, leading many open source models in multiple evaluation sets such as NLP, code, mathematics, industry, etc."
+msgstr "升級為 MOE 結構，上下文窗口為 256k ，在 NLP，代碼，數學，行業等多項評測集上領先眾多開源模型"
+
+#: apps/oss/views/file.py:38
+#: apps/oss/views/file.py:39
+#: apps/oss/views/file.py:40
+msgid "Upload file"
+msgstr "上傳文件"
+
+#: apps/application/flow/step_node/data_source_local_node/i_data_source_local_node.py:22
+msgid "Upload file size"
+msgstr ""
+
+#: apps/chat/views/chat.py:259
+#: apps/chat/views/chat.py:260
+#: apps/chat/views/chat.py:261
+msgid "Upload files"
+msgstr ""
+
+#: apps/tools/views/tool.py:668
+#: apps/tools/views/tool.py:669
+#: apps/tools/views/tool.py:670
+msgid "Upload skill file"
+msgstr ""
+
+#: apps/knowledge/serializers/common.py:44
+msgid "URL error, cannot parse [{source_url}]"
+msgstr "URL 錯誤，無法解析 [{source_url}]"
+
+#: apps/application/serializers/application_chat.py:220
+msgid "User"
+msgstr ""
+
+#: no source
+msgid "USER"
+msgstr "普通用戶"
+
+#: no source
+msgid "user"
+msgstr "用戶"
+
+#: no source
+msgid "user avatar"
+msgstr "用戶頭像"
+
+#: no source
+msgid "user avatar url"
+msgstr "用戶頭像地址"
+
+#: apps/users/serializers/user.py:471
+msgid "User does not exist"
+msgstr "用戶不存在"
+
+#: no source
+msgid "User does not have permission to use API Key"
+msgstr "使用者沒有使用 API Key 的權限"
+
+#: apps/application/serializers/application_chat.py:216
+msgid "User feedback"
+msgstr "用戶反饋"
+
+#: apps/common/constants/permission_constants.py:406
+#: apps/common/constants/permission_constants.py:430
+msgid "User Group"
+msgstr "用戶組"
+
+#: no source
+msgid "User group"
+msgstr "用戶組"
+
+#: no source
+msgid "User group does not exist"
+msgstr "用戶組不存在"
+
+#: no source
+msgid "User Group ID"
+msgstr "用戶組 ID"
+
+#: no source
+msgid "User group id"
+msgstr "用戶組ID"
+
+#: no source
+msgid "User Group IDs"
+msgstr "用戶組 IDs"
+
+#: no source
+msgid "User Group IDs cannot be empty"
+msgstr "用戶組 IDs 不能為空"
+
+#: no source
+msgid "User group name"
+msgstr "用戶名"
+
+#: no source
+msgid "User group name already exists"
+msgstr "用戶組名稱已存在"
+
+#: no source
+msgid "User Group Names"
+msgstr "用戶組名稱"
+
+#: no source
+msgid "User group relation IDs"
+msgstr "用戶組關係 ID"
+
+#: no source
+msgid "User group relation IDs cannot be empty"
+msgstr "用戶組關係 IDs 不能為空"
+
+#: apps/application/api/application_api.py:89
+#: apps/application/chat_pipeline/step/reset_problem_step/i_reset_problem_step.py:30
+#: apps/application/serializers/application.py:227
+#: apps/application/serializers/application.py:455
+#: apps/application/serializers/application.py:475
+#: apps/application/serializers/application.py:632
+#: apps/application/serializers/application.py:918
+#: apps/application/serializers/application.py:994
+#: apps/application/serializers/application_chat_link.py:58
+#: apps/homepage/serializers/homepage.py:90
+#: apps/homepage/serializers/homepage.py:151
+#: apps/homepage/serializers/homepage.py:216
+#: apps/homepage/serializers/homepage.py:388
+#: apps/homepage/serializers/homepage.py:515
+#: apps/homepage/serializers/homepage.py:655
+#: apps/homepage/serializers/homepage.py:737
+#: apps/homepage/serializers/homepage.py:778
+#: apps/homepage/serializers/homepage.py:827
+#: apps/homepage/serializers/homepage.py:874
+#: apps/knowledge/serializers/knowledge.py:1418
+#: apps/knowledge/serializers/knowledge.py:1473
+#: apps/knowledge/serializers/knowledge_workflow.py:647
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:15
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:14
+#: apps/models_provider/serializers/model_serializer.py:358
+#: apps/tools/serializers/tool.py:909
+#: apps/tools/serializers/tool.py:1152
+#: apps/tools/serializers/tool.py:1193
+#: apps/tools/serializers/tool.py:1209
+#: apps/tools/serializers/tool.py:1254
+#: apps/tools/serializers/tool.py:1307
+#: apps/tools/serializers/tool.py:1374
+#: apps/tools/serializers/tool.py:1530
+#: apps/tools/serializers/tool.py:1544
+#: apps/tools/serializers/tool_workflow.py:377
+#: apps/tools/serializers/tool_workflow.py:412
+#: apps/trigger/serializers/task_source_trigger.py:40
+#: apps/trigger/serializers/trigger.py:348
+#: apps/trigger/serializers/trigger.py:452
+#: apps/trigger/serializers/trigger.py:502
+#: apps/users/api/user.py:52
+#: apps/users/api/user.py:110
+#: apps/users/api/user.py:126
+#: apps/users/serializers/user.py:463
+msgid "User ID"
+msgstr "用戶 ID"
+
+#: apps/folders/serializers/folder.py:135
+#: apps/folders/serializers/folder.py:179
+#: apps/knowledge/serializers/document.py:1003
+#: apps/knowledge/serializers/document.py:1316
+#: apps/knowledge/serializers/knowledge.py:188
+#: apps/knowledge/serializers/knowledge.py:314
+#: apps/knowledge/serializers/knowledge.py:883
+#: apps/knowledge/serializers/knowledge.py:1134
+#: apps/knowledge/serializers/knowledge.py:1257
+#: apps/knowledge/serializers/knowledge.py:1361
+#: apps/knowledge/serializers/knowledge.py:1503
+#: apps/knowledge/serializers/knowledge_workflow.py:317
+#: apps/knowledge/serializers/knowledge_workflow.py:389
+#: apps/knowledge/serializers/knowledge_workflow.py:516
+#: apps/knowledge/serializers/knowledge_workflow.py:566
+#: apps/models_provider/serializers/model_serializer.py:129
+#: apps/models_provider/serializers/model_serializer.py:246
+#: apps/models_provider/serializers/model_serializer.py:284
+#: apps/system_manage/api/user_resource_permission.py:116
+#: apps/system_manage/serializers/user_resource_permission.py:109
+#: apps/tools/serializers/tool.py:344
+#: apps/tools/serializers/tool.py:464
+#: apps/tools/serializers/tool.py:563
+#: apps/tools/serializers/tool.py:1689
+#: apps/tools/serializers/tool_workflow.py:144
+#: apps/users/serializers/user.py:1187
+msgid "user id"
+msgstr "用戶ID"
+
+#: apps/users/api/user.py:135
+#: apps/users/serializers/user.py:623
+msgid "User IDs"
+msgstr "用戶 ID"
+
+#: apps/users/serializers/user.py:628
+msgid "User IDs cannot be empty"
+msgstr "用戶 ID 不能為空"
+
+#: no source
+msgid "User information address cannot be empty"
+msgstr "用戶信息地址不能為空"
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:20
+msgid "User Input Fields"
+msgstr "用戶輸入欄位"
+
+#: apps/common/constants/permission_constants.py:326
+#: apps/users/views/login.py:41
+#: apps/users/views/login.py:58
+#: apps/users/views/login.py:73
+#: apps/users/views/user.py:71
+#: apps/users/views/user.py:85
+#: apps/users/views/user.py:99
+#: apps/users/views/user.py:118
+#: apps/users/views/user.py:133
+#: apps/users/views/user.py:149
+#: apps/users/views/user.py:164
+#: apps/users/views/user.py:178
+#: apps/users/views/user.py:194
+#: apps/users/views/user.py:209
+#: apps/users/views/user.py:222
+#: apps/users/views/user.py:233
+#: apps/users/views/user.py:252
+#: apps/users/views/user.py:268
+#: apps/users/views/user.py:287
+#: apps/users/views/user.py:303
+#: apps/users/views/user.py:324
+#: apps/users/views/user.py:342
+#: apps/users/views/user.py:359
+#: apps/users/views/user.py:377
+msgid "User Management"
+msgstr "用戶管理"
+
+#: no source
+msgid "User management"
+msgstr "用戶管理"
+
+#: no source
+msgid "user manual url"
+msgstr "用戶手冊網址"
+
+#: apps/homepage/serializers/homepage.py:218
+#: apps/homepage/serializers/homepage.py:302
 msgid "User Name"
 msgstr "用戶名稱"
 
-msgid "New chat"
-msgstr "已生成新對話，請重新提問！"
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:62
+#: apps/application/flow/step_node/application_node/i_application_node.py:17
+#: apps/application/serializers/application_chat.py:214
+#: apps/chat/serializers/chat.py:75
+msgid "User Questions"
+msgstr "用戶問題"
+
+#: apps/users/serializers/user.py:1146
+msgid "User registration"
+msgstr "用戶註冊"
+
+#: no source
+msgid "User relation does not exist"
+msgstr "用戶關係不存在"
+
+#: no source
+msgid "User relation ID"
+msgstr "用戶關係 ID"
+
+#: no source
+msgid "User Relation ID"
+msgstr "用戶關係 ID"
+
+#: apps/homepage/api/home_page_api.py:213
+msgid "User tokens ranking list"
+msgstr "使用者 tokens 消耗排行榜列表"
+
+#: apps/application/serializers/application_chat.py:55
+#: apps/system_manage/api/user_resource_permission.py:118
+msgid "username"
+msgstr ""
+
+#: apps/users/api/login.py:26
+#: apps/users/api/login.py:26
+#: apps/users/api/user.py:77
+#: apps/users/serializers/login.py:32
+#: apps/users/serializers/login.py:32
+#: apps/users/serializers/user.py:65
+#: apps/users/serializers/user.py:173
+#: apps/users/serializers/user.py:236
+msgid "Username"
+msgstr "用戶名"
+
+#: apps/users/serializers/user.py:179
+msgid "Username must be 4-64 characters long"
+msgstr "用戶名必須為4-64個字符"
+
+#: no source
+msgid "Username or Nickname"
+msgstr "用戶名或暱稱"
+
+#: apps/system_manage/api/user_resource_permission.py:343
+#: apps/system_manage/serializers/user_resource_permission.py:323
+msgid "users_permission"
+msgstr "用戶許可權"
+
+#: no source
+msgid "user_group_id"
+msgstr "用戶組ID"
+
+#: apps/system_manage/views/valid.py:28
+msgid "Validation"
+msgstr "驗證"
+
+#: apps/application/flow/step_node/condition_node/i_condition_node.py:20
+#: apps/application/flow/step_node/loop_break_node/i_loop_break_node.py:21
+#: apps/application/flow/step_node/loop_continue_node/i_loop_continue_node.py:20
+#: apps/models_provider/api/provide.py:24
+msgid "value"
+msgstr "值"
+
+#: apps/models_provider/api/provide.py:37
+msgid "value field"
+msgstr "值"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:36
+msgid "vaporwave"
+msgstr "蒸汽波"
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:15
+msgid "Variable"
+msgstr ""
+
+#: apps/application/flow/step_node/variable_aggregation_node/i_variable_aggregation_node.py:13
+msgid "Variable id"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:24
+msgid "Variable Label"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:23
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:24
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:23
+msgid "Variable Name"
+msgstr "變量名稱"
+
+#: apps/tools/serializers/tool.py:247
+#: apps/tools/serializers/tool.py:323
+msgid "variable name"
+msgstr "變量名稱"
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:25
+msgid "Variable Source"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:26
+msgid "Variable Type"
+msgstr ""
+
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:24
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:34
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:27
+#: apps/trigger/serializers/trigger.py:51
+msgid "Variable Value"
+msgstr "變量名稱"
+
+#: apps/tools/serializers/tool.py:324
+msgid "variable value"
+msgstr "變量名稱"
+
+#: apps/common/constants/permission_constants.py:367
+msgid "Vector"
+msgstr "向量化"
+
+#: apps/local_model/serializers/model_apply_serializers.py:95
+#: apps/local_model/serializers/model_apply_serializers.py:100
+#: apps/models_provider/serializers/model_apply_serializers.py:32
+#: apps/models_provider/serializers/model_apply_serializers.py:37
+msgid "vector text"
+msgstr "向量文本"
+
+#: apps/local_model/serializers/model_apply_serializers.py:96
+#: apps/models_provider/serializers/model_apply_serializers.py:33
+msgid "vector text list"
+msgstr "向量文本列表"
+
+#: apps/models_provider/views/model_apply.py:25
+#: apps/models_provider/views/model_apply.py:26
+#: apps/models_provider/views/model_apply.py:27
+#: apps/models_provider/views/model_apply.py:37
+#: apps/models_provider/views/model_apply.py:38
+#: apps/models_provider/views/model_apply.py:39
+msgid "Vectorization documentation"
+msgstr "向量化文檔"
+
+#: apps/common/event/listener_manage.py:404
+msgid "Vectorized document: {document_id} error {error} {traceback}"
+msgstr "向量文檔: {document_id} 錯誤：{error} {traceback}"
+
+#: apps/common/event/listener_manage.py:431
+#: apps/knowledge/task/embedding.py:132
+msgid "Vectorized knowledge: {knowledge_id} error {error} {traceback}"
+msgstr "向量知識庫: {knowledge_id} 錯誤：{error} {traceback}"
+
+#: apps/common/event/listener_manage.py:138
+msgid "Vectorized paragraph: {paragraph_id_list} error {error} {traceback}"
+msgstr "向量段落: {paragraph_id_list} 錯誤：{error} {traceback}"
+
+#: apps/common/event/listener_manage.py:189
+msgid "Vectorized paragraph: {paragraph_id} error {error} {traceback}"
+msgstr "向量段落: {paragraph_id} 錯誤：{error} {traceback}"
+
+#: apps/users/serializers/user.py:1167
+msgid "Verification code"
+msgstr "驗證碼"
+
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:43
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:75
+msgid "Verification failed, please check whether the parameters are correct"
+msgstr "認證失敗，請檢查參數是否正確"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:57
+msgid "Verification failed, please check whether the parameters are correct: %(error)s"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:76
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:94
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:84
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:81
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:51
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:68
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:59
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:76
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:121
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:134
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:97
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:61
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:63
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:40
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:60
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:59
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:64
+#: apps/models_provider/impl/azure_model_provider/credential/stt.py:39
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:74
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:56
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:61
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:63
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:45
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:56
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:61
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:68
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:37
+#: apps/models_provider/impl/gemini_model_provider/credential/tti.py:44
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:71
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:62
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:42
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:54
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:84
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:57
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:86
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:51
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:84
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:60
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:61
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:63
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:45
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:56
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:43
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:62
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:63
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:54
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:38
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:58
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:29
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:65
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:55
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:76
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:102
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:61
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:53
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:53
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:49
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:42
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:61
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:63
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:50
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:61
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:66
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:80
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:53
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:52
+#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:37
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:49
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:82
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:58
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:58
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:82
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:63
+#: apps/models_provider/impl/xf_model_provider/credential/zh_en_stt.py:45
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:60
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:50
+#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:37
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:75
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:55
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:61
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:62
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:57
+msgid "Verification failed, please check whether the parameters are correct: {error}"
+msgstr "認證失敗，請檢查參數是否正確：{error}"
+
+#: no source
+msgid "Verification Token is required"
+msgstr "驗證令牌是必填項"
+
+#: apps/application/serializers/application_version.py:36
+#: apps/knowledge/serializers/knowledge_version.py:24
+#: apps/tools/serializers/tool_version.py:22
+msgid "Version Name"
+msgstr "版本名稱"
+
+#: apps/tools/serializers/tool.py:1380
+msgid "versions"
+msgstr ""
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:52
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:28
+msgid "video"
+msgstr ""
+
+#: apps/application/flow/step_node/application_node/i_application_node.py:24
+msgid "Video"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:22
+msgid "Video size"
+msgstr ""
+
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:25
+msgid "Vietnamese"
+msgstr "越南語"
+
+#: no source
+msgid "View appearance settings"
+msgstr "查看外觀設置"
+
+#: apps/common/constants/permission_constants.py:386
+msgid "View related resources"
+msgstr "查看關聯資源"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:56
+msgid "vision"
+msgstr ""
+
+#: apps/models_provider/base_model_provider.py:151
+msgid "Vision Model"
+msgstr "視覺模型"
+
+#: apps/application/serializers/application.py:390
+#: apps/application/serializers/application.py:621
+msgid "Voice playback autoplay"
+msgstr "自動播放語音"
+
+#: apps/application/serializers/application.py:384
+#: apps/application/serializers/application.py:615
+msgid "Voice playback enabled"
+msgstr "開啟語音播放"
+
+#: apps/application/serializers/application.py:386
+#: apps/application/serializers/application.py:617
+msgid "Voice playback model ID"
+msgstr "語音播放模型 ID"
+
+#: apps/application/serializers/application.py:388
+#: apps/application/serializers/application.py:619
+msgid "Voice playback type"
+msgstr "語音播放類型"
+
+#: apps/application/serializers/application.py:396
+#: apps/application/serializers/application.py:627
+msgid "Voice recognition automatic transmission"
+msgstr "語音識別自動播放"
+
+#: apps/application/serializers/application.py:392
+#: apps/application/serializers/application.py:623
+msgid "Voice recognition enabled"
+msgstr "開啟語音識別"
+
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:16
+msgid "Voice Setting"
+msgstr ""
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/volcanic_engine_model_provider.py:149
+msgid "volcano engine"
+msgstr "火山引擎"
+
+#: apps/chat/serializers/chat_record.py:31
+msgid "Vote other content"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:28
+msgid "Vote Reason"
+msgstr ""
+
+#: apps/chat/serializers/chat_record.py:58
+msgid "Voting on the current session minutes, please do not send repeated requests"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:55
+msgid "watercolor"
+msgstr "水彩"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:22
+msgid "watercolor painting"
+msgstr "水彩畫"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:33
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:36
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:22
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:22
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:49
+msgid "Watermark"
+msgstr "水印"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:24
+msgid "Web knowledge selector"
+msgstr "選擇器"
+
+#: apps/application/flow/step_node/data_source_web_node/impl/base_data_source_web_node.py:22
+msgid "Web source url"
+msgstr "Web 根地址"
+
+#: no source
+msgid "WeChat Official Account: {account}"
+msgstr "微信公眾帳號: {account}"
+
+#: apps/application/serializers/application_chat.py:291
+msgid "WeChat Public Account"
+msgstr "微信公眾號"
+
+#: no source
+msgid "wecom"
+msgstr "企业微信"
+
+#: no source
+msgid "WeCom callback"
+msgstr "企業微信回調"
+
+#: no source
+msgid "WeCom configuration not found or not active"
+msgstr "WeCom 配置未找到或未激活"
+
+#: no source
+msgid "WeCom OAuth2 callback"
+msgstr "企業微信 OAuth2 回調"
+
+#: apps/common/constants/permission_constants.py:381
+msgid "Weixin Public Account"
+msgstr ""
+
+#: no source
+msgid "Welcome to subscribe"
+msgstr "歡迎訂閱"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:33
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:36
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:22
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:22
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:49
+msgid "Whether to add watermark"
+msgstr "是否添加水印"
+
+#: apps/application/serializers/application_access_token.py:36
+msgid "Whether to display knowledge sources"
+msgstr "是否展示知識來源"
+
+#: no source
+msgid "Whether to enable MCP"
+msgstr "是否啟用 MCP"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:50
+msgid "Whether to enable MCP output"
+msgstr ""
+
+#: apps/system_manage/serializers/email_setting.py:36
+msgid "Whether to enable SSL"
+msgstr "是否啟用 SSL"
+
+#: apps/system_manage/serializers/email_setting.py:35
+msgid "Whether to enable TLS"
+msgstr "是否啟用 TLS"
+
+#: apps/application/serializers/application_access_token.py:31
+msgid "Whether to enable whitelist"
+msgstr "是否啟用白名單"
+
+#: apps/application/flow/step_node/ai_chat_step_node/i_chat_node.py:30
+#: apps/application/flow/step_node/direct_reply_node/i_reply_node.py:26
+#: apps/application/flow/step_node/image_generate_step_node/i_image_generate_node.py:29
+#: apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py:30
+#: apps/application/flow/step_node/image_understand_step_node/i_image_understand_node.py:27
+#: apps/application/flow/step_node/question_node/i_question_node.py:31
+#: apps/application/flow/step_node/speech_to_text_step_node/i_speech_to_text_node.py:18
+#: apps/application/flow/step_node/text_to_speech_step_node/i_text_to_speech_node.py:19
+#: apps/application/flow/step_node/text_to_video_step_node/i_text_to_video_node.py:29
+#: apps/application/flow/step_node/tool_lib_node/i_tool_lib_node.py:31
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:48
+#: apps/application/flow/step_node/tool_workflow_lib_node/i_tool_workflow_lib_node.py:34
+#: apps/application/flow/step_node/video_understand_step_node/i_video_understand_node.py:26
+msgid "Whether to return content"
+msgstr "是否返回內容"
+
+#: apps/application/serializers/application_access_token.py:33
+#: apps/application/serializers/application_access_token.py:34
+msgid "Whitelist"
+msgstr "白名單"
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:62
+msgid "with filter"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:68
+msgid "with filter reference"
+msgstr ""
+
+#: apps/application/flow/step_node/document_split_node/i_document_split_node.py:65
+msgid "with filter type"
+msgstr ""
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/aliyun_bai_lian_model_provider.py:71
+msgid "With the GTE-Rerank text sorting series model developed by Alibaba Tongyi Lab, developers can integrate high-quality text retrieval and sorting through the LlamaIndex framework."
+msgstr "阿里巴巴通義實驗室開發的GTE-Rerank文本排序系列模型，開發者可以通過LlamaIndex框架進行集成高質量文本檢索、排序。"
+
+#: apps/common/constants/permission_constants.py:357
+#: apps/common/constants/permission_constants.py:415
+#: apps/common/constants/permission_constants.py:425
+msgid "Workflow"
+msgstr "工作流"
+
+#: apps/application/api/application_api.py:23
+#: apps/application/serializers/application.py:298
+msgid "Workflow Objects"
+msgstr "工作流對象"
+
+#: apps/application/serializers/application_version.py:91
+#: apps/application/serializers/application_version.py:107
+#: apps/knowledge/serializers/knowledge_version.py:105
+#: apps/knowledge/serializers/knowledge_version.py:123
+#: apps/tools/serializers/tool_version.py:91
+#: apps/tools/serializers/tool_version.py:107
+msgid "Workflow version does not exist"
+msgstr "工作流版本不存在"
+
+#: no source
+msgid "Workflow version id"
+msgstr "工作流版本 ID"
+
+#: apps/common/constants/permission_constants.py:328
+#: apps/common/constants/permission_constants.py:432
+msgid "Workspace"
+msgstr "工作空間"
+
+#: no source
+msgid "Workspace does not exist"
+msgstr "工作空間不存在"
+
+#: apps/application/chat_pipeline/step/chat_step/i_chat_step.py:79
+#: apps/application/chat_pipeline/step/search_dataset_step/i_search_dataset_step.py:47
+#: apps/application/serializers/application.py:474
+#: apps/application/serializers/application.py:995
+#: apps/application/serializers/application.py:1675
+#: apps/application/serializers/application_access_token.py:48
+#: apps/application/serializers/application_api_key.py:37
+#: apps/application/serializers/application_api_key.py:74
+#: apps/application/serializers/application_chat.py:53
+#: apps/application/serializers/application_chat_record.py:46
+#: apps/application/serializers/application_chat_record.py:91
+#: apps/application/serializers/application_chat_record.py:199
+#: apps/application/serializers/application_chat_record.py:248
+#: apps/application/serializers/application_chat_record.py:381
+#: apps/application/serializers/application_chat_record.py:482
+#: apps/application/serializers/application_stats.py:38
+#: apps/application/serializers/application_version.py:40
+#: apps/application/serializers/application_version.py:43
+#: apps/application/serializers/application_version.py:68
+#: apps/chat/serializers/chat.py:155
+#: apps/chat/serializers/chat.py:532
+#: apps/homepage/api/home_page_api.py:71
+#: apps/homepage/api/home_page_api.py:122
+#: apps/homepage/api/home_page_api.py:263
+#: apps/homepage/api/home_page_api.py:277
+#: apps/homepage/api/home_page_api.py:326
+#: apps/homepage/api/home_page_api.py:363
+#: apps/homepage/api/home_page_api.py:400
+#: apps/homepage/serializers/homepage.py:89
+#: apps/homepage/serializers/homepage.py:150
+#: apps/homepage/serializers/homepage.py:215
+#: apps/homepage/serializers/homepage.py:387
+#: apps/homepage/serializers/homepage.py:514
+#: apps/homepage/serializers/homepage.py:654
+#: apps/homepage/serializers/homepage.py:736
+#: apps/homepage/serializers/homepage.py:777
+#: apps/homepage/serializers/homepage.py:826
+#: apps/homepage/serializers/homepage.py:873
+#: apps/knowledge/serializers/knowledge.py:1471
+#: apps/knowledge/serializers/knowledge_version.py:50
+#: apps/knowledge/serializers/knowledge_version.py:53
+#: apps/knowledge/serializers/knowledge_version.py:81
+#: apps/knowledge/serializers/knowledge_workflow.py:648
+#: apps/knowledge/serializers/tag.py:46
+#: apps/knowledge/serializers/tag.py:93
+#: apps/knowledge/serializers/tag.py:167
+#: apps/knowledge/serializers/tag.py:201
+#: apps/tools/serializers/tool.py:1569
+#: apps/tools/serializers/tool_version.py:40
+#: apps/tools/serializers/tool_version.py:43
+#: apps/tools/serializers/tool_version.py:68
+#: apps/tools/serializers/tool_workflow.py:378
+#: apps/trigger/serializers/trigger_task.py:43
+#: apps/trigger/serializers/trigger_task.py:67
+#: apps/trigger/serializers/trigger_task.py:127
+#: apps/users/api/user.py:64
+#: apps/users/api/user.py:170
+msgid "Workspace ID"
+msgstr "工作空間 ID"
+
+#: apps/application/serializers/application.py:631
+#: apps/folders/serializers/folder.py:130
+#: apps/folders/serializers/folder.py:134
+#: apps/folders/serializers/folder.py:177
+#: apps/folders/serializers/folder.py:306
+#: apps/knowledge/serializers/document.py:354
+#: apps/knowledge/serializers/document.py:472
+#: apps/knowledge/serializers/document.py:586
+#: apps/knowledge/serializers/document.py:684
+#: apps/knowledge/serializers/document.py:1001
+#: apps/knowledge/serializers/document.py:1206
+#: apps/knowledge/serializers/document.py:1292
+#: apps/knowledge/serializers/document.py:1314
+#: apps/knowledge/serializers/document.py:1651
+#: apps/knowledge/serializers/document.py:1697
+#: apps/knowledge/serializers/document.py:1772
+#: apps/knowledge/serializers/document.py:1813
+#: apps/knowledge/serializers/document.py:1842
+#: apps/knowledge/serializers/document.py:1878
+#: apps/knowledge/serializers/knowledge.py:315
+#: apps/knowledge/serializers/knowledge.py:884
+#: apps/knowledge/serializers/knowledge.py:1135
+#: apps/knowledge/serializers/knowledge.py:1255
+#: apps/knowledge/serializers/knowledge.py:1359
+#: apps/knowledge/serializers/knowledge.py:1502
+#: apps/knowledge/serializers/knowledge.py:1558
+#: apps/knowledge/serializers/knowledge_workflow.py:113
+#: apps/knowledge/serializers/knowledge_workflow.py:265
+#: apps/knowledge/serializers/knowledge_workflow.py:318
+#: apps/knowledge/serializers/knowledge_workflow.py:390
+#: apps/knowledge/serializers/knowledge_workflow.py:517
+#: apps/knowledge/serializers/knowledge_workflow.py:567
+#: apps/knowledge/serializers/paragraph.py:107
+#: apps/knowledge/serializers/paragraph.py:200
+#: apps/knowledge/serializers/paragraph.py:436
+#: apps/knowledge/serializers/paragraph.py:472
+#: apps/knowledge/serializers/paragraph.py:552
+#: apps/knowledge/serializers/paragraph.py:601
+#: apps/knowledge/serializers/paragraph.py:778
+#: apps/knowledge/serializers/problem.py:63
+#: apps/knowledge/serializers/problem.py:137
+#: apps/knowledge/serializers/problem.py:197
+#: apps/knowledge/serializers/problem.py:234
+#: apps/knowledge/serializers/termbase.py:35
+#: apps/knowledge/serializers/termbase.py:65
+#: apps/knowledge/serializers/termbase.py:103
+#: apps/knowledge/serializers/termbase.py:139
+#: apps/models_provider/api/model.py:30
+#: apps/models_provider/api/model.py:86
+#: apps/models_provider/api/model.py:99
+#: apps/models_provider/serializers/model_serializer.py:130
+#: apps/models_provider/serializers/model_serializer.py:255
+#: apps/models_provider/serializers/model_serializer.py:291
+#: apps/models_provider/serializers/model_serializer.py:364
+#: apps/models_provider/serializers/model_serializer.py:482
+#: apps/models_provider/serializers/model_serializer.py:541
+#: apps/system_manage/serializers/user_resource_permission.py:108
+#: apps/system_manage/serializers/user_resource_permission.py:298
+#: apps/system_manage/serializers/user_resource_permission.py:299
+#: apps/system_manage/serializers/user_resource_permission.py:306
+#: apps/system_manage/serializers/user_resource_permission.py:320
+#: apps/tools/serializers/tool.py:341
+#: apps/tools/serializers/tool.py:465
+#: apps/tools/serializers/tool.py:550
+#: apps/tools/serializers/tool.py:564
+#: apps/tools/serializers/tool.py:620
+#: apps/tools/serializers/tool.py:910
+#: apps/tools/serializers/tool.py:1151
+#: apps/tools/serializers/tool.py:1210
+#: apps/tools/serializers/tool.py:1308
+#: apps/tools/serializers/tool.py:1375
+#: apps/tools/serializers/tool.py:1425
+#: apps/tools/serializers/tool.py:1435
+#: apps/tools/serializers/tool.py:1531
+#: apps/tools/serializers/tool.py:1545
+#: apps/tools/serializers/tool.py:1628
+#: apps/tools/serializers/tool.py:1686
+#: apps/tools/serializers/tool_workflow.py:145
+#: apps/trigger/serializers/task_source_trigger.py:39
+#: apps/trigger/serializers/task_source_trigger.py:61
+#: apps/trigger/serializers/task_source_trigger.py:182
+#: apps/trigger/serializers/trigger.py:347
+#: apps/trigger/serializers/trigger.py:451
+#: apps/trigger/serializers/trigger.py:503
+#: apps/trigger/serializers/trigger.py:644
+msgid "workspace id"
+msgstr "工作空間ID"
+
+#: no source
+msgid "workspace id list"
+msgstr "工作空間ID"
+
+#: apps/users/api/user.py:30
+msgid "Workspace IDs"
+msgstr "工作空間 ID"
+
+#: no source
+msgid "Workspace Name"
+msgstr "工作空間"
+
+#: no source
+msgid "Workspace name already exists"
+msgstr "工作空間名稱已存在"
+
+#: no source
+msgid "Workspace Role"
+msgstr "工作空間角色"
+
+#: no source
+msgid "Workspace/Chat user"
+msgstr "工作空間/對話用戶"
+
+#: no source
+msgid "Workspace/User Group"
+msgstr "工作空間/用戶組"
+
+#: no source
+msgid "workspace_id"
+msgstr "工作空間ID"
+
+#: apps/system_manage/serializers/resource_mapping_serializers.py:33
+#: apps/system_manage/serializers/resource_mapping_serializers.py:115
+msgid "workspace_ids"
+msgstr ""
+
+#: no source
+msgid "WORKSPACE_MANAGE"
+msgstr "空間管理員"
+
+#: apps/application/serializers/application.py:1157
+msgid "work_flow is a required field"
+msgstr "工作流是必填欄位"
+
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/reranker.py:47
+msgid "World"
+msgstr ""
+
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:42
+msgid "You can request 1 image at a time (requesting more images by making parallel requests), or up to 10 images at a time using the n parameter."
+msgstr "您可以一次請求 1 個圖像（通過發出並行請求來請求更多圖像），或者使用 n 參數一次最多請求 10 個圖像。"
+
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:43
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:43
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:43
+msgid "You can use DALL·E 3 to request 1 image at a time (requesting more images by issuing parallel requests), or use DALL·E 2 with the n parameter to request up to 10 images at a time."
+msgstr "您可以使用 DALL·E 3 一次請求 1 個圖像（通過發出並行請求來請求更多圖像），或者使用帶有 n 參數的 DALL·E 2 一次最多請求 10 個圖像。"
+
+#: apps/models_provider/impl/zhipu_model_provider/zhipu_model_provider.py:75
+msgid "zhipu AI"
+msgstr "智譜 AI"
+
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:30
+msgid "[0.2,3], the default is 1, usually one decimal place is enough"
+msgstr "[0.2,3]，默認為1，通常保留一位小數即可"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:37
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:68
+msgid "[0.5, 2], the default is 1, usually one decimal place is enough"
+msgstr "[0.5,2]，默認為1，通常一位小數就足夠了"
+
+#: apps/models_provider/impl/openai_model_provider/openai_model_provider.py:61
+msgid "[Legacy] gpt-3.5-turbo snapshot on June 13, 2023, will be deprecated on June 13, 2024"
+msgstr "[Legacy] 2023年6月13日的gpt-3.5-turbo快照，將於2024年6月13日棄用"
+
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:33
+#: apps/application/flow/step_node/loop_node/i_loop_node.py:38
+#: apps/application/flow/step_node/tool_node/i_tool_node.py:40
+msgid "{field}, this field is required."
+msgstr "{field_label} 欄位是必填項"
+
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:40
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:61
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:87
+msgid "{keys} is required"
+msgstr "{keys} 是必填項"
+
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:47
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:31
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:50
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:63
+#: apps/models_provider/impl/azure_model_provider/credential/stt.py:27
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:62
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:45
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:49
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:49
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:42
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:33
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:44
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:47
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:25
+#: apps/models_provider/impl/gemini_model_provider/credential/tti.py:32
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:30
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:42
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:45
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:46
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:62
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:73
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:49
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:49
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:33
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:44
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:31
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:50
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:52
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:49
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:42
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:26
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:65
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:46
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:51
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:47
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:64
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:39
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:57
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:37
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:30
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:47
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:51
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:38
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:50
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:55
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:69
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:41
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:61
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:86
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:92
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:38
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:33
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:70
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:46
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:51
+#: apps/models_provider/impl/xf_model_provider/credential/zh_en_stt.py:33
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:40
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:47
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:59
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:39
+#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:26
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:64
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:44
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:47
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:50
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:45
+msgid "{key}  is required"
+msgstr "{key} 是必填項"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:62
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:80
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:66
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:67
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:37
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:54
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:45
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:62
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:107
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:120
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:83
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:55
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:57
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:70
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:72
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:70
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:46
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:71
+msgid "{key} is required"
+msgstr "{key} 是必填項"
+
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:33
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:53
+msgid "{model_name} The model does not support"
+msgstr "{model_name} 模型不支持"
+
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/image.py:54
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/itv.py:71
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/reranker.py:58
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/asr_stt.py:28
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/default_stt.py:45
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/omni_stt.py:36
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/stt/stt.py:53
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tti.py:98
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/tts.py:111
+#: apps/models_provider/impl/aliyun_bai_lian_model_provider/credential/ttv.py:74
+#: apps/models_provider/impl/anthropic_model_provider/credential/image.py:42
+#: apps/models_provider/impl/anthropic_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/embedding.py:20
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/image.py:40
+#: apps/models_provider/impl/aws_bedrock_model_provider/credential/llm.py:39
+#: apps/models_provider/impl/azure_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/azure_model_provider/credential/image.py:45
+#: apps/models_provider/impl/azure_model_provider/credential/llm.py:58
+#: apps/models_provider/impl/azure_model_provider/credential/stt.py:22
+#: apps/models_provider/impl/azure_model_provider/credential/tti.py:57
+#: apps/models_provider/impl/azure_model_provider/credential/tts.py:40
+#: apps/models_provider/impl/deepseek_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/docker_ai_model_provider/credential/embedding.py:44
+#: apps/models_provider/impl/docker_ai_model_provider/credential/image.py:44
+#: apps/models_provider/impl/docker_ai_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/docker_ai_model_provider/credential/reranker.py:38
+#: apps/models_provider/impl/docker_ai_model_provider/credential/stt.py:28
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/docker_ai_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/gemini_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/gemini_model_provider/credential/image.py:42
+#: apps/models_provider/impl/gemini_model_provider/credential/itv.py:48
+#: apps/models_provider/impl/gemini_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/gemini_model_provider/credential/stt.py:20
+#: apps/models_provider/impl/gemini_model_provider/credential/tti.py:27
+#: apps/models_provider/impl/gemini_model_provider/credential/ttv.py:48
+#: apps/models_provider/impl/kimi_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/local_model_provider/credential/embedding/model.py:26
+#: apps/models_provider/impl/local_model_provider/credential/reranker/model.py:38
+#: apps/models_provider/impl/minimax_model_provider/credential/itv.py:61
+#: apps/models_provider/impl/minimax_model_provider/credential/llm.py:40
+#: apps/models_provider/impl/minimax_model_provider/credential/tti.py:63
+#: apps/models_provider/impl/minimax_model_provider/credential/tts.py:34
+#: apps/models_provider/impl/minimax_model_provider/credential/ttv.py:61
+#: apps/models_provider/impl/ollama_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/ollama_model_provider/credential/image.py:39
+#: apps/models_provider/impl/ollama_model_provider/credential/llm.py:44
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:37
+#: apps/models_provider/impl/ollama_model_provider/credential/reranker.py:41
+#: apps/models_provider/impl/openai_model_provider/credential/embedding.py:44
+#: apps/models_provider/impl/openai_model_provider/credential/image.py:44
+#: apps/models_provider/impl/openai_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/openai_model_provider/credential/stt.py:28
+#: apps/models_provider/impl/openai_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/openai_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/regolo_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/regolo_model_provider/credential/image.py:45
+#: apps/models_provider/impl/regolo_model_provider/credential/llm.py:47
+#: apps/models_provider/impl/regolo_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/image.py:44
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/reranker.py:38
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/stt.py:21
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py:60
+#: apps/models_provider/impl/siliconCloud_model_provider/credential/tts.py:41
+#: apps/models_provider/impl/tencent_cloud_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/tencent_model_provider/credential/embedding.py:18
+#: apps/models_provider/impl/tencent_model_provider/credential/image.py:47
+#: apps/models_provider/impl/tencent_model_provider/credential/llm.py:30
+#: apps/models_provider/impl/tencent_model_provider/credential/stt.py:51
+#: apps/models_provider/impl/tencent_model_provider/credential/tti.py:77
+#: apps/models_provider/impl/vllm_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/vllm_model_provider/credential/image.py:42
+#: apps/models_provider/impl/vllm_model_provider/credential/llm.py:38
+#: apps/models_provider/impl/vllm_model_provider/credential/reranker.py:34
+#: apps/models_provider/impl/vllm_model_provider/credential/whisper_stt.py:39
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/bigModel_stt.py:32
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/embedding.py:25
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/image.py:42
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/stt.py:33
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tti.py:45
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/tts.py:50
+#: apps/models_provider/impl/volcanic_engine_model_provider/credential/ttv.py:64
+#: apps/models_provider/impl/wenxin_model_provider/credential/embedding.py:29
+#: apps/models_provider/impl/wenxin_model_provider/credential/llm.py:49
+#: apps/models_provider/impl/wenxin_model_provider/credential/reranker.py:33
+#: apps/models_provider/impl/xf_model_provider/credential/embedding.py:26
+#: apps/models_provider/impl/xf_model_provider/credential/image.py:28
+#: apps/models_provider/impl/xf_model_provider/credential/llm.py:65
+#: apps/models_provider/impl/xf_model_provider/credential/stt.py:41
+#: apps/models_provider/impl/xf_model_provider/credential/tts/default_tts.py:39
+#: apps/models_provider/impl/xf_model_provider/credential/tts/super_humanoid_tts.py:64
+#: apps/models_provider/impl/xf_model_provider/credential/tts/tts.py:46
+#: apps/models_provider/impl/xf_model_provider/credential/zh_en_stt.py:28
+#: apps/models_provider/impl/xinference_model_provider/credential/embedding.py:19
+#: apps/models_provider/impl/xinference_model_provider/credential/image.py:42
+#: apps/models_provider/impl/xinference_model_provider/credential/llm.py:39
+#: apps/models_provider/impl/xinference_model_provider/credential/reranker.py:35
+#: apps/models_provider/impl/xinference_model_provider/credential/stt.py:21
+#: apps/models_provider/impl/xinference_model_provider/credential/tti.py:59
+#: apps/models_provider/impl/xinference_model_provider/credential/tts.py:39
+#: apps/models_provider/impl/zhipu_model_provider/credential/image.py:42
+#: apps/models_provider/impl/zhipu_model_provider/credential/llm.py:46
+#: apps/models_provider/impl/zhipu_model_provider/credential/tti.py:40
+msgid "{model_type} Model type is not supported"
+msgstr "{model_type} 模型類型不支持"
+
+#: apps/application/flow/common.py:230
+msgid "{node} Nodes cannot be considered as end nodes"
+msgstr "{node} 節點不能被視為結束節點"
+
+#: apps/users/serializers/user.py:1145
+msgid "【Intelligent knowledge base question and answer system-{action}】"
+msgstr "【智能知識庫問答系統-{action}】"

--- a/apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py
+++ b/apps/models_provider/impl/aliyun_bai_lian_model_provider/model/tts.py
@@ -84,7 +84,7 @@ class AliyunBaiLianTextToSpeech(MaxKBBaseModel, BaseTextToSpeech):
             if audio_hex:
                 audio = bytes.fromhex(audio_hex)
             else:
-                raise Exception('Failed to get audio data from response' + str(response.text))
+                raise Exception('Failed to get audio data from response: ' + str(response.text))
         else:
             from dashscope.audio.tts_v2 import SpeechSynthesizer
             synthesizer = SpeechSynthesizer(model=self.model, **self.params)

--- a/apps/models_provider/impl/docker_ai_model_provider/credential/tti.py
+++ b/apps/models_provider/impl/docker_ai_model_provider/credential/tti.py
@@ -25,7 +25,7 @@ class DockerAITTIModelParams(BaseForm):
     )
 
     quality = forms.SingleSelect(
-        TooltipLabel(_('Picture quality'), _('''       
+        TooltipLabel(_('Picture quality'), _('''
 By default, images are produced in standard quality, but with DALL·E 3 you can set quality: "hd" to enhance detail. Square, standard quality images are generated fastest.
         ''')),
         required=True,

--- a/apps/models_provider/impl/openai_model_provider/credential/tti.py
+++ b/apps/models_provider/impl/openai_model_provider/credential/tti.py
@@ -25,7 +25,7 @@ class OpenAITTIModelParams(BaseForm):
     )
 
     quality = forms.SingleSelect(
-        TooltipLabel(_('Picture quality'), _('''       
+        TooltipLabel(_('Picture quality'), _('''
 By default, images are produced in standard quality, but with DALL·E 3 you can set quality: "hd" to enhance detail. Square, standard quality images are generated fastest.
         ''')),
         required=True,

--- a/apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py
+++ b/apps/models_provider/impl/siliconCloud_model_provider/credential/tti.py
@@ -25,7 +25,7 @@ class SiliconCloudTTIModelParams(BaseForm):
     )
 
     quality = forms.SingleSelect(
-        TooltipLabel(_('Picture quality'), _('''       
+        TooltipLabel(_('Picture quality'), _('''
 By default, images are produced in standard quality, but with DALL·E 3 you can set quality: "hd" to enhance detail. Square, standard quality images are generated fastest.
         ''')),
         required=True,

--- a/apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py
+++ b/apps/models_provider/impl/xinference_model_provider/xinference_model_provider.py
@@ -41,7 +41,7 @@ model_info_list = [
     ),
     ModelInfo(
         'code-llama-instruct',
-        _('''       
+        _('''
 Code Llama Instruct is a fine-tuned version of Code Llama's instructions, designed to perform specific tasks.
         '''),
         ModelTypeConst.LLM,

--- a/apps/models_provider/serializers/model_serializer.py
+++ b/apps/models_provider/serializers/model_serializer.py
@@ -6,26 +6,25 @@ import time
 from typing import Dict
 
 import uuid_utils.compat as uuid
-from django.core.cache import cache
-from django.db import transaction
-from django.db.models import QuerySet
-from django.utils.translation import gettext_lazy as _
-from rest_framework import serializers
-
 from common.config.embedding_config import ModelManage
 from common.constants.cache_version import Cache_Version
-from common.constants.permission_constants import ResourcePermission, ResourceAuthType
+from common.constants.permission_constants import ResourceAuthType, ResourcePermission
 from common.database_model_manage.database_model_manage import DatabaseModelManage
 from common.db.search import native_search
 from common.exception.app_exception import AppApiException
 from common.utils.common import get_file_content
-from common.utils.rsa_util import rsa_long_encrypt, rsa_long_decrypt
+from common.utils.rsa_util import rsa_long_decrypt, rsa_long_encrypt
+from django.core.cache import cache
+from django.db import transaction
+from django.db.models import QuerySet
+from django.utils.translation import gettext_lazy as _
 from maxkb.conf import PROJECT_DIR
-from models_provider.base_model_provider import ValidCode, DownModelChunkStatus
+from models_provider.base_model_provider import DownModelChunkStatus, ValidCode
 from models_provider.constants.model_provider_constants import ModelProvideConstants
 from models_provider.models import Model, Status
 from models_provider.tools import get_model_credential
-from system_manage.models import WorkspaceUserResourcePermission, AuthTargetType
+from rest_framework import serializers
+from system_manage.models import AuthTargetType, WorkspaceUserResourcePermission
 from system_manage.models.resource_mapping import ResourceMapping
 from system_manage.serializers.resource_mapping_serializers import ResourceMappingSerializer
 from system_manage.serializers.user_resource_permission import UserResourcePermissionSerializer
@@ -44,9 +43,19 @@ class ModelModelSerializer(serializers.ModelSerializer):
     class Meta:
         model = Model
         fields = [
-            'id', 'name', 'status', 'model_type', 'model_name',
-            'user', 'provider', 'credential', 'meta',
-            'model_params_form', 'workspace_id', 'create_time', 'update_time'
+            "id",
+            "name",
+            "status",
+            "model_type",
+            "model_name",
+            "user",
+            "provider",
+            "credential",
+            "meta",
+            "model_params_form",
+            "workspace_id",
+            "create_time",
+            "update_time",
         ]
 
 
@@ -83,19 +92,15 @@ class ModelPullManage:
             status = Status.ERROR
             message = ""
             for chunk in down_model_chunk.values():
-                if chunk.get('status') == DownModelChunkStatus.success.value:
+                if chunk.get("status") == DownModelChunkStatus.success.value:
                     status = Status.SUCCESS
-                elif chunk.get('status') == DownModelChunkStatus.error.value:
+                elif chunk.get("status") == DownModelChunkStatus.error.value:
                     message = chunk.get("digest")
 
-            QuerySet(Model).filter(id=model.id).update(
-                meta={"down_model_chunk": [], "message": message},
-                status=status
-            )
+            QuerySet(Model).filter(id=model.id).update(meta={"down_model_chunk": [], "message": message}, status=status)
         except Exception as e:
             QuerySet(Model).filter(id=model.id).update(
-                meta={"down_model_chunk": [], "message": str(e)},
-                status=Status.ERROR
+                meta={"down_model_chunk": [], "message": str(e)}, status=Status.ERROR
             )
 
 
@@ -104,19 +109,19 @@ class ModelSerializer(serializers.Serializer):
     def model_to_dict(model: Model):
         credential = json.loads(rsa_long_decrypt(model.credential))
         return {
-            'id': str(model.id),
-            'provider': model.provider,
-            'name': model.name,
-            'model_type': model.model_type,
-            'model_name': model.model_name,
-            'status': model.status,
-            'meta': model.meta,
-            'credential': ModelProvideConstants[model.provider].value.get_model_credential(
-                model.model_type, model.model_name
-            ).encryption_dict(credential),
-            'workspace_id': model.workspace_id,
-            'nick_name': model.user.nick_name if model.user else '',
-            'username': model.user.username if model.user else ''
+            "id": str(model.id),
+            "provider": model.provider,
+            "name": model.name,
+            "model_type": model.model_type,
+            "model_name": model.model_name,
+            "status": model.status,
+            "meta": model.meta,
+            "credential": ModelProvideConstants[model.provider]
+            .value.get_model_credential(model.model_type, model.model_name)
+            .encryption_dict(credential),
+            "workspace_id": model.workspace_id,
+            "nick_name": model.user.nick_name if model.user else "",
+            "username": model.user.username if model.user else "",
         }
 
     class Operate(serializers.Serializer):
@@ -132,44 +137,49 @@ class ModelSerializer(serializers.Serializer):
                 model_query = model_query.filter(workspace_id=workspace_id)
             model = model_query.first()
             if model is None:
-                raise AppApiException(500, _('Model does not exist'))
-            if model.workspace_id == 'None':
-                raise AppApiException(500, _('Shared models cannot be deleted or modified'))
+                raise AppApiException(500, _("Model does not exist"))
+            if model.workspace_id == "None":
+                raise AppApiException(500, _("Shared models cannot be deleted or modified"))
 
         def one(self, with_valid=False):
             if with_valid:
                 super().is_valid(raise_exception=True)
-            model = QuerySet(Model).get(
-                id=self.data.get('id'), workspace_id=self.data.get('workspace_id', 'None')
-            )
+            model = QuerySet(Model).get(id=self.data.get("id"), workspace_id=self.data.get("workspace_id", "None"))
             return ModelSerializer.model_to_dict(model)
 
         def one_meta(self, with_valid=False):
             model = None
             if with_valid:
                 super().is_valid(raise_exception=True)
-                model = QuerySet(Model).filter(id=self.data.get("id"),
-                                               workspace_id=self.data.get('workspace_id', 'None')).first()
+                model = (
+                    QuerySet(Model)
+                    .filter(id=self.data.get("id"), workspace_id=self.data.get("workspace_id", "None"))
+                    .first()
+                )
             if model is None:
-                raise AppApiException(500, _('Model does not exist'))
-            return {'id': str(model.id), 'provider': model.provider, 'name': model.name, 'model_type': model.model_type,
-                    'model_name': model.model_name,
-                    'status': model.status,
-                    'meta': model.meta,
-                    'workspace_id': model.workspace_id,
-                    }
+                raise AppApiException(500, _("Model does not exist"))
+            return {
+                "id": str(model.id),
+                "provider": model.provider,
+                "name": model.name,
+                "model_type": model.model_type,
+                "model_name": model.model_name,
+                "status": model.status,
+                "meta": model.meta,
+                "workspace_id": model.workspace_id,
+            }
 
         def pause_download(self, with_valid=True):
             if with_valid:
                 self.is_valid(raise_exception=True)
-            QuerySet(Model).filter(id=self.data.get('id')).update(status=Status.PAUSE_DOWNLOAD)
+            QuerySet(Model).filter(id=self.data.get("id")).update(status=Status.PAUSE_DOWNLOAD)
             return True
 
         @transaction.atomic
         def delete(self, with_valid=True):
             if with_valid:
                 super().is_valid(raise_exception=True)
-            model_id = self.data.get('id')
+            model_id = self.data.get("id")
             model = Model.objects.filter(id=model_id).first()
             if model is None:
                 return True
@@ -198,30 +208,28 @@ class ModelSerializer(serializers.Serializer):
         def edit(self, instance: Dict, user_id: str, with_valid=True):
             if with_valid:
                 super().is_valid(raise_exception=True)
-            model = QuerySet(Model).filter(id=self.data.get('id')).first()
+            model = QuerySet(Model).filter(id=self.data.get("id")).first()
 
-            credential, model_credential, provider_handler = ModelSerializer.Edit(
-                data={**instance}).is_valid(
-                model=model)
+            credential, model_credential, provider_handler = ModelSerializer.Edit(data={**instance}).is_valid(
+                model=model
+            )
             try:
                 model.status = Status.SUCCESS
-                default_params = {item['field']: item['default_value'] for item in model.model_params_form}
+                default_params = {item["field"]: item["default_value"] for item in model.model_params_form}
                 # 校验模型认证数据
-                provider_handler.is_valid_credential(model.model_type,
-                                                     instance.get("model_name"),
-                                                     credential,
-                                                     default_params,
-                                                     raise_exception=True)
+                provider_handler.is_valid_credential(
+                    model.model_type, instance.get("model_name"), credential, default_params, raise_exception=True
+                )
 
             except AppApiException as e:
                 if e.code == ValidCode.model_not_fount:
                     model.status = Status.DOWNLOAD
                 else:
                     raise e
-            update_keys = ['credential', 'name', 'model_type', 'model_name']
+            update_keys = ["credential", "name", "model_type", "model_name"]
             for update_key in update_keys:
                 if update_key in instance and instance.get(update_key) is not None:
-                    if update_key == 'credential':
+                    if update_key == "credential":
                         model_credential_str = json.dumps(credential)
                         model.__setattr__(update_key, rsa_long_encrypt(model_credential_str))
                     else:
@@ -235,38 +243,35 @@ class ModelSerializer(serializers.Serializer):
             return self.one(with_valid=False)
 
     class Edit(serializers.Serializer):
-        user_id = serializers.CharField(required=False, label=(_('user id')))
+        user_id = serializers.CharField(required=False, label=(_("user id")))
 
-        name = serializers.CharField(required=False, max_length=64,
-                                     label=(_("model name")))
+        name = serializers.CharField(required=False, max_length=64, label=(_("model name")))
 
         model_type = serializers.CharField(required=False, label=(_("model type")))
 
         model_name = serializers.CharField(required=False, label=(_("base model")))
 
-        credential = serializers.DictField(required=False,
-                                           label=(_("certification information")))
+        credential = serializers.DictField(required=False, label=(_("certification information")))
         workspace_id = serializers.CharField(required=False, label=(_("workspace id")))
 
         def is_valid(self, model=None, raise_exception=False):
             super().is_valid(raise_exception=True)
-            filter_params = {'workspace_id': model.workspace_id}
-            if 'name' in self.data and self.data.get('name') is not None:
-                filter_params['name'] = self.data.get('name')
+            filter_params = {"workspace_id": model.workspace_id}
+            if "name" in self.data and self.data.get("name") is not None:
+                filter_params["name"] = self.data.get("name")
                 if QuerySet(Model).exclude(id=model.id).filter(**filter_params).exists():
-                    raise AppApiException(500, _('base model【{model_name}】already exists').format(
-                        model_name=self.data.get("name")))
+                    raise AppApiException(
+                        500, _("base model【{model_name}】already exists").format(model_name=self.data.get("name"))
+                    )
 
             ModelSerializer.model_to_dict(model)
 
             provider = model.provider
-            model_type = self.data.get('model_type')
-            model_name = self.data.get(
-                'model_name')
-            credential = self.data.get('credential')
+            model_type = self.data.get("model_type")
+            model_name = self.data.get("model_name")
+            credential = self.data.get("credential")
             provider_handler = ModelProvideConstants[provider].value
-            model_credential = ModelProvideConstants[provider].value.get_model_credential(model_type,
-                                                                                          model_name)
+            model_credential = ModelProvideConstants[provider].value.get_model_credential(model_type, model_name)
             source_model_credential = json.loads(rsa_long_decrypt(model.credential))
             source_encryption_model_credential = model_credential.encryption_dict(source_model_credential)
             if credential is not None:
@@ -276,7 +281,7 @@ class ModelSerializer(serializers.Serializer):
             return credential, model_credential, provider_handler
 
     class Create(serializers.Serializer):
-        user_id = serializers.UUIDField(required=True, label=_('user id'))
+        user_id = serializers.UUIDField(required=True, label=_("user id"))
         name = serializers.CharField(required=True, max_length=64, label=_("model name"))
         provider = serializers.CharField(required=True, label=_("provider"))
         model_type = serializers.CharField(required=True, label=_("model type"))
@@ -287,21 +292,21 @@ class ModelSerializer(serializers.Serializer):
 
         def is_valid(self, *, raise_exception=False):
             super().is_valid(raise_exception=True)
-            if QuerySet(Model).filter(
-                    name=self.data.get('name'),
-                    workspace_id=self.data.get('workspace_id', 'None')
-            ).exists():
+            if (
+                QuerySet(Model)
+                .filter(name=self.data.get("name"), workspace_id=self.data.get("workspace_id", "None"))
+                .exists()
+            ):
                 raise AppApiException(
-                    500,
-                    _('base model【{model_name}】already exists').format(model_name=self.data.get("name"))
+                    500, _("base model【{model_name}】already exists").format(model_name=self.data.get("name"))
                 )
-            default_params = {item['field']: item['default_value'] for item in self.data.get('model_params_form')}
-            ModelProvideConstants[self.data.get('provider')].value.is_valid_credential(
-                self.data.get('model_type'),
-                self.data.get('model_name'),
-                self.data.get('credential'),
+            default_params = {item["field"]: item["default_value"] for item in self.data.get("model_params_form")}
+            ModelProvideConstants[self.data.get("provider")].value.is_valid_credential(
+                self.data.get("model_type"),
+                self.data.get("model_name"),
+                self.data.get("credential"),
                 default_params,
-                raise_exception=True
+                raise_exception=True,
             )
 
         def insert(self, workspace_id, with_valid=True):
@@ -315,28 +320,30 @@ class ModelSerializer(serializers.Serializer):
                     else:
                         raise e
 
-            credential = self.data.get('credential')
+            credential = self.data.get("credential")
             model_data = {
-                'id': uuid.uuid7(),
-                'status': status,
-                'user_id': self.data.get('user_id'),
-                'name': self.data.get('name'),
-                'credential': rsa_long_encrypt(json.dumps(credential)),
-                'provider': self.data.get('provider'),
-                'model_type': self.data.get('model_type'),
-                'model_name': self.data.get('model_name'),
-                'model_params_form': self.data.get('model_params_form'),
-                'workspace_id': workspace_id
+                "id": uuid.uuid7(),
+                "status": status,
+                "user_id": self.data.get("user_id"),
+                "name": self.data.get("name"),
+                "credential": rsa_long_encrypt(json.dumps(credential)),
+                "provider": self.data.get("provider"),
+                "model_type": self.data.get("model_type"),
+                "model_name": self.data.get("model_name"),
+                "model_params_form": self.data.get("model_params_form"),
+                "workspace_id": workspace_id,
             }
             model = Model(**model_data)
             try:
                 model.save()
-                if workspace_id != 'None':
-                    UserResourcePermissionSerializer(data={
-                        'workspace_id': workspace_id,
-                        'user_id': self.data.get('user_id'),
-                        'auth_target_type': AuthTargetType.MODEL.value
-                    }).auth_resource(str(model.id))
+                if workspace_id != "None":
+                    UserResourcePermissionSerializer(
+                        data={
+                            "workspace_id": workspace_id,
+                            "user_id": self.data.get("user_id"),
+                            "auth_target_type": AuthTargetType.MODEL.value,
+                        }
+                    ).auth_resource(str(model.id))
             except Exception as save_error:
                 # 可添加日志记录
                 raise AppApiException(500, _("Model saving failed")) from save_error
@@ -349,12 +356,12 @@ class ModelSerializer(serializers.Serializer):
 
     class Query(serializers.Serializer):
         user_id = serializers.CharField(required=True, label=_("User ID"))
-        name = serializers.CharField(required=False, max_length=64, label=_('model name'))
-        model_type = serializers.CharField(required=False, label=_('model type'))
-        model_name = serializers.CharField(required=False, label=_('base model'))
-        provider = serializers.CharField(required=False, label=_('provider'))
-        create_user = serializers.CharField(required=False, label=_('create user'))
-        workspace_id = serializers.CharField(required=False, label=_('workspace id'))
+        name = serializers.CharField(required=False, max_length=64, label=_("model name"))
+        model_type = serializers.CharField(required=False, label=_("model type"))
+        model_name = serializers.CharField(required=False, label=_("base model"))
+        provider = serializers.CharField(required=False, label=_("provider"))
+        create_user = serializers.CharField(required=False, label=_("create user"))
+        workspace_id = serializers.CharField(required=False, label=_("workspace id"))
 
         @staticmethod
         def is_x_pack_ee():
@@ -366,15 +373,23 @@ class ModelSerializer(serializers.Serializer):
             if with_valid:
                 self.is_valid(raise_exception=True)
             user_id = self.data.get("user_id")
-            workspace_manage = is_workspace_manage_permission_read(user_id, workspace_id, 'MODEL:READ')
+            workspace_manage = is_workspace_manage_permission_read(user_id, workspace_id, "MODEL:READ")
             query_params = self._build_query_params(workspace_id, workspace_manage, user_id)
             is_x_pack_ee = self.is_x_pack_ee()
-            result = native_search(query_params,
-                                   select_string=get_file_content(
-                                       os.path.join(PROJECT_DIR, "apps", "models_provider", 'sql',
-                                                    'list_model.sql' if workspace_manage else (
-                                                        'list_model_user_ee.sql' if is_x_pack_ee else 'list_model_user.sql')
-                                                    )))
+            result = native_search(
+                query_params,
+                select_string=get_file_content(
+                    os.path.join(
+                        PROJECT_DIR,
+                        "apps",
+                        "models_provider",
+                        "sql",
+                        "list_model.sql"
+                        if workspace_manage
+                        else ("list_model_user_ee.sql" if is_x_pack_ee else "list_model_user.sql"),
+                    )
+                ),
+            )
             return ResourceMappingSerializer().get_resource_count(result)
 
         def share_list(self, workspace_id, with_valid=True):
@@ -382,24 +397,20 @@ class ModelSerializer(serializers.Serializer):
                 self.is_valid(raise_exception=True)
             user_id = self.data.get("user_id")
             query_params = self._build_query_params(workspace_id, False, user_id)
-            result = [
-                self._build_model_data(
-                    model
-                ) for model in query_params.get('model_query_set')
-            ]
+            result = [self._build_model_data(model) for model in query_params.get("model_query_set")]
             return ResourceMappingSerializer().get_resource_count(result)
 
         def model_list(self, workspace_id, with_valid=True):
             if with_valid:
                 self.is_valid(raise_exception=True)
             user_id = self.data.get("user_id")
-            workspace_manage = is_workspace_manage_permission_read(user_id, workspace_id, 'MODEL:READ')
+            workspace_manage = is_workspace_manage_permission_read(user_id, workspace_id, "MODEL:READ")
             queryset = self._build_query_params(workspace_id, workspace_manage, user_id)
             get_authorized_model = DatabaseModelManage.get_model("get_authorized_model")
 
             shared_queryset = QuerySet(Model).none()
             if get_authorized_model is not None:
-                shared_queryset = self._build_query_params('None', False, user_id)['model_query_set']
+                shared_queryset = self._build_query_params("None", False, user_id)["model_query_set"]
                 shared_queryset = get_authorized_model(shared_queryset, workspace_id)
 
             # 构建共享模型和普通模型列表
@@ -410,95 +421,116 @@ class ModelSerializer(serializers.Serializer):
                 queryset,
                 select_string=get_file_content(
                     os.path.join(
-                        PROJECT_DIR, "apps", "models_provider", 'sql',
-                        'list_model.sql' if workspace_manage else (
-                            'list_model_user_ee.sql' if is_x_pack_ee else 'list_model_user.sql')
+                        PROJECT_DIR,
+                        "apps",
+                        "models_provider",
+                        "sql",
+                        "list_model.sql"
+                        if workspace_manage
+                        else ("list_model_user_ee.sql" if is_x_pack_ee else "list_model_user.sql"),
                     )
-                )
+                ),
             )
-            return {
-                "shared_model": shared_model,
-                "model": normal_model
-            }
+            return {"shared_model": shared_model, "model": normal_model}
 
         def _build_query_params(self, workspace_id, workspace_manage: bool, user_id):
             queryset = QuerySet(Model)
             if workspace_id:
                 queryset = queryset.filter(workspace_id=workspace_id)
-            for field in ['name', 'model_type', 'model_name', 'provider', 'create_user']:
+            for field in ["name", "model_type", "model_name", "provider", "create_user"]:
                 value = self.data.get(field)
                 if value is not None:
-                    if field == 'name':
-                        queryset = queryset.filter(**{f'{field}__icontains': value})
-                    elif field == 'create_user':
+                    if field == "name":
+                        queryset = queryset.filter(**{f"{field}__icontains": value})
+                    elif field == "create_user":
                         queryset = queryset.filter(user_id=value)
                     else:
                         queryset = queryset.filter(**{field: value})
             queryset = queryset.order_by("-create_time")
-            return {
-                'model_query_set': queryset,
-                'workspace_user_resource_permission_query_set': QuerySet(WorkspaceUserResourcePermission).filter(
-                    auth_target_type="MODEL",
-                    workspace_id=workspace_id,
-                    user_id=user_id)} if (
-                not workspace_manage) else {
-                'model_query_set': queryset,
-            }
+            return (
+                {
+                    "model_query_set": queryset,
+                    "workspace_user_resource_permission_query_set": QuerySet(WorkspaceUserResourcePermission).filter(
+                        auth_target_type="MODEL", workspace_id=workspace_id, user_id=user_id
+                    ),
+                }
+                if (not workspace_manage)
+                else {
+                    "model_query_set": queryset,
+                }
+            )
 
         def _build_model_data(self, model):
             return {
-                'id': str(model.id),
-                'provider': model.provider,
-                'name': model.name,
-                'model_type': model.model_type,
-                'model_name': model.model_name,
-                'status': model.status,
-                'meta': model.meta,
-                'user_id': model.user_id,
-                'username': model.user.username,
-                'nick_name': model.user.nick_name,
+                "id": str(model.id),
+                "provider": model.provider,
+                "name": model.name,
+                "model_type": model.model_type,
+                "model_name": model.model_name,
+                "status": model.status,
+                "meta": model.meta,
+                "user_id": model.user_id,
+                "username": model.user.username,
+                "nick_name": model.user.nick_name,
             }
 
         def page(self, current_page, page_size):
             pass
 
     class ModelParams(serializers.Serializer):
-        id = serializers.UUIDField(required=True, label=_('model id'))
+        id = serializers.UUIDField(required=True, label=_("model id"))
+        workspace_id = serializers.UUIDField(required=False, label=_("workspace id"))
 
         def is_valid(self, *, raise_exception=False):
             super().is_valid(raise_exception=True)
-            model = QuerySet(Model).filter(id=self.data.get("id")).first()
+
+            validated_data = self.validated_data
+            model = (
+                QuerySet(Model)
+                .filter(
+                    id=validated_data.get("id"),
+                    workspace_id=validated_data.get("workspace_id"),
+                )
+                .first()
+            )
+
             if model is None:
                 raise AppApiException(500, _("Model does not exist"))
 
+            return model
+
         def get_model_params(self, with_valid=True):
+            model = None
+
             if with_valid:
-                self.is_valid(raise_exception=True)
-            model_id = self.data.get('id')
-            model = QuerySet(Model).filter(id=model_id).first()
-            return model.model_params_form
+                model = self.is_valid(raise_exception=True)
+
+            return model.model_params_form if model else None
 
         def save_model_params_form(self, model_params_form, with_valid=True):
+            model = None
             if with_valid:
-                self.is_valid(raise_exception=True)
+                model = self.is_valid(raise_exception=True)
             if model_params_form is None:
                 model_params_form = []
-            model_id = self.data.get('id')
-            model = QuerySet(Model).filter(id=model_id).first()
             if not isinstance(model_params_form, list):
-                raise AppApiException(500, _('model_params_form must be a list'))
+                raise AppApiException(500, _("model_params_form must be a list"))
             # 还需要校验几个字段：label required default_value
             # 校验每个配置项的必要字段
             for index, param in enumerate(model_params_form):
                 if not isinstance(param, dict):
-                    raise AppApiException(500, _('The {index}th item in model_params_form must be a dictionary').format(
-                        index=index))
+                    raise AppApiException(
+                        500, _("The {index}th item in model_params_form must be a dictionary").format(index=index)
+                    )
 
                 # 校验 label 字段
-                if 'label' not in param or param['label'] is None:
-                    raise AppApiException(500,
-                                          _('The label field is required for the {index}th item in model_params_form').format(
-                                              index=index))
+                if "label" not in param or param["label"] is None:
+                    raise AppApiException(
+                        500,
+                        _("The label field is required for the {index}th item in model_params_form").format(
+                            index=index
+                        ),
+                    )
 
             model.model_params_form = model_params_form
             model.save()
@@ -506,31 +538,31 @@ class ModelSerializer(serializers.Serializer):
 
 
 class WorkspaceSharedModelSerializer(serializers.Serializer):
-    workspace_id = serializers.CharField(required=True, label=_('workspace id'))
-    name = serializers.CharField(required=False, max_length=64, label=_('model name'))
-    model_type = serializers.CharField(required=False, label=_('model type'))
-    model_name = serializers.CharField(required=False, label=_('base model'))
-    provider = serializers.CharField(required=False, label=_('provider'))
-    create_user = serializers.CharField(required=False, label=_('create user'))
+    workspace_id = serializers.CharField(required=True, label=_("workspace id"))
+    name = serializers.CharField(required=False, max_length=64, label=_("model name"))
+    model_type = serializers.CharField(required=False, label=_("model type"))
+    model_name = serializers.CharField(required=False, label=_("base model"))
+    provider = serializers.CharField(required=False, label=_("provider"))
+    create_user = serializers.CharField(required=False, label=_("create user"))
 
     def get_share_model_list(self):
         self.is_valid(raise_exception=True)
-        workspace_id = self.data.get('workspace_id')
+        workspace_id = self.data.get("workspace_id")
 
         queryset = self._build_queryset(workspace_id)
 
         return [
             {
-                'id': str(model.id),
-                'provider': model.provider,
-                'name': model.name,
-                'model_type': model.model_type,
-                'model_name': model.model_name,
-                'status': model.status,
-                'meta': model.meta,
-                'user_id': model.user_id,
-                'nick_name': model.user.nick_name,
-                'username': model.user.username
+                "id": str(model.id),
+                "provider": model.provider,
+                "name": model.name,
+                "model_type": model.model_type,
+                "model_name": model.model_name,
+                "status": model.status,
+                "meta": model.meta,
+                "user_id": model.user_id,
+                "nick_name": model.user.nick_name,
+                "username": model.user.username,
             }
             for model in queryset.order_by("-create_time")
         ]
@@ -542,12 +574,12 @@ class WorkspaceSharedModelSerializer(serializers.Serializer):
             if get_authorized_model is not None:
                 queryset = get_authorized_model(queryset, workspace_id)
 
-        for field in ['name', 'model_type', 'model_name', 'provider', 'create_user']:
+        for field in ["name", "model_type", "model_name", "provider", "create_user"]:
             value = self.data.get(field)
             if value is not None:
-                if field == 'name':
-                    queryset = queryset.filter(**{f'{field}__icontains': value})
-                elif field == 'create_user':
+                if field == "name":
+                    queryset = queryset.filter(**{f"{field}__icontains": value})
+                elif field == "create_user":
                     queryset = queryset.filter(user_id=value)
                 else:
                     queryset = queryset.filter(**{field: value})

--- a/apps/models_provider/views/model.py
+++ b/apps/models_provider/views/model.py
@@ -195,7 +195,7 @@ class ModelSetting(APIView):
                          RoleConstants.USER.get_workspace_role(),)
         def get(self, request: Request, workspace_id: str, model_id: str):
             return result.success(
-                ModelSerializer.ModelParams(data={'id': model_id}).get_model_params())
+                ModelSerializer.ModelParams(data={'id': model_id, 'workspace_id': workspace_id}).get_model_params())
 
         @extend_schema(methods=['PUT'],
                        summary=_('Save model parameter form'),
@@ -217,7 +217,7 @@ class ModelSetting(APIView):
              )
         def put(self, request: Request, workspace_id: str, model_id: str):
             return result.success(
-                ModelSerializer.ModelParams(data={'id': model_id}).save_model_params_form(request.data))
+                ModelSerializer.ModelParams(data={'id': model_id, 'workspace_id': workspace_id}).save_model_params_form(request.data))
 
     class ModelMeta(APIView):
         authentication_classes = [TokenAuth]

--- a/apps/oss/serializers/file.py
+++ b/apps/oss/serializers/file.py
@@ -244,7 +244,7 @@ def get_url_content(url, application_id: str):
 
     final_host = urlparse(response.url).hostname
     if is_private_ip(final_host):
-        raise ValueError("Blocked unsafe redirect to internal host")
+        raise ValueError(_("Blocked unsafe redirect to internal host"))
     # 判断文件大小
     if int(response.headers.get('Content-Length', 0)) > file_limit:
         raise AppApiException(500, _('File size exceeds limit'))


### PR DESCRIPTION
# Django 国际化翻译文件自动化脚本

## 功能执行过程：
1. 缓存已翻译的内容
2. 扫描所有Python文件中的国际化代码
3. 合并已有翻译和新发现的未翻译项
4. 生成排序后的翻译文件（根据 `msgid移除前面空白符并转大写后的字符串` 进行排序）
5. 扫描所有Python文件中未使用国际化功能的代码，并写入 `not_internationalized.txt` 文件中
    > 注：步骤5的扫描规则可能还不够完善，无法扫描到所有未调用国际化方法的源码。

## 使用说明:
1. 手动执行命令：
```
python apps/locales/i18n_automation.py
```
2. 可修改脚本中的 `KEEP_NO_SOURCE` 为 `False`，自动将源码中已经不存在的项从翻译文件中删除。（但会保留已翻译的项）


## 脚本对源码的检索率自查：
1. 先说结论：源码检索率应该是达到了 `100%`
2. 手动校验截图：
    1. 源码中存在 `4200` 处：   - 检索词：正则 `\b(?:_|gettext_lazy|gettext)\(\s*(?:'[^']|"[^"]|'''|""")`
        检索到 `4215` 处，减掉当前脚本内的 `15` 处，即 `4200` 处。
        <img width="1920" height="1030" alt="图片" src="https://github.com/user-attachments/assets/e9345e94-b54f-46fc-8d42-7e4757789992" />
    2. 自动生成的翻译文件中也存在 `4200` 处，和源码中的一致：   - 检索词：`#: apps/`
        <img width="1920" height="1030" alt="图片" src="https://github.com/user-attachments/assets/bc2378ee-1008-490a-b68d-f680edcd8243" />

## 后续优化方向建议：
添加 `自动翻译` 功能，就可以做成自动化程序了。
请对 `翻译功能` 比较熟的朋友，后续添加该功能，谢谢！！！

## 此次执行日志：
```log
使用项目根目录: E:\Workspace_Java\3rd-party\1Panel-dev\MaxKB
开始 Django 国际化翻译文件自动化处理
项目根目录: E:\Workspace_Java\3rd-party\1Panel-dev\MaxKB

============================================================
步骤1: 缓存已有的翻译内容
============================================================
从 django.po 解析到 65 条翻译（en_US）
从 django.po 解析到 1762 条翻译（zh_CN）
从 django.po 解析到 1761 条翻译（zh_Hant）
共缓存 1762 条已有翻译

============================================================
步骤2: 扫描 Python 文件中的国际化代码
============================================================
找到 1044 个 Python 文件
扫描了 326 个文件
提取到 1501 条国际化字符串

============================================================
步骤3: 合并已有翻译
============================================================
合并完成，共 2105 条翻译项
其中有翻译内容的: 1762

============================================================
步骤4: 生成翻译文件
============================================================
en_US:   共 2105 条，已翻译 65 条
zh_CN:   共 2105 条，已翻译 1762 条
zh_Hant: 共 2105 条，已翻译 1761 条

所有翻译文件已生成完成！！！

============================================================
步骤5: 扫描未国际化的字符串
============================================================
找到 1044 个 Python 文件
扫描了 45 个文件
发现 88 条未国际化的字符串

============================================================
步骤6: 写入 not_internationalized.txt 文件
============================================================
已写入 78 条未国际化字符串到: E:\Workspace_Java\3rd-party\1Panel-dev\MaxKB\apps\locales\not_internationalized.txt


============================================================
翻译统计报告
============================================================

总翻译条目数: 2105
英文已翻译: 65 (3.09%)
简体中文已翻译: 1762 (83.71%)
繁体中文已翻译: 1761 (83.66%)
有代码来源: 1501
无代码来源(遗留): 604 （可将脚本中的 `KEEP_NO_SOURCE = False` 来自动清除这些项）


============================================================
前10个未翻译简体中文的项目:
============================================================
- Chat record id
- Agent 【{name}】 access token authentication is not supported for agent tool
- Agent Key is required for agent tool 【{name}】
- Model id type
- MCP Server
- MCP Tool ID
- MCP Tool IDs
- MCP Source
- Tool IDs
- App IDs

============================================================
不一致翻译项（简体已翻译但繁体未翻译，或繁体已翻译但简体未翻译）:
============================================================
简体已翻译但繁体未翻译 (1 项):
  1. 原文: User
     简体: 用户

============================================================
处理完成！
============================================================
```