### PR TITLE
fix: Fix missing `import gettext_lazy as _` issues

### DIFF
--- a/apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py
+++ b/apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py
@@ -5,8 +5,8 @@ from typing import List
 
 import requests
 from django.db.models import QuerySet
+from django.utils.translation import gettext_lazy as _, gettext
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
-from django.utils.translation import gettext_lazy as _
 from application.flow.common import WorkflowMode
 from application.flow.i_step_node import NodeResult
 from application.flow.step_node.image_to_video_step_node.i_image_to_video_node import IImageToVideoNode
@@ -14,7 +14,6 @@ from common.utils.common import bytes_to_uploaded_file
 from knowledge.models import FileSourceType, File
 from oss.serializers.file import FileSerializer, mime_types
 from models_provider.tools import get_model_instance_by_model_workspace_id
-from django.utils.translation import gettext
 
 
 class BaseImageToVideoNode(IImageToVideoNode):

--- a/apps/application/flow/step_node/intent_node/impl/base_intent_node.py
+++ b/apps/application/flow/step_node/intent_node/impl/base_intent_node.py
@@ -6,6 +6,7 @@ from typing import List, Dict, Any
 from functools import reduce
 
 from django.db.models import QuerySet
+from django.utils.translation import gettext_lazy as _
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from application.flow.i_step_node import INode, NodeResult

--- a/apps/application/flow/step_node/parameter_extraction_node/impl/base_parameter_extraction_node.py
+++ b/apps/application/flow/step_node/parameter_extraction_node/impl/base_parameter_extraction_node.py
@@ -10,6 +10,7 @@ import json
 import re
 
 from django.db.models import QuerySet
+from django.utils.translation import gettext_lazy as _
 from langchain_core.messages import HumanMessage
 from langchain_core.prompts import PromptTemplate
 

--- a/apps/application/flow/step_node/question_node/impl/base_question_node.py
+++ b/apps/application/flow/step_node/question_node/impl/base_question_node.py
@@ -12,6 +12,7 @@ from functools import reduce
 from typing import List, Dict
 
 from django.db.models import QuerySet
+from django.utils.translation import gettext_lazy as _
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
 from application.flow.i_step_node import NodeResult, INode

--- a/apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py
+++ b/apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py
@@ -12,7 +12,7 @@ from common.utils.common import bytes_to_uploaded_file
 from knowledge.models import FileSourceType
 from oss.serializers.file import FileSerializer
 from models_provider.tools import get_model_instance_by_model_workspace_id
-from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _, gettext
 
 
 class BaseTextToVideoNode(ITextToVideoNode):
@@ -37,8 +37,6 @@ class BaseTextToVideoNode(ITextToVideoNode):
             if reference_data and isinstance(reference_data, dict):
                 model_id = reference_data.get('model_id', model_id)
                 model_params_setting = reference_data.get('model_params_setting')
-
-        from django.utils.translation import gettext_lazy as _
 
         if model_id is None or model_id == '':
             raise Exception(_('Model is not allowed to be empty'))

--- a/apps/application/serializers/application_chat_record.py
+++ b/apps/application/serializers/application_chat_record.py
@@ -20,8 +20,7 @@ from common.utils.common import post
 from django.db import transaction
 from django.db.models import QuerySet
 from django.db.models.aggregates import Max, Min
-from django.utils.translation import gettext
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, gettext
 from knowledge.models import Document, Knowledge, Paragraph, Problem, ProblemParagraphMapping
 from knowledge.serializers.common import get_embedding_model_id_by_knowledge_id, update_document_char_length
 from knowledge.serializers.paragraph import ParagraphSerializers

--- a/apps/knowledge/serializers/knowledge.py
+++ b/apps/knowledge/serializers/knowledge.py
@@ -34,8 +34,7 @@ from django.db.models import QuerySet
 from django.db.models.functions import Reverse, Substr
 from django.db.models.query_utils import Q
 from django.http import HttpResponse
-from django.utils.translation import gettext
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, gettext
 from maxkb.conf import PROJECT_DIR
 from maxkb.const import CONFIG
 from models_provider.models import Model

--- a/apps/models_provider/impl/ollama_model_provider/credential/reranker.py
+++ b/apps/models_provider/impl/ollama_model_provider/credential/reranker.py
@@ -8,7 +8,6 @@
 """
 from typing import Dict
 
-from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _, gettext
 from langchain_core.documents import Document
 

--- a/apps/tools/serializers/tool_workflow.py
+++ b/apps/tools/serializers/tool_workflow.py
@@ -41,8 +41,7 @@ from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.http import HttpResponse
 from django.utils import timezone
-from django.utils.translation import gettext
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, gettext
 from knowledge.models import Knowledge, KnowledgeScope, KnowledgeWorkflow
 from knowledge.serializers.knowledge import KnowledgeModelSerializer, KnowledgeSerializer
 from maxkb.const import CONFIG


### PR DESCRIPTION
fix: Fix missing `import gettext_lazy as _` issues

修复3个文件缺失 `import gettext_lazy as _` 的问题：

- `base_intent_node.py` : `line-67`
    <img width="1920" height="1030" alt="图片" src="https://github.com/user-attachments/assets/39651e00-b1e0-49ba-abe5-0bdbb26e14bd" />
- `base_parameter_extraction_node.py` : `line-99`
    <img width="1920" height="1030" alt="图片" src="https://github.com/user-attachments/assets/38cdbeb3-13ae-4ac4-8eeb-b3691f1e448c" />
- `base_question_node.py` : `line-98`
    <img width="1920" height="1030" alt="图片" src="https://github.com/user-attachments/assets/bcfb450e-d47b-4a20-9353-659307b4ad7a" />