### PR TITLE
fix generated media history URLs

### DIFF
--- a/apps/application/flow/step_node/image_generate_step_node/impl/base_image_generate_node.py
+++ b/apps/application/flow/step_node/image_generate_step_node/impl/base_image_generate_node.py
@@ -84,7 +84,10 @@ class BaseImageGenerateNode(IImageGenerateNode):
                     return chat_record.get_ai_message()
                 image_list = val['image_list']
                 return AIMessage(content=[
-                    *[{'type': 'image_url', 'image_url': {'url': f'{file_url}'}} for file_url in image_list]
+                    *[
+                        {'type': 'image_url', 'image_url': {'url': image_url}}
+                        for image_url in self.get_image_url_list(image_list)
+                    ]
                 ])
         return chat_record.get_ai_message()
 
@@ -115,6 +118,20 @@ class BaseImageGenerateNode(IImageGenerateNode):
             *history_message,
             question
         ]
+
+    @staticmethod
+    def get_image_url_list(image_list):
+        image_url_list = []
+        for image in image_list or []:
+            if isinstance(image, dict):
+                image_url = image.get('url') or (
+                    f"./oss/file/{image.get('file_id')}" if image.get('file_id') else None
+                )
+            else:
+                image_url = image
+            if image_url:
+                image_url_list.append(image_url)
+        return image_url_list
 
     def upload_file(self, file):
         if [WorkflowMode.KNOWLEDGE, WorkflowMode.KNOWLEDGE_LOOP].__contains__(

--- a/apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py
+++ b/apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py
@@ -149,7 +149,10 @@ class BaseImageToVideoNode(IImageToVideoNode):
                     return chat_record.get_ai_message()
                 image_list = val['image_list']
                 return AIMessage(content=[
-                    *[{'type': 'image_url', 'image_url': {'url': f'{file_url}'}} for file_url in image_list]
+                    *[
+                        {'type': 'image_url', 'image_url': {'url': image_url}}
+                        for image_url in self.get_image_url_list(image_list)
+                    ]
                 ])
         return chat_record.get_ai_message()
 
@@ -180,6 +183,20 @@ class BaseImageToVideoNode(IImageToVideoNode):
             *history_message,
             question
         ]
+
+    @staticmethod
+    def get_image_url_list(image_list):
+        image_url_list = []
+        for image in image_list or []:
+            if isinstance(image, dict):
+                image_url = image.get('url') or (
+                    f"./oss/file/{image.get('file_id')}" if image.get('file_id') else None
+                )
+            else:
+                image_url = image
+            if image_url:
+                image_url_list.append(image_url)
+        return image_url_list
 
     @staticmethod
     def reset_message_list(message_list: List[BaseMessage], answer_text):

--- a/apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py
+++ b/apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py
@@ -125,7 +125,10 @@ class BaseTextToVideoNode(ITextToVideoNode):
                     return chat_record.get_ai_message()
                 image_list = val['image_list']
                 return AIMessage(content=[
-                    *[{'type': 'image_url', 'image_url': {'url': f'{file_url}'}} for file_url in image_list]
+                    *[
+                        {'type': 'image_url', 'image_url': {'url': image_url}}
+                        for image_url in self.get_image_url_list(image_list)
+                    ]
                 ])
         return chat_record.get_ai_message()
 
@@ -156,6 +159,20 @@ class BaseTextToVideoNode(ITextToVideoNode):
             *history_message,
             question
         ]
+
+    @staticmethod
+    def get_image_url_list(image_list):
+        image_url_list = []
+        for image in image_list or []:
+            if isinstance(image, dict):
+                image_url = image.get('url') or (
+                    f"./oss/file/{image.get('file_id')}" if image.get('file_id') else None
+                )
+            else:
+                image_url = image
+            if image_url:
+                image_url_list.append(image_url)
+        return image_url_list
 
     @staticmethod
     def reset_message_list(message_list: List[BaseMessage], answer_text):


### PR DESCRIPTION
﻿#### What this PR does / why we need it?

Fixes generated media history replay so stored image metadata dictionaries are converted back into actual image URLs.

Closes #6371.

#### Summary of your change

- Adds a small helper to normalize historical `image_list` entries.
- Supports both existing string entries and current `{ file_id, url }` metadata dictionaries.
- Replays the actual URL instead of the string representation of the whole Python dict.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Validation:
- `python -m py_compile apps/application/flow/step_node/image_generate_step_node/impl/base_image_generate_node.py apps/application/flow/step_node/text_to_video_step_node/impl/base_text_to_video_node.py apps/application/flow/step_node/image_to_video_step_node/impl/base_image_to_video_node.py`
- `git diff --check`
