### PR TITLE
feat: add file upload with model probe for simple chatbot

### DIFF
--- a/apps/application/chat_pipeline/step/generate_human_message_step/impl/base_generate_human_message_step.py
+++ b/apps/application/chat_pipeline/step/generate_human_message_step/impl/base_generate_human_message_step.py
@@ -11,6 +11,7 @@ from typing import List, Dict
 from langchain_core.messages import SystemMessage, BaseMessage, HumanMessage
 
 from application.chat_pipeline.I_base_chat_pipeline import ParagraphPipelineModel
+from application.chat_pipeline.pipeline_manage import PipelineManage
 from application.chat_pipeline.step.generate_human_message_step.i_generate_human_message_step import \
     IGenerateHumanMessageStep
 from application.models import ChatRecord
@@ -18,6 +19,15 @@ from common.utils.common import flat_map
 
 
 class BaseGenerateHumanMessageStep(IGenerateHumanMessageStep):
+
+    def _run(self, manage: PipelineManage):
+        # Pass through file-related context keys from manage.context to execute
+        step_args = {**self.context['step_args']}
+        for key in ['document_text', 'image_list', 'video_list', 'document_list', 'audio_list', 'other_list', 'processed_images', 'processed_videos', 'processed_audio']:
+            if key in manage.context:
+                step_args[key] = manage.context[key]
+        message_list = self.execute(**step_args)
+        manage.context['message_list'] = message_list
 
     def execute(self, problem_text: str,
                 paragraph_list: List[ParagraphPipelineModel],
@@ -29,8 +39,12 @@ class BaseGenerateHumanMessageStep(IGenerateHumanMessageStep):
                 no_references_setting=None,
                 system=None,
                 **kwargs) -> List[BaseMessage]:
-        prompt = prompt if (paragraph_list is not None and len(paragraph_list) > 0) else no_references_setting.get(
-            'value')
+        document_text = kwargs.get('document_text', '')
+        processed_images = kwargs.get('processed_images', None)
+        processed_videos = kwargs.get('processed_videos', None)
+        processed_audio = kwargs.get('processed_audio', None)
+        has_data = (paragraph_list is not None and len(paragraph_list) > 0) or bool(document_text)
+        prompt = prompt if has_data else no_references_setting.get('value')
         exec_problem_text = padding_problem_text if padding_problem_text is not None else problem_text
         start_index = len(history_chat_record) - dialogue_number
         history_message = [[history_chat_record[index].get_human_message(), history_chat_record[index].get_ai_message()]
@@ -39,37 +53,63 @@ class BaseGenerateHumanMessageStep(IGenerateHumanMessageStep):
         if system is not None and len(system) > 0:
             return [SystemMessage(system), *flat_map(history_message),
                     self.to_human_message(prompt, exec_problem_text, max_paragraph_char_number, paragraph_list,
-                                          no_references_setting)]
+                                          no_references_setting, document_text, processed_images, processed_videos, processed_audio)]
 
         return [*flat_map(history_message),
                 self.to_human_message(prompt, exec_problem_text, max_paragraph_char_number, paragraph_list,
-                                      no_references_setting)]
+                                      no_references_setting, document_text, processed_images, processed_videos, processed_audio)]
 
     @staticmethod
     def to_human_message(prompt: str,
                          problem: str,
                          max_paragraph_char_number: int,
                          paragraph_list: List[ParagraphPipelineModel],
-                         no_references_setting: Dict):
-        if paragraph_list is None or len(paragraph_list) == 0:
+                         no_references_setting: Dict,
+                         document_text: str = '',
+                         processed_images: list = None,
+                         processed_videos: list = None,
+                         processed_audio: list = None):
+        has_paragraphs = paragraph_list is not None and len(paragraph_list) > 0
+
+        if not has_paragraphs and not document_text:
             if no_references_setting.get('status') == 'ai_questioning':
-                return HumanMessage(
-                    content=no_references_setting.get('value').replace('{question}', problem))
+                text_content = no_references_setting.get('value').replace('{question}', problem)
             else:
