### PR TITLE
docs: document user list query parameters

### DIFF
--- a/apps/users/api/user.py
+++ b/apps/users/api/user.py
@@ -59,13 +59,22 @@ class UserProfileAPI(APIMixin):
 class WorkspaceUserAPI(APIMixin):
     @staticmethod
     def get_parameters():
-        return [OpenApiParameter(
-            name="workspace_id",
-            description=_('Workspace ID'),
-            type=OpenApiTypes.STR,
-            location=OpenApiParameter.PATH,
-            required=True,
-        )]
+        return [
+            OpenApiParameter(
+                name="workspace_id",
+                description=_('Workspace ID'),
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                required=True,
+            ),
+            OpenApiParameter(
+                name="nick_name",
+                description=_('Nick name'),
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+            )
+        ]
 
     @staticmethod
     def get_response():
@@ -165,16 +174,10 @@ class UserPageApi(APIMixin):
 class UserListApi(APIMixin):
     @staticmethod
     def get_parameters():
-        return [OpenApiParameter(
-            name="workspace_id",
-            description=_('Workspace ID'),
-            type=OpenApiTypes.STR,
-            location=OpenApiParameter.PATH,
-            required=False,
-        ),
+        return [
             OpenApiParameter(
                 name="nick_name",
-                description=_('Nickname'),
+                description=_('Nick name'),
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.QUERY,
                 required=False,

--- a/apps/users/views/user.py
+++ b/apps/users/views/user.py
@@ -11,8 +11,7 @@ import json
 from django.core.cache import cache
 from django.db.models import QuerySet
 from django.utils.translation import gettext_lazy as _
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.views import APIView
 
@@ -131,13 +130,7 @@ class UserList(APIView):
                    description=_("Get all user"),
                    operation_id=_("Get all user"),  # type: ignore
                    tags=[_("User Management")],  # type: ignore
-                   parameters=[OpenApiParameter(
-                       name="nick_name",
-                       description=_('Nickname'),
-                       type=OpenApiTypes.STR,
-                       location=OpenApiParameter.QUERY,  # type: ignore
-                       required=False,
-                   )],
+                   parameters=UserListApi.get_parameters(),
                    responses=UserListApi.get_response())
     @has_permissions(RoleConstants.WORKSPACE_MANAGE, RoleConstants.ADMIN, RoleConstants.EXTENDS_ADMIN,
                      RoleConstants.EXTENDS_WORKSPACE_MANAGE, RoleConstants.USER, RoleConstants.EXTENDS_USER)


### PR DESCRIPTION
## Summary
- Document the `nick_name` query parameter for `/user/list`.
- Document the same optional filter for workspace user list schema.

## Root cause
The API intentionally caps user list results at 200 records, but the generated OpenAPI docs did not expose the supported filter parameter.

## Validation
- `python -m py_compile apps\users\api\user.py apps\users\views\user.py`
- `git diff --check`

Fixes #6375