### PR TITLE
[codex] docs: fix English README link

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -4,7 +4,7 @@
     <a href="https://trendshift.io/repositories/9113" target="_blank"><img src="https://trendshift.io/api/badge/repositories/9113" alt="1Panel-dev%2FMaxKB | Trendshift" style="width: 250px; height: auto;" /></a>
 </p>
 <p align="center">
-  <a href="README_EN.md"><img src="https://img.shields.io/badge/English_README-blue" alt="English README"></a>
+  <a href="README.md"><img src="https://img.shields.io/badge/English_README-blue" alt="English README"></a>
   <a href="https://www.gnu.org/licenses/gpl-3.0.html#license-text"><img src="https://img.shields.io/github/license/1Panel-dev/maxkb?color=%231890FF" alt="License: GPL v3"></a>
   <a href="https://github.com/1Panel-dev/maxkb/releases/latest"><img src="https://img.shields.io/github/v/release/1Panel-dev/maxkb" alt="Latest release"></a>
   <a href="https://github.com/1Panel-dev/maxkb"><img src="https://img.shields.io/github/stars/1Panel-dev/maxkb?style=flat-square" alt="Stars"></a>


### PR DESCRIPTION
﻿#### What this PR does / why we need it?

Fixes a broken documentation link in `README_CN.md`.

The English README badge pointed to `README_EN.md`, but this repository currently contains `README.md` as the English README. Clicking the badge from the Chinese README therefore opened a missing file/404 page.

Closes #6365.

#### Summary of your change

Updated the English README badge link in `README_CN.md` from `README_EN.md` to `README.md`.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Validation: ran `git diff --check`; no whitespace errors were reported.