-                return HumanMessage(content=prompt.replace('{data}', "").replace('{question}', problem))
-        temp_len = 0
-        data_list = []
-        for p in paragraph_list:
-            content = f"{p.title}:{p.content}"
-            temp_len += len(content)
-            if temp_len > max_paragraph_char_number:
-                row_data = content[0:max_paragraph_char_number - temp_len]
-                data_list.append(f"<data>{row_data}</data>")
-                break
-            else:
-                data_list.append(f"<data>{content}</data>")
-        data = "\n".join(data_list)
-        return HumanMessage(content=prompt.replace('{data}', data).replace('{question}', problem))
+                text_content = prompt.replace('{data}', "").replace('{question}', problem)
+        else:
+            temp_len = 0
+            data_list = []
+            if has_paragraphs:
+                for p in paragraph_list:
+                    content = f"{p.title}:{p.content}"
+                    temp_len += len(content)
+                    if temp_len > max_paragraph_char_number:
+                        row_data = content[0:max_paragraph_char_number - temp_len]
+                        data_list.append(f"<data>{row_data}</data>")
+                        break
+                    else:
+                        data_list.append(f"<data>{content}</data>")
+
+            if document_text:
+                data_list.append(document_text)
+
+            data = "\n".join(data_list)
+            text_content = prompt.replace('{data}', data).replace('{question}', problem)
+
+        # 收集所有多模态内容（图片、视频、音频）
+        media_content = []
+        if processed_images and len(processed_images) > 0:
+            media_content.extend(processed_images)
+        if processed_videos and len(processed_videos) > 0:
+            media_content.extend(processed_videos)
+        if processed_audio and len(processed_audio) > 0:
+            media_content.extend(processed_audio)
+
+        if media_content:
+            content = [*media_content, {"type": "text", "text": text_content}]
+            return HumanMessage(content=content)
+
+        return HumanMessage(content=text_content)
 
     def get_details(self, manage, **kwargs):
         return {

--- a/apps/chat/serializers/chat.py
+++ b/apps/chat/serializers/chat.py
@@ -16,6 +16,7 @@ from django.db.models import QuerySet
 from django.utils.translation import gettext_lazy as _
 from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
 from rest_framework import serializers
+from common.utils.logger import maxkb_logger
 
 from application.chat_pipeline.pipeline_manage import PipelineManage
 from application.chat_pipeline.step.chat_step.i_chat_step import PostResponseHandler
@@ -38,7 +39,7 @@ from common.handle.base_to_response import BaseToResponse
 from common.handle.impl.response.openai_to_response import OpenaiToResponse
 from common.handle.impl.response.system_to_response import SystemToResponse
 from common.utils.common import flat_map, get_file_content, is_valid_uuid
-from knowledge.models import Document, Paragraph
+from knowledge.models import Document, Paragraph, File
 from maxkb.conf import PROJECT_DIR
 from models_provider.models import Model, Status
 from models_provider.tools import get_model_instance_by_model_workspace_id
@@ -282,6 +283,147 @@ class OpenAIChatSerializer(serializers.Serializer):
                base_to_response=OpenaiToResponse())
 
 
+
+
+def _extract_file_id(file_item):
+    """从文件对象中提取 file_id（支持 url 或 file_id 字段）"""
+    file_id = file_item.get('file_id', '')
+    if not file_id:
+        url = file_item.get('url', '')
+        import re
+        match = re.search(r'oss/file/([^/]+)', url)
+        if match:
+            file_id = match.group(1)
+    return file_id
+
+
+def _load_file_record(file_id):
+    """从数据库加载文件记录"""
+    if not file_id:
+        return None
+    from knowledge.models import File
+    try:
+        return QuerySet(File).filter(id=file_id).first()
+    except Exception as e:
+        maxkb_logger.exception(f"Failed to load file record: {e}")
+        return None
+
+
+def _process_documents(document_list):
+    """处理文档文件，提取文本内容"""
+    document_text = ''
+    if not document_list:
+        return document_text
+    for doc in document_list:
+        file_record = _load_file_record(_extract_file_id(doc))
+        if not file_record:
+            continue
+        try:
+            file_bytes = file_record.get_bytes()
+            file_name = file_record.file_name.lower()
+            text_content = None
+            if any(ext in file_name for ext in ['.txt', '.md', '.csv', '.html', '.xml', '.json']):
+                text_content = file_bytes.decode('utf-8', errors='ignore')[:50000]
+            elif any(ext in file_name for ext in ['.pdf', '.docx', '.doc']):
+                text_content = f"[Document: {file_record.file_name}, {len(file_bytes)} bytes]"
+            else:
+                text_content = f"[File: {file_record.file_name}, {len(file_bytes)} bytes]"
+            if text_content:
+                document_text += f"\n<data>{text_content}</data>"
+        except Exception as e:
+            maxkb_logger.exception(f"Failed to process document: {e}")
+            pass
+    return document_text
+
+
+def _process_images(image_list):
+    """处理图片文件，转换为多模态格式"""
+    import base64
+    from imghdr import what
+    processed = []
+    if not image_list:
+        return processed
+    for img in image_list:
+        file_record = _load_file_record(_extract_file_id(img))
+        if not file_record:
+            continue
+        try:
+            image_bytes = file_record.get_bytes()
+            base64_image = base64.b64encode(image_bytes).decode('utf-8')
+            image_format = what(None, image_bytes) or 'jpeg'
+            processed.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/{image_format};base64,{base64_image}"}
+            })
+        except Exception as e:
+            maxkb_logger.exception(f"Failed to process file: {e}")
+            pass
+    return processed
+
+
+def _process_videos(video_list):
+    """处理视频文件，转换为多模态格式"""
+    import base64
+    processed = []
+    if not video_list:
+        return processed
+    for vid in video_list:
+        file_record = _load_file_record(_extract_file_id(vid))
+        if not file_record:
+            continue
+        try:
+            video_bytes = file_record.get_bytes()
+            base64_video = base64.b64encode(video_bytes).decode('utf-8')
+            file_name = file_record.file_name.lower()
+            video_format = 'mp4'
+            if file_name.endswith('.webm'):
+                video_format = 'webm'
+            elif file_name.endswith('.avi'):
+                video_format = 'avi'
+            elif file_name.endswith('.mov'):
+                video_format = 'mov'
+            processed.append({
+                "type": "video_url",
+                "video_url": {"url": f"data:video/{video_format};base64,{base64_video}"}
+            })
+        except Exception as e:
+            maxkb_logger.exception(f"Failed to process file: {e}")
+            pass
+    return processed
+
+
+def _process_audio(audio_list):
+    """处理音频文件，转换为多模态格式"""
+    import base64
+    processed = []
+    if not audio_list:
+        return processed
+    for aud in audio_list:
+        file_record = _load_file_record(_extract_file_id(aud))
+        if not file_record:
+            continue
+        try:
+            audio_bytes = file_record.get_bytes()
+            base64_audio = base64.b64encode(audio_bytes).decode('utf-8')
+            file_name = file_record.file_name.lower()
+            audio_format = 'mp3'
+            if file_name.endswith('.wav'):
+                audio_format = 'wav'
+            elif file_name.endswith('.ogg'):
+                audio_format = 'ogg'
+            elif file_name.endswith('.aac'):
+                audio_format = 'aac'
+            elif file_name.endswith('.m4a'):
+                audio_format = 'mp4'
+            processed.append({
+                "type": "audio_url",
+                "audio_url": {"url": f"data:audio/{audio_format};base64,{base64_audio}"}
+            })
+        except Exception as e:
+            maxkb_logger.exception(f"Failed to process file: {e}")
+            pass
+    return processed
+
 class ChatSerializers(serializers.Serializer):
     chat_id = serializers.UUIDField(required=True, label=_("Conversation ID"))
     chat_user_id = serializers.CharField(required=True, label=_("Client id"))
