### PR TITLE
fix default icon path interpolation

### DIFF
--- a/ui/src/utils/common.ts
+++ b/ui/src/utils/common.ts
@@ -27,7 +27,7 @@ export function filesize(size: number) {
 }
 
 // 头像
-export const defaultIcon = '/${window.MaxKB.prefix}/favicon.ico'
+export const defaultIcon = `${window.MaxKB.prefix}/favicon.ico`
 
 export function isAppIcon(url: string | undefined) {
   return url === defaultIcon ? '' : url


### PR DESCRIPTION
﻿#### What this PR does / why we need it?

Fixes `defaultIcon` so `window.MaxKB.prefix` is interpolated instead of treated as a literal string.

Closes #6369.

#### Summary of your change

Changes the default icon path from a normal quoted string to a template literal.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Validation: ran `git diff --check`.

Note: Frontend type-check was not run because this checkout does not include `ui/node_modules` or a frontend lockfile.
