### PR TITLE
fix: vllm reranker passes top_n twice to cohere rerank()

### DIFF
--- a/apps/models_provider/impl/vllm_model_provider/model/reranker.py
+++ b/apps/models_provider/impl/vllm_model_provider/model/reranker.py
@@ -31,12 +31,14 @@ class VllmBgeReranker(MaxKBBaseModel, BaseDocumentCompressor):
     @staticmethod
     def new_instance(model_type, model_name, model_credential: Dict[str, object], **model_kwargs):
         r_url = model_credential.get('api_url')[:-3] if model_credential.get('api_url').endswith('/v1') else model_credential.get('api_url')
+        optional_params = MaxKBBaseModel.filter_optional_params(model_kwargs)
+        top_n = optional_params.pop('top_n', 3)
         return VllmBgeReranker(
             model=model_name,
             api_key=model_credential.get('api_key'),
             api_url=r_url,
-            params=model_kwargs,
-            **model_kwargs
+            top_n=top_n,
+            params=optional_params,
         )
 
     def compress_documents(self, documents: Sequence[Document], query: str, callbacks: Optional[Callbacks] = None) -> \


### PR DESCRIPTION
fix: vllm reranker passes top_n twice to cohere rerank() 