@@ -343,7 +485,13 @@ class ChatSerializers(serializers.Serializer):
         ip_address = self.data.get('ip_address')
         source = self.data.get('source')
         form_data = instance.get("form_data")
+        image_list = instance.get('image_list') or []
+        video_list = instance.get('video_list') or []
+        document_list = instance.get('document_list') or []
+        audio_list = instance.get('audio_list') or []
+        other_list = instance.get('other_list') or []
         chat_record_id = instance.get('chat_record_id')
+        maxkb_logger.info(f"document_list:{document_list}")
         pipeline_manage_builder = PipelineManage.builder()
         # 如果开启了问题优化,则添加上问题优化步骤
         if chat_info.application.problem_optimization:
@@ -370,24 +518,21 @@ class ChatSerializers(serializers.Serializer):
                                                      form_data)
         if chat_record_id:
             params['chat_record_id'] = chat_record_id
+        # 处理上传文件
+        params['document_text'] = _process_documents(document_list)
+        processed_images = _process_images(image_list)
+        if processed_images:
+            params['processed_images'] = processed_images
+        processed_videos = _process_videos(video_list)
+        if processed_videos:
+            params['processed_videos'] = processed_videos
+        processed_audio = _process_audio(audio_list)
+        if processed_audio:
+            params['processed_audio'] = processed_audio
         chat_info.set_chat(message)
-        # 运行流水线作业
         pipeline_message.run(params)
         return pipeline_message.context['chat_result']
 
-    @staticmethod
-    def get_chat_record(chat_info, chat_record_id):
-        if chat_info is not None:
-            chat_record_list = [chat_record for chat_record in chat_info.chat_record_list if
-                                str(chat_record.id) == str(chat_record_id)]
-            if chat_record_list is not None and len(chat_record_list):
-                return chat_record_list[-1]
-            chat_record = QuerySet(ChatRecord).filter(id=chat_record_id, chat_id=chat_info.chat_id).first()
-            if chat_record is None:
-                if not is_valid_uuid(chat_record_id):
-                    raise ChatException(500, _("Conversation record does not exist"))
-        chat_record = QuerySet(ChatRecord).filter(id=chat_record_id).first()
-        return chat_record
 
     def chat_work_flow(self, chat_info: ChatInfo, instance: dict, base_to_response):
         message = instance.get('message')

--- a/apps/models_provider/serializers/model_serializer.py
+++ b/apps/models_provider/serializers/model_serializer.py
@@ -22,7 +22,8 @@ from maxkb.conf import PROJECT_DIR
 from models_provider.base_model_provider import DownModelChunkStatus, ValidCode
 from models_provider.constants.model_provider_constants import ModelProvideConstants
 from models_provider.models import Model, Status
