### PR TITLE
【backup】fix: Fix the `generate_prompt` method generated an empty string

### DIFF
--- a/apps/application/flow/compare/__init__.py
+++ b/apps/application/flow/compare/__init__.py
@@ -64,7 +64,7 @@ def _compare(source_value, compare, target_value):
 
 def _assertion(workflow_manage, field_list: List[str], compare: str, value):
     try:
-        value = workflow_manage.generate_prompt(value)
+        value = workflow_manage.generate_field_value(value)
     except Exception:
         pass
     field_value = None

--- a/apps/application/flow/loop_workflow_manage.py
+++ b/apps/application/flow/loop_workflow_manage.py
@@ -179,17 +179,54 @@ class LoopWorkflowManage(WorkflowManage):
         prompt = self.parentWorkflowManage.reset_prompt(prompt)
         return prompt
 
-    def generate_prompt(self, prompt: str):
+    def generate_prompt(self, prompt: str) -> str:
         """
         格式化生成提示词
         @param prompt: 提示词信息
         @return: 格式化后的提示词
         """
+        if prompt is None:
+            return ''
+        if prompt == '':
+            return ''
+        if "{{" not in prompt or "}}" not in prompt:
+            return prompt
 
         context = {**self.get_workflow_content(), **self.parentWorkflowManage.get_workflow_content()}
         prompt = self.reset_prompt(prompt)
         prompt_template = PromptTemplate.from_template(prompt, template_format='jinja2')
         value = prompt_template.format(context=context)
+        return value
+
+    def reset_field_value(self, prompt: str):
+        prompt = super().reset_field_value(prompt)
+        for field in self.loop_field_list:
+            chatLabel = f"loop.{field.get('value')}"
+            chatValue = f"context.get('loop').get('{field.get('value', '')}')"
+            prompt = prompt.replace(chatLabel, chatValue)
+
+        prompt = self.parentWorkflowManage.reset_field_value(prompt)
+        return prompt
+
+    def generate_field_value(self, field_value: str):
+        """
+        格式化生成参数值
+        @param field_value: 参数信息
+        @return: 格式化后的参数值
+        """
+        if field_value is None:
+            return None
+        if field_value == '':
+            return ''
+        if "{{" not in field_value or "}}" not in field_value:
+            return field_value
+
+        context = {**self.get_workflow_content(), **self.parentWorkflowManage.get_workflow_content()}
+        field_value = self.reset_field_value(field_value)
+        prompt_template = PromptTemplate.from_template(field_value, template_format='jinja2')
+        value = prompt_template.format(context=context)
+        if value == 'None':
+            return None
         return value
 
     def get_source_type(self):

--- a/apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py
+++ b/apps/application/flow/step_node/ai_chat_step_node/impl/base_chat_node.py
@@ -468,7 +468,7 @@ class BaseChatNode(IChatNode):
         # 处理参数中的变量
         for k, v in tool_params.items():
             if type(v) == str:
-                tool_params[k] = self.workflow_manage.generate_prompt(tool_params[k])
+                tool_params[k] = self.workflow_manage.generate_field_value(v)
             elif type(v) == dict:
                 self.handle_variables(v)
             elif (type(v) == list) and len(v) > 0 and (type(v[0]) == str):

--- a/apps/application/flow/step_node/mcp_node/impl/base_mcp_node.py
+++ b/apps/application/flow/step_node/mcp_node/impl/base_mcp_node.py
@@ -58,7 +58,7 @@ class BaseMcpNode(IMcpNode):
         # 处理参数中的变量
         for k, v in tool_params.items():
             if type(v) == str:
-                tool_params[k] = self.workflow_manage.generate_prompt(tool_params[k])
+                tool_params[k] = self.workflow_manage.generate_field_value(v)
             elif type(v) == dict:
                 self.handle_variables(v)
             elif (type(v) == list) and len(v) > 0 and (type(v[0]) == str):

--- a/apps/application/flow/step_node/search_document_node/impl/base_search_document_node.py
+++ b/apps/application/flow/step_node/search_document_node/impl/base_search_document_node.py
@@ -125,10 +125,10 @@ class BaseSearchDocumentNode(ISearchDocumentStepNode):
 
             for condition in search_condition_list:
                 tag_key = condition['key']
-                field_value = self.workflow_manage.generate_prompt(condition['value'])
+                field_value = self.workflow_manage.generate_field_value(condition['value'])
                 compare_type = condition['compare']
 
-                if not field_value or field_value == 'None' or len(field_value) == 0:
+                if not field_value:
                     continue
 
                 # 构建查询条件
@@ -164,10 +164,10 @@ class BaseSearchDocumentNode(ISearchDocumentStepNode):
 
             for condition in search_condition_list:
                 tag_key = condition['key']
-                field_value = self.workflow_manage.generate_prompt(condition['value'])
+                field_value = self.workflow_manage.generate_field_value(condition['value'])
                 compare_type = condition['compare']
 
-                if not field_value or field_value == 'None' or len(field_value) == 0:
+                if not field_value:
                     continue
 
                 if compare_type == 'not_contain':

--- a/apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py
+++ b/apps/application/flow/step_node/tool_lib_node/impl/base_tool_lib_node.py
@@ -106,7 +106,7 @@ def convert_value(name: str, value, _type, is_required, source, node):
             return float(value)
         return value
     try:
