### PR TITLE
【backup】fix: fix the `user_input` not being displayed in the execution details of `intent-node`

### DIFF
--- a/ui/src/components/execution-detail-card/index.vue
+++ b/ui/src/components/execution-detail-card/index.vue
@@ -312,7 +312,7 @@
                 {{ $t('aiChat.executionDetails.currentChat') }}
               </h5>
               <div class="p-8-12 border-t-dashed lighter pre-wrap">
-                {{ data.question || '-' }}
+                {{ data.question || data.user_input || '-' }}
               </div>
             </div>
             <div class="card-never border-r-6 mt-8">


### PR DESCRIPTION
fix: fix the `user_input` not being displayed in the execution details of `intent-node`
修复 `意图识别` 节点的执行详情，未显示用户输入内容的问题。

---

1. 修复前：
    <img width="976" height="710" alt="图片" src="https://github.com/user-attachments/assets/5d2a2ddf-6055-437a-ab4e-3be4611a3e4e" />

2. 修复后：
    <img width="975" height="715" alt="图片" src="https://github.com/user-attachments/assets/0c86573a-6389-46b7-a55d-56670d425fc9" />