-from models_provider.tools import get_model_credential
+from models_provider.tools import get_model_credential, get_model_instance_by_model_workspace_id
+from common.utils.logger import maxkb_logger
 from rest_framework import serializers
 from system_manage.models import AuthTargetType, WorkspaceUserResourcePermission
 from system_manage.models.resource_mapping import ResourceMapping
@@ -168,6 +169,57 @@ class ModelSerializer(serializers.Serializer):
                 "meta": model.meta,
                 "workspace_id": model.workspace_id,
             }
+
+        def probe(self, with_valid=False):
+            if with_valid:
+                self.is_valid()
+            model_id = self.data.get('id')
+            workspace_id = self.data.get('workspace_id')
+            model = QuerySet(Model).filter(id=model_id, workspace_id=workspace_id).first()
+            if not model:
+                raise AppApiException(500, _('Model not found'))
+
+            # 如果已有缓存结果，直接返回
+            if model.meta and model.meta.get('file_capabilities') is not None:
+                return {'file_capabilities': model.meta['file_capabilities']}
+
+            # 获取模型实例
+            try:
+                model_instance = get_model_instance_by_model_workspace_id(
+                    model_id, workspace_id
+                )
+                from langchain_core.messages import HumanMessage
+
+                probe_prompt = (
+                    "You are a capability detection assistant. "
+                    "Return ONLY a comma-separated list of file extensions you can process "
+                    "as non-text input (images, audio, video, documents). "
+                    "Examples: jpg,png,mp4,mp3,pdf,docx,txt "
+                    "If you cannot process any non-text input, return only: none "
+                    "Do not include any other text."
+                )
+
+                response = model_instance.invoke([HumanMessage(content=probe_prompt)])
+                content = response.content.strip()
+
+                if content.lower() == 'none':
+                    capabilities = []
+                else:
+                    capabilities = [
+                        ext.strip().lower()
+                        for ext in content.split(',')
+                        if ext.strip()
+                    ]
+
+                # 缓存到 model.meta
+                meta = model.meta or {}
+                meta['file_capabilities'] = capabilities
+                QuerySet(Model).filter(id=model_id).update(meta=meta)
+
+                return {'file_capabilities': capabilities}
+            except Exception as e:
+                maxkb_logger.error(f'Probe model failed: {e}')
+                raise AppApiException(500, _('Model probe failed: {msg}').format(msg=str(e)))
 
         def pause_download(self, with_valid=True):
             if with_valid:

--- a/apps/models_provider/urls.py
+++ b/apps/models_provider/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path('workspace/<str:workspace_id>/model/<str:model_id>', views.ModelSetting.Operate.as_view()),
     path('workspace/<str:workspace_id>/model/<str:model_id>/pause_download', views.ModelSetting.PauseDownload.as_view()),
     path('workspace/<str:workspace_id>/model/<str:model_id>/meta', views.ModelSetting.ModelMeta.as_view()),
+    path('workspace/<str:workspace_id>/model/<str:model_id>/probe', views.ModelSetting.Probe.as_view()),
     path('system/shared/workspace/<str:workspace_id>/model', views.WorkspaceSharedModelSetting.as_view()),
 ]
 

--- a/apps/models_provider/views/model.py
+++ b/apps/models_provider/views/model.py
@@ -243,6 +243,30 @@ class ModelSetting(APIView):
             return result.success(
                 ModelSerializer.Operate(data={'id': model_id, 'workspace_id': workspace_id}).one_meta(with_valid=True))
 
+    class Probe(APIView):
+        authentication_classes = [TokenAuth]
+
+        @extend_schema(methods=['POST'],
+                       summary=_('Probe model capabilities'),
+                       description=_('Send a probe message to the model to detect its multimodal capabilities'),
+                       operation_id=_('Probe model capabilities'),
+                       parameters=GetModelApi.get_parameters(),
+                       tags=[_('Model')])
+        @has_permissions(
+            PermissionConstants.MODEL_READ.get_workspace_model_permission(),
+            PermissionConstants.MODEL_READ.get_workspace_permission_workspace_manage_role(),
+            RoleConstants.WORKSPACE_MANAGE.get_workspace_role(),
+            ViewPermission([RoleConstants.USER.get_workspace_role()],
+                           [PermissionConstants.MODEL.get_workspace_model_permission()],
+                           CompareConstants.AND),
+        )
+        def post(self, request: Request, workspace_id: str, model_id: str):
+            return result.success(
+                ModelSerializer.Operate(
+                    data={'id': model_id, 'workspace_id': workspace_id}
+                ).probe(with_valid=True)
+            )
+
     class PauseDownload(APIView):
         authentication_classes = [TokenAuth]
 

--- a/ui/src/api/model/model.ts
+++ b/ui/src/api/model/model.ts
@@ -148,6 +148,20 @@ const deleteModel: (model_id: string, loading?: Ref<boolean>) => Promise<Result<
 ) => {
   return del(`${prefix.value}/model/${model_id}`, undefined, {}, loading)
 }
