### PR TITLE
fix: inline exposed params not reacting to popover form value changes

### DIFF
--- a/ui/src/components/ai-chat/component/inline-params/index.vue
+++ b/ui/src/components/ai-chat/component/inline-params/index.vue
@@ -78,7 +78,7 @@ watch(
       }
     }
   },
-  { immediate: true },
+  { immediate: true, deep: true },
 )
 
 watch(


### PR DESCRIPTION
fix: inline exposed params not reacting to popover form value changes 