### PR TITLE
Refresh MiniMax M3 provider metadata

### DIFF
--- a/apps/models_provider/impl/minimax_model_provider/credential/llm.py
+++ b/apps/models_provider/impl/minimax_model_provider/credential/llm.py
@@ -64,9 +64,9 @@ class MiniMaxLLMModelCredential(BaseForm, BaseModelCredential):
     def encryption_dict(self, model: Dict[str, object]):
         return {**model, 'api_key': super().encryption(model.get('api_key', ''))}
 
-    api_base = forms.TextInputField('API URL', required=True,
-                                    default_value='https://api.minimaxi.com/v1')
-    api_key = forms.PasswordInputField('API Key', required=True)
+    api_base = forms.TextInputField(_('API URL'), required=True,
+                                    default_value='https://api.minimax.io/v1')
+    api_key = forms.PasswordInputField(_('API Key'), required=True)
 
     def get_model_params_setting_form(self, model_name):
         return MiniMaxLLMModelParams()

--- a/apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py
+++ b/apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py
@@ -28,9 +28,23 @@ minimax_tti_model_credential = MiniMaxTextToImageModelCredential()
 minimax_ttv_model_credential = TextToVideoModelCredential()
 minimax_itv_model_credential = ImageToVideoModelCredential()
 
+MINIMAX_ENDPOINTS = {
+    "global_en": {
+        "openai_base_url": "https://api.minimax.io/v1",
+        "anthropic_base_url": "https://api.minimax.io/anthropic/v1",
+    },
+    "cn_zh": {
+        "openai_base_url": "https://api.minimaxi.com/v1",
+        "anthropic_base_url": "https://api.minimaxi.com/anthropic/v1",
+    },
+}
+
 minimax_m2_7 = ModelInfo(
     "MiniMax-M2.7",
-    _("Latest flagship model with enhanced reasoning and coding. 204K context window"),
+    _(
+        "Reasoning model with always-on thinking, 204,800-token context window, "
+        "$0.30/M input, $1.20/M output, $0.06/M cache read, and $0.375/M cache write"
+    ),
     ModelTypeConst.LLM,
     minimax_llm_model_credential,
     MiniMaxChatModel,
@@ -38,7 +52,10 @@ minimax_m2_7 = ModelInfo(
 
 minimax_m3 = ModelInfo(
     "MiniMax-M3",
-    _(""),
+    _(
+        "Adaptive-thinking multimodal model with text, image, and video inputs, "
+        "1,000,000-token context window, $0.60/M input, $2.40/M output, and $0.12/M cache read"
+    ),
     ModelTypeConst.LLM,
     minimax_llm_model_credential,
     MiniMaxChatModel,
@@ -100,7 +117,7 @@ model_info_manage = (
     .append_model_info(minimax_m2_7_highspeed)
     .append_model_info(minimax_m2_5)
     .append_model_info(minimax_m2_5_highspeed)
-    .append_default_model_info(minimax_m2_7)
+    .append_default_model_info(minimax_m3)
     .append_model_info(minimax_tts_hd)
     .append_model_info(minimax_tts_turbo)
     .append_default_model_info(minimax_tts_hd)

--- a/apps/models_provider/impl/minimax_model_provider/model/llm.py
+++ b/apps/models_provider/impl/minimax_model_provider/model/llm.py
@@ -22,7 +22,7 @@ class MiniMaxChatModel(MaxKBBaseModel, BaseChatOpenAI):
         optional_params['extra_body'] = extra_body
         return MiniMaxChatModel(
             model=model_name,
-            openai_api_base=model_credential.get('api_base') or 'https://api.minimaxi.com/v1',
+            openai_api_base=model_credential.get('api_base') or 'https://api.minimax.io/v1',
             openai_api_key=model_credential.get('api_key'),
             **optional_params,
         )


### PR DESCRIPTION
Reason: refresh MiniMax endpoints and M3 context metadata in existing provider

## Summary
- Updates MiniMax LLM default endpoint to the global OpenAI-compatible URL.
- Records both global and China OpenAI/Anthropic endpoint metadata, including /anthropic/v1 URLs.
- Refreshes MiniMax-M3 and MiniMax-M2.7 descriptions with context, pricing, and thinking metadata, and makes MiniMax-M3 the default LLM.

## Checks
- python3 -m py_compile apps/models_provider/impl/minimax_model_provider/credential/llm.py apps/models_provider/impl/minimax_model_provider/model/llm.py apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py