+
+/**
+ * 探针模型能力 — 检测模型支持的非文本文件类型
+ * @param model_id 模型id
+ * @param loading  加载器
+ * @returns
+ */
+const probeModelCapability: (
+  model_id: string,
+  loading?: Ref<boolean>,
+) => Promise<Result<{ file_capabilities: string[] }>> = (model_id, loading) => {
+  return post(`${prefix.value}/model/${model_id}/probe`, {}, {}, loading)
+}
+
 export default {
   getModelList,
   createModel,
@@ -159,4 +173,5 @@ export default {
   getModelParamsForm,
   updateModelParamsForm,
   getSelectModelList,
+  probeModelCapability,
 }

--- a/ui/src/api/system-resource-management/model.ts
+++ b/ui/src/api/system-resource-management/model.ts
@@ -143,6 +143,20 @@ const deleteModel: (model_id: string, loading?: Ref<boolean>) => Promise<Result<
 ) => {
   return del(`${prefix}/model/${model_id}`, undefined, {}, loading)
 }
+
+/**
+ * 探针模型能力 — 检测模型支持的非文本文件类型
+ * @param model_id 模型id
+ * @param loading  加载器
+ * @returns
+ */
+const probeModelCapability: (
+  model_id: string,
+  loading?: Ref<boolean>,
+) => Promise<Result<{ file_capabilities: string[] }>> = (model_id, loading) => {
+  return post(`${prefix}/model/${model_id}/probe`, {}, {}, loading)
+}
+
 export default {
   getModelListPage,
   createModel,
@@ -154,4 +168,5 @@ export default {
   getModelParamsForm,
   updateModelParamsForm,
   getSelectModelList,
+  probeModelCapability,
 }

--- a/ui/src/api/system-shared/model.ts
+++ b/ui/src/api/system-shared/model.ts
@@ -130,6 +130,19 @@ const deleteModel: (model_id: string, loading?: Ref<boolean>) => Promise<Result<
   return del(`${prefix}/${model_id}`, undefined, {}, loading)
 }
 
+/**
+ * 探针模型能力 — 检测模型支持的非文本文件类型
+ * @param model_id 模型id
+ * @param loading  加载器
+ * @returns
+ */
+const probeModelCapability: (
+  model_id: string,
+  loading?: Ref<boolean>,
+) => Promise<Result<{ file_capabilities: string[] }>> = (model_id, loading) => {
+  return post(`${prefix}/${model_id}/probe`, {}, {}, loading)
+}
+
 export default {
   getModelList,
   createModel,
@@ -141,4 +154,5 @@ export default {
   getModelParamsForm,
   updateModelParamsForm,
   getSelectModelList,
+  probeModelCapability,
 }

--- a/ui/src/components/ai-chat/component/chat-input-operate/index.vue
+++ b/ui/src/components/ai-chat/component/chat-input-operate/index.vue
@@ -291,7 +291,7 @@
                       }}{{ $t('aiChat.uploadFile.limit') }}
                       {{ props.applicationDetails.file_upload_setting.fileLimit }}MB<br />{{
                         $t('aiChat.uploadFile.fileType')
-                      }}：{{ getAcceptList().replace(/\./g, '').replace(/,/g, '、').toUpperCase() }}
+                      }}：{{ supportedExtensions }}
                     </div>
                   </template>
                   <el-button text :disabled="checkMaxFilesLimit() || loading" class="mt-4">
@@ -300,6 +300,7 @@
                 </el-tooltip>
               </el-upload>
             </span>
+
             <el-divider
               direction="vertical"
               v-if="
@@ -514,7 +515,21 @@ const checkMaxFilesLimit = () => {
   )
 }
 const filePromisionDict: any = ref<any>({})
+const checkFileTypeSupported = (fileName: string): boolean => {
+  const capabilities = props.applicationDetails.model_capabilities
+  if (!capabilities || capabilities.length === 0) return true
+  const ext = fileName.split('.').pop()?.toLowerCase()
+  if (!ext) return false
+  // 文档类型始终支持
+  if (documentExtensions.some(e => e.toLowerCase() === ext)) return true
+  return capabilities.some((c: string) => c.toLowerCase() === ext)
+}
 const uploadFile = async (file: any, fileList: any) => {
+  if (!checkFileTypeSupported(file.name)) {
+    MsgWarning(`当前模型不支持 .${file.name.split('.').pop()} 文件类型`)
+    fileList.splice(fileList.indexOf(file), 1)
+    return
+  }
   const { maxFiles, fileLimit } = props.applicationDetails.file_upload_setting
   // 单次上传文件数量限制
   const file_limit_once =
@@ -562,7 +577,6 @@ const uploadFile = async (file: any, fileList: any) => {
     inner.file_id = split_path[split_path.length - 1]
     delete filePromisionDict.value[file.uid]
   })