-        value = node.workflow_manage.generate_prompt(value)
+        value = node.workflow_manage.generate_field_value(value)
         return common_convert_value(_type, value)
     except Exception as e:
         raise Exception(

--- a/apps/application/flow/step_node/tool_node/impl/base_tool_node.py
+++ b/apps/application/flow/step_node/tool_node/impl/base_tool_node.py
@@ -81,7 +81,7 @@ def convert_value(name: str, value, _type, is_required, source, node):
             return float(value)
         return value
     try:
-        value = node.workflow_manage.generate_prompt(value)
+        value = node.workflow_manage.generate_field_value(value)
         return common_convert_value(_type, value)
     except Exception as e:
         raise Exception(

--- a/apps/application/flow/step_node/variable_assign_node/impl/base_variable_assign_node.py
+++ b/apps/application/flow/step_node/variable_assign_node/impl/base_variable_assign_node.py
@@ -53,7 +53,7 @@ class BaseVariableAssignNode(IVariableAssignNode):
                 result['output_value'] = variable['value'] = val
             elif variable['type'] == 'string':
                 # 变量解析 例如：{{global.xxx}}
-                val = self.workflow_manage.generate_prompt(variable['value'])
+                val = self.workflow_manage.generate_field_value(variable['value'])
                 evaluation(variable, val)
                 result['output_value'] = val
             else:

--- a/apps/application/flow/workflow_manage.py
+++ b/apps/application/flow/workflow_manage.py
@@ -775,16 +775,65 @@ class WorkflowManage:
 
         return prompt
 
-    def generate_prompt(self, prompt: str):
+    def generate_prompt(self, prompt: str) -> str:
         """
         格式化生成提示词
         @param prompt: 提示词信息
         @return: 格式化后的提示词
         """
+        if prompt is None:
+            return ''
+        if prompt == '':
+            return ''
+        if "{{" not in prompt or "}}" not in prompt:
+            return prompt
+
         context = self.get_workflow_content()
         prompt = self.reset_prompt(prompt)
         prompt_template = PromptTemplate.from_template(prompt, template_format='jinja2')
         value = prompt_template.format(context=context)
+        return value
+
+    def reset_field_value(self, prompt: str):
+        placeholder = "{}"
+        for field in self.field_list:
+            globeLabel = f"{field.get('node_name')}.{field.get('value')}"
+            globeValue = f"context.get('{field.get('node_id')}',{placeholder}).get('{field.get('value', '')}')"
+            prompt = prompt.replace(globeLabel, globeValue)
+        for field in self.global_field_list:
+            globeLabel = f"全局变量.{field.get('value')}"
+            globeLabelNew = f"global.{field.get('value')}"
+            globeValue = f"context.get('global').get('{field.get('value', '')}')"
+            prompt = prompt.replace(globeLabel, globeValue).replace(globeLabelNew, globeValue)
+        for field in self.chat_field_list:
+            chatLabel = f"chat.{field.get('value')}"
+            chatValue = f"context.get('chat').get('{field.get('value', '')}')"
+            prompt = prompt.replace(chatLabel, chatValue)
+
+        return prompt
+
+    def generate_field_value(self, field_value: str):
+        """
+        格式化生成参数值
+        @param field_value: 参数信息
+        @return: 格式化后的参数值
+        """
+        if field_value is None:
+            return None
+        if not field_value:
+            return ''
+        if "{{" not in field_value or "}}" not in field_value:
+            return field_value
+
+        context = self.get_workflow_content()
+        field_value = self.reset_field_value(field_value)
+        field_value_template = PromptTemplate.from_template(field_value, template_format='jinja2')
+        value = field_value_template.format(context=context)
+        maxkb_logger.info(f"context: {json.dumps(context, ensure_ascii=False)}")
+        maxkb_logger.info(f"value: {value}, type: {type(value)}")
+        maxkb_logger.info(field_value)
+        if value == 'None':
+            return None
         return value
 
     def get_start_node(self):


### PR DESCRIPTION
#### What this PR does / why we need it?
fix: Fix the `generate_prompt` method generated an empty string

方法 `generate_prompt`：修复当原变量值为 `None`时，该方法生成了空字符串 `''` 的问题。
注：调用端并不是生成提示词时，这是错误的，应该返回None，而不是空字符串 `''`。

**修复方案**：
另外写一个方法；`generate_field_value`，生成属性值时，逻辑稍微和 `generate_prompt` 有些不同：
- 获取变量值的方法：`context.get('xxx').get(key, '')` 改为 `context.get('xxx').get(key)`，即值为 `None` 时，不再返回空字符串 `''`
- 当生成的值为 `'None'` 字符串时，返回 空，即：`None` 

#### Summary of your change
用 `判断器` 做测试：
1. 修复前：（`a=None`，`b=None`，但 `a != b`，因为 `None != ''`）
    <img width="1920" height="879" alt="图片" src="https://github.com/user-attachments/assets/be44897e-6872-4df1-89aa-414d412bf76f" />

3. 修复后：（`a=None`，`b=None`，`a == b`， `None == None`）
    <img width="1920" height="879" alt="图片" src="https://github.com/user-attachments/assets/0f8e8f97-967b-4a36-8d85-84ed80e63dcc" />

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.