### PR TITLE
fix: correct OSS route registration and get_url resolution

### DIFF
--- a/apps/maxkb/urls/web.py
+++ b/apps/maxkb/urls/web.py
@@ -42,12 +42,12 @@ urlpatterns = [
     path(admin_api_prefix, include("system_manage.urls")),
     path(admin_api_prefix, include("application.urls")),
     path(admin_api_prefix, include("trigger.urls")),
-    path(admin_api_prefix, include("oss.urls")),
+    path(admin_api_prefix, include("oss.urls", namespace="admin_oss")),
     path(admin_api_prefix, include("homepage.urls")),
-    path(chat_api_prefix, include("oss.urls")),
+    path(chat_api_prefix, include("oss.urls", namespace="chat_oss")),
     path(chat_api_prefix, include("chat.urls")),
-    path(f'{admin_ui_prefix[1:]}/', include('oss.retrieval_urls')),
-    path(f'{chat_ui_prefix[1:]}/', include('oss.retrieval_urls')),
+    path(f'{admin_ui_prefix[1:]}/', include('oss.retrieval_urls', namespace='admin_oss_retrieval')),
+    path(f'{chat_ui_prefix[1:]}/', include('oss.retrieval_urls', namespace='chat_oss_retrieval')),
 ]
 init_doc(urlpatterns, chat_urlpatterns)
 

--- a/apps/oss/retrieval_urls.py
+++ b/apps/oss/retrieval_urls.py
@@ -13,11 +13,11 @@ from . import views
 app_name = 'oss'
 
 urlpatterns = [
-    re_path(rf'^(.*)/oss/file/(?P<file_id>[\w-]+)/?$',
+    re_path(r'^(.*)/oss/file/(?P<file_id>[\w-]+)/?$',
             views.FileRetrievalView.as_view()),
-    re_path(rf'oss/file/(?P<file_id>[\w-]+)/?$',
+    re_path(r'oss/file/(?P<file_id>[\w-]+)/?$',
             views.FileRetrievalView.as_view()),
-    re_path(rf'^/oss/get_url/(?P<url>[\w-]+)?$',
+    re_path(r'^oss/get_url/(?P<application_id>[\w-]+)/?$',
             views.GetUrlView.as_view()),
 
 ]

--- a/apps/oss/tests.py
+++ b/apps/oss/tests.py
@@ -1,3 +1,54 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
+from django.urls import resolve
 
-# Create your tests here.
+from maxkb.const import CONFIG
+from oss.views import FileRetrievalView, FileView, GetUrlView
+
+
+class OssUrlTestCase(SimpleTestCase):
+    def assert_resolves(self, path, view_class, namespace, kwargs=None):
+        match = resolve(path)
+
+        self.assertIs(match.func.view_class, view_class)
+        self.assertEqual(match.namespace, namespace)
+        self.assertEqual(match.kwargs, kwargs or {})
+
+    def test_file_api_routes_use_unique_namespaces(self):
+        self.assert_resolves(
+            f'{CONFIG.get_admin_path()}/api/oss/file',
+            FileView,
+            'admin_oss',
+        )
+        self.assert_resolves(
+            f'{CONFIG.get_chat_path()}/api/oss/file',
+            FileView,
+            'chat_oss',
+        )
+
+    def test_file_retrieval_routes_use_unique_namespaces(self):
+        self.assert_resolves(
+            f'{CONFIG.get_admin_path()}/oss/file/file-id',
+            FileRetrievalView,
+            'admin_oss_retrieval',
+            {'file_id': 'file-id'},
+        )
+        self.assert_resolves(
+            f'{CONFIG.get_chat_path()}/oss/file/file-id',
+            FileRetrievalView,
+            'chat_oss_retrieval',
+            {'file_id': 'file-id'},
+        )
+
+    def test_get_url_retrieval_routes_pass_application_id(self):
+        self.assert_resolves(
+            f'{CONFIG.get_admin_path()}/oss/get_url/application-id',
+            GetUrlView,
+            'admin_oss_retrieval',
+            {'application_id': 'application-id'},
+        )
+        self.assert_resolves(
+            f'{CONFIG.get_chat_path()}/oss/get_url/application-id',
+            GetUrlView,
+            'chat_oss_retrieval',
+            {'application_id': 'application-id'},
+        )


### PR DESCRIPTION
web.py 中同一个 URLConf 被分别挂载到管理端和聊天端：
path(admin_api_prefix, include("oss.urls"))
path(chat_api_prefix, include("oss.urls"))
但 oss.urls 的 app_name 都是 oss。不指定实例命名空间时，Django 会出现重复 URL namespace，之后通过 reverse() 或解析路由时可能指向不确定的 oss 路由。
改成：
include("oss.urls", namespace="admin_oss")
include("oss.urls", namespace="chat_oss")
让管理端和聊天端各自独立。同理，文件检索路由使用 admin_oss_retrieval 和 chat_oss_retrieval。
retrieval_urls.py 里的实际问题在这一条：
re_path(rf'^/oss/get_url/(?P<url>[\w-]+)?$', ...)
有三个缺陷：
子路由被 path('admin/', include(...)) 挂载后，传入的剩余路径是 oss/get_url/...，没有开头 /；原正则要求 /oss，因此通常匹配不到。
捕获参数叫 url，但 GetUrlView 接收的是 application_id，即使匹配也会收到错误的关键字参数。
? 让 ID 可选，不符合获取应用 URL 必须提供 application_id 的接口语义。
修复后：
re_path(r'^oss/get_url/(?P<application_id>[\w-]+)/?$', ...)
现在以下路径都会正确进入 GetUrlView，并把 ID 作为 application_id 传入：
/admin/oss/get_url/<application_id>
/chat/oss/get_url/<application_id>
两处 rf'...' 改为 r'...' 只是清理：正则中没有插值变量，行为没有变化。