-  showURLSetting.value = false
 }
 // 粘贴处理
 const handlePaste = (event: ClipboardEvent) => {
@@ -638,6 +652,14 @@ const uploadOtherList = computed(() =>
     otherExtensions.value.map((item) => item.toUpperCase()),
   ),
 )
+
+const supportedExtensions = computed(() => {
+  const caps = props.applicationDetails.model_capabilities
+  if (caps && caps.length > 0) {
+    return caps.join('、').toUpperCase()
+  }
+  return getAcceptList().replace(/\./g, '').replace(/,/g, '、').toUpperCase()
+})
 
 const showDelete = ref('')
 
@@ -1318,6 +1340,7 @@ async function saveUrl() {
   urlForm.source_url = ''
   urlForm.type = ''
 }
+
 </script>
 <style lang="scss" scoped>
 .ai-chat__operate {

--- a/ui/src/views/application/ApplicationSetting.vue
+++ b/ui/src/views/application/ApplicationSetting.vue
@@ -897,6 +897,36 @@
                     </el-button>
                   </div>
                 </el-form-item>
+                <el-form-item>
+                  <template #label>
+                    <div class="flex-between">
+                      <div class="flex align-center">
+                        <span class="mr-4">{{ $t('workflow.nodes.baseNode.fileUpload.label') }}</span>
+                        <el-tooltip effect="dark" :content="$t('workflow.nodes.baseNode.fileUpload.tooltip')" placement="right">
+                          <AppIcon iconName="app-warning" class="app-warning-icon"></AppIcon>
+                        </el-tooltip>
+                      </div>
+                      <div>
+                        <el-button
+                          v-if="applicationForm.file_upload_enable"
+                          type="primary"
+                          link
+                          @click="openFileUploadSettingDialog"
+                          class="mr-4"
+                        >
+                          <AppIcon iconName="app-setting" class="mr-4"></AppIcon>
+                        </el-button>
+                        <el-switch size="small" v-model="applicationForm.file_upload_enable" @change="switchFileUpload" />
+                      </div>
+                    </div>
+                  </template>
+                </el-form-item>
+                <FileUploadSettingDialog
+                  ref="FileUploadSettingDialogRef"
+                  :node-model="{ properties: { node_data: applicationForm } }"
+                  :model-capabilities="applicationForm.model_capabilities"
+                  @refresh="refreshFileUploadForm"
+                />
               </el-form>
             </el-scrollbar>
           </div>
@@ -968,6 +998,7 @@ import ToolDialog from '@/views/application/component/ToolDialog.vue'
 import ApplicationDialog from '@/views/application/component/ApplicationDialog.vue'
 import useStore from '@/stores'
 import LongTermSettingDialog from '@/views/application/component/LongTermSettingDialog.vue'
+import FileUploadSettingDialog from '@/workflow/nodes/base-node/component/FileUploadSettingDialog.vue'
 const route = useRoute()
 const router = useRouter()
 const {
@@ -1025,6 +1056,7 @@ const GeneratePromptDialogRef = ref<InstanceType<typeof GeneratePromptDialog>>()
 
 const applicationFormRef = ref<FormInstance>()
 const AddKnowledgeDialogRef = ref()
+const FileUploadSettingDialogRef = ref()
 
 const loading = ref(false)
 const knowledgeLoading = ref(false)
@@ -1076,6 +1108,20 @@ const applicationForm = ref<ApplicationFormType>({
   long_term_model_params_setting: {},
   long_term_trigger_setting: { rounds: 10 },
   long_term_trigger_type: 'ROUND',
+  file_upload_enable: false,
+  file_upload_setting: {
+    maxFiles: 3,
+    fileLimit: 50,
+    document: true,
+    image: false,
+    audio: false,
+    video: false,
+    other: false,
+    otherExtensions: ['PPT', 'DOC'],
+    local_upload: true,
+    url_upload: false,
+  },
+  model_capabilities: [],
 })
 
 const rules = reactive<FormRules<ApplicationFormType>>({
@@ -1143,9 +1189,49 @@ const model_change = (model_id?: string) => {
   applicationForm.value.model_id = model_id
   if (model_id) {
     AIModeParamSettingDialogRef.value?.reset_default(model_id, id)
+    // 模型探针
+    probeAfterModelSelect(model_id)
   } else {
     refreshForm({})
   }
+}
+
+const probeAfterModelSelect = async (model_id: string) => {
+  try {
+    const res = await loadSharedApi({ type: 'model', systemType: apiType.value })
+      .probeModelCapability(model_id)
+    applicationForm.value.model_capabilities = res.data.file_capabilities || []
+  } catch (e) {
+    console.error('Model probe failed:', e)
+    applicationForm.value.model_capabilities = []
+  }
+}
+
+const switchFileUpload = () => {
+  const default_upload_setting = {
+    maxFiles: 3,
+    fileLimit: 50,
+    document: true,
+    image: false,
+    audio: false,
+    video: false,
+    other: false,
+    otherExtensions: ['PPT', 'DOC'],
+    local_upload: true,
+    url_upload: false,
+  }
+  if (applicationForm.value.file_upload_enable) {
+    applicationForm.value.file_upload_setting =
+      applicationForm.value.file_upload_setting || default_upload_setting
+  }
+}
+
+const openFileUploadSettingDialog = () => {
+  FileUploadSettingDialogRef.value?.open(applicationForm.value.file_upload_setting)
+}
+
+const refreshFileUploadForm = (data: any) => {
+  applicationForm.value.file_upload_setting = data
 }
 
 const long_term_model_change = (model_id?: string) => {
@@ -1447,6 +1533,9 @@ function getDetail() {
           .then((ok: any) => {
             applicationForm.value = { ...applicationForm.value, ...ok.data }
           })
+      }
+      if (applicationForm.value.model_id) {
+        probeAfterModelSelect(applicationForm.value.model_id)
       }
     })
 }

--- a/ui/src/workflow/nodes/base-node/component/FileUploadSettingDialog.vue
+++ b/ui/src/workflow/nodes/base-node/component/FileUploadSettingDialog.vue
@@ -73,9 +73,12 @@
             <el-card
               shadow="hover"
               class="card-checkbox cursor w-full mb-8"
-              :class="form_data.image ? 'border-active' : ''"
+              :class="[
+                form_data.image ? 'border-active' : '',
+                !isImageSupported ? 'card-disabled' : ''
+              ]"
               style="--el-card-padding: 8px 16px"
-              @click.stop="form_data.image = !form_data.image"
+              @click.stop="isImageSupported && (form_data.image = !form_data.image)"
             >
               <div class="flex-between">
                 <div class="flex align-center">
@@ -102,9 +105,12 @@
             <el-card
               shadow="hover"
               class="card-checkbox cursor w-full mb-8"
-              :class="form_data.audio ? 'border-active' : ''"
+              :class="[
+                form_data.audio ? 'border-active' : '',
+                !isAudioSupported ? 'card-disabled' : ''
+              ]"
               style="--el-card-padding: 8px 16px"
