### PR TITLE
fix application chat log route

### DIFF
--- a/ui/src/views/application/index.vue
+++ b/ui/src/views/application/index.vue
@@ -734,7 +734,7 @@ const get_route = (item: any) => {
       'OR',
     )
   ) {
-    return `/application//workspace${item.id}/${item.type}/chat-log`
+    return `/application/workspace/${item.id}/${item.type}/chat-log`
   } else return `/application/`
 }
 


### PR DESCRIPTION
﻿#### What this PR does / why we need it?

Fixes the malformed application chat-log fallback route.

Closes #6367.

#### Summary of your change

Updates the fallback route from `/application//workspace${item.id}/...` to `/application/workspace/${item.id}/...` so it matches the registered application detail route.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Validation: ran `git diff --check`.
