### PR TITLE
fix: In the trigger, the default value of the user input parameter for the advanced agent was not passed, and the user input parameter value was empty #6320

### DIFF
--- a/apps/trigger/handler/impl/task/application_task.py
+++ b/apps/trigger/handler/impl/task/application_task.py
@@ -32,10 +32,10 @@ def get_reference(fields, obj):
 
 
 def conversion_custom_value(value, _type):
-    if _type in ('array', 'dict', 'float', 'int', 'boolean', 'any'):
+    if ['array', 'dict', 'float', 'int', 'boolean', 'any'].__contains__(_type):
         try:
             return json.loads(value)
-        except Exception:
+        except Exception as e:
             pass
     return value
 
@@ -48,11 +48,9 @@ def valid_value_type(value, _type):
     if _type == 'float':
         return isinstance(value, float)
     if _type == 'int':
-        return isinstance(value, int) and not isinstance(value, bool)
+        return isinstance(value, int)
     if _type == 'boolean':
         return isinstance(value, bool)
-    if _type == 'any':
-        return True
     return isinstance(value, str)
 
 
@@ -62,17 +60,15 @@ def get_field_value(value, kwargs, _type, required, default_value, field):
         _value = value.get('value')
         if _value:
             _value = conversion_custom_value(_value, _type)
+        else:
+            if default_value:
+                return default_value
+            if required:
+                raise Exception(f'{field} is required')
+            else:
+                return None
     else:
         _value = get_reference(value.get('value'), kwargs)
-
-    if _value is None:
-        if default_value:
-            return default_value
-        if required:
-            raise Exception(f'{field} is required')
-        else:
-            return None
-
     valid = valid_value_type(_value, _type)
     if not valid:
         raise Exception(f'{field} type error')


### PR DESCRIPTION
fix: In the trigger, the default value of the user input parameter for the advanced agent was not passed, and the user input parameter value was empty #6320 