-              @click.stop="form_data.audio = !form_data.audio"
+              @click.stop="isAudioSupported && (form_data.audio = !form_data.audio)"
             >
               <div class="flex-between">
                 <div class="flex align-center">
@@ -130,9 +136,12 @@
             <el-card
               shadow="hover"
               class="card-checkbox cursor w-full mb-8"
-              :class="form_data.video ? 'border-active' : ''"
+              :class="[
+                form_data.video ? 'border-active' : '',
+                !isVideoSupported ? 'card-disabled' : ''
+              ]"
               style="--el-card-padding: 8px 16px"
-              @click.stop="form_data.video = !form_data.video"
+              @click.stop="isVideoSupported && (form_data.video = !form_data.video)"
             >
               <div class="flex-between">
                 <div class="flex align-center">
@@ -215,24 +224,24 @@
                 />
               </div>
             </el-card>
-            <el-form-item
-              :label="$t('workflow.nodes.baseNode.FileUploadSetting.fileUploadType.uploadMethod')"
-            >
-              <template #label>
-                <span>
-                  {{ $t('workflow.nodes.baseNode.FileUploadSetting.fileUploadType.uploadMethod')
-                  }}<span class="color-danger">*</span>
-                </span>
-              </template>
-              <div class="flex align-center">
-                <el-checkbox v-model="form_data.local_upload" class="mr-16">
-                  {{ $t('common.fileUpload.localUpload') }}
-                </el-checkbox>
-                <el-checkbox v-model="form_data.url_upload">
-                  {{ $t('common.fileUpload.urlUpload') }}
-                </el-checkbox>
-              </div>
-            </el-form-item>
+          </el-form-item>
+          <el-form-item
+            :label="$t('workflow.nodes.baseNode.FileUploadSetting.fileUploadType.uploadMethod')"
+          >
+            <template #label>
+              <span>
+                {{ $t('workflow.nodes.baseNode.FileUploadSetting.fileUploadType.uploadMethod')
+                }}<span class="color-danger">*</span>
+              </span>
+            </template>
+            <div class="flex align-center">
+              <el-checkbox v-model="form_data.local_upload" class="mr-16">
+                {{ $t('common.fileUpload.localUpload') }}
+              </el-checkbox>
+              <el-checkbox v-model="form_data.url_upload">
+                {{ $t('common.fileUpload.urlUpload') }}
+              </el-checkbox>
+            </div>
           </el-form-item>
         </el-form>
       </div>
@@ -250,14 +259,14 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import type { InputInstance } from 'element-plus'
 import { cloneDeep } from 'lodash'
 import { MsgWarning } from '@/utils/message'
 import { t } from '@/locales'
 
 const emit = defineEmits(['refresh'])
-const props = defineProps<{ nodeModel: any }>()
+const props = defineProps<{ nodeModel: any; modelCapabilities?: string[] }>()
 
 const dialogVisible = ref(false)
 const inputVisible = ref(false)
