### PR TITLE
fix Windows torch source marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ explicit = true
 [tool.uv.sources]
 torch = [
     { index = "pytorch", marker = "sys_platform == 'linux'" },
-    { index = "pytorch", marker = "sys_platform == 'win'" },
+    { index = "pytorch", marker = "sys_platform == 'win32'" },
     { index = "macpytorch", marker = "sys_platform == 'darwin'" },
 ]
 


### PR DESCRIPTION
﻿#### What this PR does / why we need it?

Fixes the Windows `torch` uv source marker.

Closes #6368.

#### Summary of your change

Changes the Windows marker from `sys_platform == 'win'` to `sys_platform == 'win32'`, which is the value used by Python packaging markers on Windows.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Validation:
- `git diff --check`
- `packaging.markers.Marker("sys_platform == 'win32'").evaluate({'sys_platform': 'win32'})` returns `True`.
