### PR TITLE
fix: reject empty image-to-video first frames

### DIFF
--- a/apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py
+++ b/apps/application/flow/step_node/image_to_video_step_node/i_image_to_video_node.py
@@ -32,7 +32,7 @@ class ImageToVideoNodeSerializer(serializers.Serializer):
     model_params_setting = serializers.JSONField(required=False, default=dict,
                                                  label=_("Model parameter settings"))
 
-    first_frame_url = serializers.ListField(required=True, label=_("First frame url"))
+    first_frame_url = serializers.ListField(required=True, allow_empty=False, label=_("First frame url"))
     last_frame_url = serializers.ListField(required=False, label=_("Last frame url"))
 
 
@@ -48,7 +48,7 @@ class IImageToVideoNode(INode):
         first_frame_url = self.workflow_manage.get_reference_field(
             self.node_params_serializer.data.get('first_frame_url')[0],
             self.node_params_serializer.data.get('first_frame_url')[1:])
-        if first_frame_url is []:
+        if not first_frame_url:
             raise ValueError(
                 _("First frame url cannot be empty"))
         last_frame_url = None

--- a/apps/application/tests.py
+++ b/apps/application/tests.py
@@ -1,3 +1,53 @@
-from django.test import TestCase
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
-# Create your tests here.
+from django.test import SimpleTestCase
+
+from application.flow.common import WorkflowMode
+from application.flow.step_node.image_to_video_step_node.i_image_to_video_node import (
+    IImageToVideoNode,
+    ImageToVideoNodeSerializer,
+)
+
+
+class ImageToVideoNodeTestCase(SimpleTestCase):
+    @staticmethod
+    def build_node(first_frame_url):
+        workflow_manage = MagicMock()
+        workflow_manage.flow.workflow_mode = WorkflowMode.APPLICATION
+        workflow_manage.get_reference_field.return_value = first_frame_url
+        node = IImageToVideoNode(
+            SimpleNamespace(id='image-to-video', properties={'node_data': {}}),
+            {},
+            workflow_manage,
+        )
+        node.node_params_serializer = SimpleNamespace(data={'first_frame_url': ['source', 'image']})
+        node.flow_params_serializer = SimpleNamespace(data={})
+        node.execute = MagicMock(return_value='executed')
+        return node
+
+    def test_serializer_rejects_empty_first_frame_reference(self):
+        serializer = ImageToVideoNodeSerializer(data={'prompt': 'prompt', 'first_frame_url': []})
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('first_frame_url', serializer.errors)
+
+    def test_empty_first_frame_value_does_not_execute_node(self):
+        for empty_value in (None, [], ''):
+            with self.subTest(empty_value=empty_value):
+                node = self.build_node(empty_value)
+
+                with self.assertRaises(ValueError):
+                    node._run()
+
+                node.execute.assert_not_called()
+
+    def test_valid_first_frame_value_executes_node(self):
+        for first_frame_url in ('https://example.com/image.png', [{'file_id': 'file-id'}]):
+            with self.subTest(first_frame_url=first_frame_url):
+                node = self.build_node(first_frame_url)
+
+                result = node._run()
+
+                self.assertEqual(result, 'executed')
+                self.assertEqual(node.execute.call_args.kwargs['first_frame_url'], first_frame_url)


### PR DESCRIPTION
required=True 只保证字段存在，原来传 [] 空列表仍会校验通过。
加上 allow_empty=False 后，空列表会在参数校验阶段直接被拒绝，避免后续代码访问 first_frame_url[0] 时触发 IndexError。
if first_frame_url is []:
使用的是 Python 的对象身份比较，不是在判断“内容是否为空”，基本不会匹配到运行时返回的空列表。
新的 not first_frame_url 会正确识别空值，例如 None、[]、''，并抛出明确的 First frame url cannot be empty 错误，且不会继续执行图生视频节点