@@ -270,6 +279,16 @@ const documentExtensions = ['TXT', 'MD', 'DOCX', 'HTML', 'CSV', 'XLSX', 'XLS', '
 const imageExtensions = ['JPG', 'JPEG', 'PNG', 'GIF']
 const audioExtensions = ['MP3', 'WAV', 'OGG', 'ACC', 'M4A']
 const videoExtensions: any = ['MP4', 'AVI', 'MKV', 'MOV', 'FLV', 'WMV']
+
+const isImageSupported = computed(() => {
+  return props.modelCapabilities?.some(c => imageExtensions.includes(c.toUpperCase())) ?? true
+})
+const isAudioSupported = computed(() => {
+  return props.modelCapabilities?.some(c => audioExtensions.includes(c.toUpperCase())) ?? true
+})
+const isVideoSupported = computed(() => {
+  return props.modelCapabilities?.some(c => videoExtensions.includes(c.toUpperCase())) ?? true
+})
 
 const form_data = ref({
   maxFiles: 3,
@@ -288,6 +307,14 @@ function open(data: any) {
   dialogVisible.value = true
   nextTick(() => {
     form_data.value = { ...form_data.value, ...data }
+    const caps = props.modelCapabilities
+    if (caps && caps.length > 0) {
+      const lowerCaps = caps.map((c: string) => c.toLowerCase())
+      form_data.value.document = documentExtensions.some((ext: string) => lowerCaps.includes(ext.toLowerCase()))
+      form_data.value.image = imageExtensions.some((ext: string) => lowerCaps.includes(ext.toLowerCase()))
+      form_data.value.audio = audioExtensions.some((ext: string) => lowerCaps.includes(ext.toLowerCase()))
+      form_data.value.video = videoExtensions.some((ext: string) => lowerCaps.includes(ext.toLowerCase()))
+    }
   })
 }
 
@@ -336,7 +363,7 @@ async function submit() {
     const formattedData = cloneDeep(form_data.value)
     emit('refresh', formattedData)
     // emit('refresh', form_data.value)
-    props.nodeModel.graphModel.eventCenter.emit('refreshFileUploadConfig')
+    props.nodeModel?.graphModel?.eventCenter?.emit('refreshFileUploadConfig')
     dialogVisible.value = false
   })
 }
@@ -346,4 +373,13 @@ defineExpose({
 })
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.card-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: auto;
+  &:hover {
+    box-shadow: none;
+  }
+}
+</style>


### PR DESCRIPTION
#### What this PR does / why we need it?

为对话型应用（简单模式）添加文件上传功能。用户可以在应用设置中通过模型探针自动检测模型的多模态能力（图片、视频、音频等），配置允许上传的文件类型，并在对话中上传文件供 LLM 处理。

#### Summary of your change

**后端：**
- 新增探针 API `POST /workspace/{workspace_id}/model/{model_id}/probe`，向 LLM 发送探针消息检测其支持的文件后缀，结果缓存到 `model.meta.file_capabilities`
- `chat_simple` 方法支持文件列表提取与处理，拆分为 `_process_documents`、`_process_images`、`_process_videos`、`_process_audio` 四个模块级函数
- `BaseGenerateHumanMessageStep` 支持多模态 `HumanMessage`（图片/视频/音频以 base64 格式嵌入，文档文本注入 `{data}` 占位符）

**前端：**
- 三个 model API 模块新增 `probeModelCapability()` 方法
- `ApplicationSetting.vue` 增加文件上传开关 + `FileUploadSettingDialog` 集成，模型切换时自动触发探针
- `FileUploadSettingDialog` 接受 `modelCapabilities` prop，根据探针结果自动勾选/禁用文件类型
- `chat-input-operate` 上传前根据 `model_capabilities` 检测文件类型是否受模型支持

#### Please indicate you've done the following:
- [x] Made changes to the UI (应用设置页 + 聊天输入组件)
- [x] Checked for breaking changes (无破坏性变更)
- [x] Tested the changes (前端构建通过，后端 Python 语法验证通过)

### Examples
1. 文档识别
<img width="1195" height="715" alt="image" src="https://github.com/user-attachments/assets/c8f1edb9-814c-4561-ab86-079edd1f7e2a" />
2. 图片识别
<img width="1267" height="1057" alt="image" src="https://github.com/user-attachments/assets/57030795-246f-4225-9e92-e5d89dc5981c" />
3. 视频识别
<img width="1229" height="930" alt="image" src="https://github.com/user-attachments/assets/b40e5fa1-e28e-4fc4-bda1-04debde9bd03" />

4. 文件上传设置
<img width="992" height="1038" alt="image" src="https://github.com/user-attachments/assets/a3fcee24-30e8-4114-a9c0-bd8dc87f56b4" />


#### Please indicate you've done the following:

- [ x] Made sure tests are passing and test coverage is added if needed.
- [x ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.