### PR TITLE
fix: update translation for user retrieval message to specify name-based filtering and limit

### DIFF
--- a/apps/locales/en_US/LC_MESSAGES/django.po
+++ b/apps/locales/en_US/LC_MESSAGES/django.po
@@ -6815,7 +6815,7 @@ msgstr ""
 #: apps/users/views/user.py:120 apps/users/views/user.py:121
 #: apps/users/views/user.py:122
 msgid "Get all user"
-msgstr ""
+msgstr "Retrieve users by their names (up to 200 users)"
 
 #: apps/users/views/user.py:133 apps/users/views/user.py:134
 #: apps/users/views/user.py:135

--- a/apps/locales/zh_CN/LC_MESSAGES/django.po
+++ b/apps/locales/zh_CN/LC_MESSAGES/django.po
@@ -6935,7 +6935,7 @@ msgstr "获取当前用户信息"
 #: apps/users/views/user.py:120 apps/users/views/user.py:121
 #: apps/users/views/user.py:122
 msgid "Get all user"
-msgstr "获取所有用户"
+msgstr "根据姓名获取用户(最多获取200个)"
 
 #: apps/users/views/user.py:133 apps/users/views/user.py:134
 #: apps/users/views/user.py:135

--- a/apps/locales/zh_Hant/LC_MESSAGES/django.po
+++ b/apps/locales/zh_Hant/LC_MESSAGES/django.po
@@ -6935,7 +6935,7 @@ msgstr "獲取當前用戶信息"
 #: apps/users/views/user.py:120 apps/users/views/user.py:121
 #: apps/users/views/user.py:122
 msgid "Get all user"
-msgstr "獲取所有用戶"
+msgstr "根據姓名獲取用戶(最多獲取200個)"
 
 #: apps/users/views/user.py:133 apps/users/views/user.py:134
 #: apps/users/views/user.py:135


### PR DESCRIPTION
fix: update translation for user retrieval message to specify name-based filtering and limit 