### PR TITLE
add generated media download timeouts

### DIFF
--- a/apps/application/flow/step_node/image_generate_step_node/impl/base_image_generate_node.py
+++ b/apps/application/flow/step_node/image_generate_step_node/impl/base_image_generate_node.py
@@ -14,6 +14,9 @@ from models_provider.tools import get_model_instance_by_model_workspace_id
 from oss.serializers.file import FileSerializer
 
 
+GENERATED_MEDIA_DOWNLOAD_TIMEOUT = 30
+
+
 class BaseImageGenerateNode(IImageGenerateNode):
     def save_context(self, details, workflow_manage):
         self.context['answer'] = details.get('answer')
@@ -59,7 +62,9 @@ class BaseImageGenerateNode(IImageGenerateNode):
             if isinstance(image_url, str):
                 if image_url.startswith('http'):
                     # HTTP URL 情况
-                    image_url = requests.get(image_url).content
+                    response = requests.get(image_url, timeout=GENERATED_MEDIA_DOWNLOAD_TIMEOUT)
+                    response.raise_for_status()
+                    image_url = response.content
                 elif image_url.startswith('data:image'):
                     # Data URL 格式 (data:image/png;base64,...)
                     import base64

--- a/apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py
+++ b/apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py
@@ -16,6 +16,9 @@ from oss.serializers.file import FileSerializer, mime_types
 from models_provider.tools import get_model_instance_by_model_workspace_id
 
 
+GENERATED_MEDIA_DOWNLOAD_TIMEOUT = 30
+
+
 class BaseImageToVideoNode(IImageToVideoNode):
     def save_context(self, details, workflow_manage):
         self.context['answer'] = details.get('answer')
@@ -64,7 +67,9 @@ class BaseImageToVideoNode(IImageToVideoNode):
             return NodeResult({'answer': gettext('Failed to generate video')}, {})
         file_name = 'generated_video.mp4'
         if isinstance(video_urls, str) and video_urls.startswith('http'):
-            video_urls = requests.get(video_urls).content
+            response = requests.get(video_urls, timeout=GENERATED_MEDIA_DOWNLOAD_TIMEOUT)
+            response.raise_for_status()
+            video_urls = response.content
         file = bytes_to_uploaded_file(video_urls, file_name)
         file_url = self.upload_file(file)
         video_label = f'<video src="{file_url}" controls style="max-width: 100%; width: 100%; height: auto; max-height: 60vh;"></video>'

--- a/apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py
+++ b/apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py
@@ -15,6 +15,9 @@ from models_provider.tools import get_model_instance_by_model_workspace_id
 from django.utils.translation import gettext_lazy as _, gettext
 
 
+GENERATED_MEDIA_DOWNLOAD_TIMEOUT = 30
+
+
 class BaseTextToVideoNode(ITextToVideoNode):
     def save_context(self, details, workflow_manage):
         self.context['answer'] = details.get('answer')
@@ -57,7 +60,9 @@ class BaseTextToVideoNode(ITextToVideoNode):
             return NodeResult({'answer': gettext('Failed to generate video')}, {})
         file_name = 'generated_video.mp4'
         if isinstance(video_urls, str) and video_urls.startswith('http'):
-            video_urls = requests.get(video_urls).content
+            response = requests.get(video_urls, timeout=GENERATED_MEDIA_DOWNLOAD_TIMEOUT)
+            response.raise_for_status()
+            video_urls = response.content
         file = bytes_to_uploaded_file(video_urls, file_name)
         file_url = self.upload_file(file)
         video_label = f'<video src="{file_url}" controls style="max-width: 100%; width: 100%; height: auto;"></video>'


### PR DESCRIPTION
﻿#### What this PR does / why we need it?

Adds explicit timeouts and HTTP status checks when generated media workflow nodes download remote image/video URLs.

Closes #6370.

#### Summary of your change

- Adds a generated media download timeout constant.
- Uses `requests.get(..., timeout=...)` for generated remote media URLs.
- Calls `raise_for_status()` before saving the downloaded media bytes.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Validation:
- `python -m py_compile apps/application/flow/step_node/image_generate_step_node/impl/base_image_generate_node.py apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py`
- `git diff --check`
