### PR TITLE
fix: replace dynamic form code execution with declarative handlers

### DIFF
--- a/ui/src/components/ai-chat/component/inline-params/InlineFormItem.vue
+++ b/ui/src/components/ai-chat/component/inline-params/InlineFormItem.vue
@@ -46,7 +46,7 @@
 </template>
 <script setup lang="ts">
 import { ref, computed, onMounted, type Ref } from 'vue'
-import type { FormField } from '@/components/dynamics-form/type'
+import type { FormField, TriggerSetting } from '@/components/dynamics-form/type'
 import type { Dict } from '@/api/type/common'
 import bus from '@/utils/bus'
 import { get } from 'lodash'
@@ -59,7 +59,7 @@ const props = defineProps<{
   trigger: (
     trigger_field: string,
     trigger_value: any,
-    trigger_setting: any,
+    trigger_setting: TriggerSetting,
     self: any,
     loading: Ref<boolean>,
   ) => void

--- a/ui/src/components/dynamics-form/Demo.vue
+++ b/ui/src/components/dynamics-form/Demo.vue
@@ -56,8 +56,7 @@ const damo_data: Array<FormField> = [
       relation_trigger_field_dict: {
         name: {
           values: ['01993837-5b09-7f20-9360-801d11d43d28'],
-          request:
-            'self.children=()=>request.get(extra.renderTemplate(trigger_setting.url)).then(ok=>{return ok})',
+          request_action: 'set_children_loader',
           url: '/workspace/${current_workspace_id}/model/${trigger_value}/model_params_form',
         },
       },
@@ -140,8 +139,7 @@ const damo_data: Array<FormField> = [
       relation_trigger_field_dict: {
         single_select_field: {
           values: [],
-          request:
-            'self.children=()=>request.get(extra.renderTemplate(trigger_setting.url)).then(ok=>{return ok})',
+          request_action: 'set_children_loader',
           url: '/workspace/${current_workspace_id}/model/${trigger_value}/model_params_form',
         },
       },
@@ -152,6 +150,7 @@ const damo_data: Array<FormField> = [
         values: [],
         url: '/workspace/${current_workspace_id}/model_list?model_type=LLM',
         change_field: 'option_list',
+        response_type: 'model_options',
       },
     },
   },
@@ -237,9 +236,10 @@ const damo_data: Array<FormField> = [
       active_msg: '当前选中',
       table_columns: [
         {
-          property: '`${row.key}${row.number}`',
+          property: 'key',
+          value_fields: ['key', 'number'],
           label: '名称',
-          type: 'eval',
+          type: 'concat',
         },
         {
           property: 'ProgressTableItem',
@@ -258,15 +258,17 @@ const damo_data: Array<FormField> = [
           props_info: {
             view_card: [
               {
-                type: 'eval',
+                type: 'number',
                 title: '测试',
-                value_field:
-                  '`${parseFloat(row.number).toLocaleString("zh-CN",{style: "decimal",maximumFractionDigits:1})}%&nbsp;&nbsp;&nbsp;`',
+                value_field: 'number',
+                locale: 'zh-CN',
+                maximum_fraction_digits: 1,
+                suffix: '%',
               },
               {
-                type: 'eval',
+                type: 'default',
                 title: '名称',
-                value_field: '`${row.key}&nbsp;&nbsp;&nbsp;`',
+                value_field: 'key',
               },
             ],
           },
@@ -297,9 +299,10 @@ const damo_data: Array<FormField> = [
       active_msg: '当前选中',
       table_columns: [
         {
-          property: '`${row.key}${row.number}`',
+          property: 'key',
+          value_fields: ['key', 'number'],
           label: '名称',
-          type: 'eval',
+          type: 'concat',
         },
         {
           property: 'ProgressTableItem',
@@ -318,15 +321,17 @@ const damo_data: Array<FormField> = [
           props_info: {
             view_card: [
               {
-                type: 'eval',
+                type: 'number',
                 title: '测试',
-                value_field:
-                  '`${parseFloat(row.number).toLocaleString("zh-CN",{style: "decimal",maximumFractionDigits:1})}%&nbsp;&nbsp;&nbsp;`',
+                value_field: 'number',
+                locale: 'zh-CN',
+                maximum_fraction_digits: 1,
+                suffix: '%',
               },
               {
-                type: 'eval',
+                type: 'default',
                 title: '名称',
-                value_field: '`${row.key}&nbsp;&nbsp;&nbsp;`',
+                value_field: 'key',
               },
             ],
           },

--- a/ui/src/components/dynamics-form/FormItem.vue
+++ b/ui/src/components/dynamics-form/FormItem.vue
@@ -34,7 +34,7 @@
 </template>
 <script setup lang="ts">
 import { ref, computed, onMounted, type Ref } from 'vue'
-import type { FormField } from '@/components/dynamics-form/type'
+import type { FormField, TriggerSetting } from '@/components/dynamics-form/type'
 import FormItemLabel from './FormItemLabel.vue'
 import type { Dict } from '@/api/type/common'
 import bus from '@/utils/bus'
@@ -54,7 +54,7 @@ const props = defineProps<{
   trigger: (
     trigger_field: string,
     trigger_value: any,
-    trigger_setting: any,
+    trigger_setting: TriggerSetting,
     self: any,
     loading: Ref<boolean>,
   ) => void
@@ -100,6 +100,17 @@ const itemValue = computed({
   },
 })
 const componentFormRef = ref<any>()
+const componentValidator = (rule: any, value: string, callback: any) => {
+  return componentFormRef.value?.validate_rules(rule, value, callback)
+}
+
+const isComponentValidator = (validator: unknown) => {
+  return (
+    validator === 'component' ||
+    (typeof validator === 'string' &&
+      validator.includes('componentFormRef.value?.validate_rules(rule, value, callback)'))
+  )
+}
 const label_attrs = computed(() => {
   return props.formfield.label &&
     typeof props.formfield.label !== 'string' &&
@@ -132,13 +143,16 @@ const errMsg = computed(() => {
  * @param rule
  */
 const to_rule = (rule: any) => {
-  if (rule.validator) {
-    // eslint-disable-next-line prefer-const, @typescript-eslint/no-unused-vars
-    let validator = (rule: any, value: string, callback: any) => {}
-    eval(rule.validator)
-    return { ...rule, validator }
+  if (typeof rule.validator === 'function' || !rule.validator) {
+    return rule
   }
-  return rule
+
+  if (isComponentValidator(rule.validator)) {
+    return { ...rule, validator: componentValidator }
+  }
+
+  const { validator: _validator, ...safeRule } = rule
+  return safeRule
 }
 
 /**
@@ -187,9 +201,9 @@ onMounted(() => {
   props.initDefaultData(props.formfield)
   initTrigger(props.formfield, props.formfield.relation_trigger_field_dict)
   initTrigger(props.formfield.label, props.formfield.label?.relation_trigger_field_dict)
-  isString(props.formfield.label)
-    ? undefined
-    : onTrigger(props.formfield.label, props.formfield.label.relation_trigger_field_dict)
+  if (!isString(props.formfield.label)) {
+    onTrigger(props.formfield.label, props.formfield.label.relation_trigger_field_dict)
+  }
   onTrigger(props.formfield, props.formfield.relation_trigger_field_dict)
 })
 const onTrigger = (self: any, trigger_field_dict?: Dict<any>) => {

--- a/ui/src/components/dynamics-form/constructor/items/JsonInputConstructor.vue
+++ b/ui/src/components/dynamics-form/constructor/items/JsonInputConstructor.vue
@@ -112,10 +112,7 @@ const getData = () => {
       rules: [
         {
           required: formValue.value.required,
-          validator: `validator = (rule, value, callback) => {
-            return componentFormRef.value?.validate_rules(rule, value, callback);
-
-}`,
+          validator: 'component',
           trigger: 'blur',
         },
       ],

--- a/ui/src/components/dynamics-form/index.vue
+++ b/ui/src/components/dynamics-form/index.vue
@@ -35,19 +35,14 @@
 <script lang="ts" setup>
 import type { Dict } from '@/api/type/common'
 import FormItem from '@/components/dynamics-form/FormItem.vue'
-import type { FormField } from '@/components/dynamics-form/type'
+import type { FormField, TriggerSetting } from '@/components/dynamics-form/type'
 import { ref, onBeforeMount, watch, type Ref, nextTick, computed } from 'vue'
 import type { FormInstance } from 'element-plus'
 import type Result from '@/request/Result'
 import _ from 'lodash'
-import { get, post, put, del } from '@/request/index'
+import { get } from '@/request/index'
 import { computeVisibilityMap } from './visibility'
-const request = {
-  get,
-  post,
-  put,
-  del,
-}
+import { runTrigger } from './trigger'
 defineOptions({ name: 'dynamicsForm' })
 
 const props = withDefaults(
@@ -152,59 +147,23 @@ watch(
   { deep: true },
 )
 
-function renderTemplate(template: string, data: any) {
-  return template.replace(/\$\{(\w+)\}/g, (match, key) => {
-    return data[key] !== undefined ? data[key] : match
-  })
-}
 /**
  * 触发器,用户获取子表单 或者 下拉选项
  * @param field
  * @param loading
  */
 const trigger = (
-  trigger_field: string,
+  _trigger_field: string,
   trigger_value: any,
-  trigger_setting: any,
+  trigger_setting: TriggerSetting,
   self: any,
   loading: Ref<boolean>,
 ) => {
-  const request_call = new Function(
-    'self',
-    'trigger_setting',
-    'request',
-    'extra',
-    trigger_setting.request
-      ? trigger_setting.request
-      : 'return  request.get(extra.renderTemplate(trigger_setting.url));',
-  )(self, trigger_setting, request, {
-    renderTemplate: (url: string) =>
-      renderTemplate(url, {
-        trigger_value: trigger_value,
-        ...props.otherParams,
-      }),
-  })
-
-  if (!trigger_setting.change && !trigger_setting.change_field) {
-    return
-  }
-  request_call.then((ok: any) => {
-    new Function(
-      'self',
-      'trigger_setting',
-      'response',
-      'extra',
-      trigger_setting.change
-        ? trigger_setting.change
-        : `self[trigger_setting.change_field]=[
-        ...response.data.shared_model.map((m) => {
-          return { ...m, type: 'share' }
-        }),
-        ...response.data.model.map((m) => {
-          return { ...m, type: 'workspace' }
-        })
-      ];`,
-    )(self, trigger_setting, ok, { form_data: formValue, getDefault: getFormDefaultValue })
+  return runTrigger(trigger_setting, self, {
+    triggerValue: trigger_value,
+    otherParams: props.otherParams,
+    loading,
+    get,
   })
 }
 /**

--- a/ui/src/components/dynamics-form/items/table/ProgressTableItem.vue
+++ b/ui/src/components/dynamics-form/items/table/ProgressTableItem.vue
@@ -13,14 +13,17 @@
       <div>
         <el-row v-for="(item, index) in view_card" :key="index">
           <el-col :span="6">{{ item.title }}</el-col>
-          <el-col :span="18"> <span class="value" :innerHTML="value_html(item)"> </span></el-col>
+          <el-col :span="18">
+            <span class="value">{{ formatTableValue(item, row) }}</span>
+          </el-col>
         </el-row>
       </div>
     </el-popover>
   </div>
 </template>
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
+import { formatTableValue } from '@/components/dynamics-form/items/table/valueFormatter'
 const props = defineProps<{
   /**
    *表单渲染Item column
@@ -31,12 +34,6 @@ const props = defineProps<{
    */
   row: any
 }>()
-const rowRef = ref<any>()
-
-function evalF(text: string, row: any) {
-  rowRef.value = row
-  return eval(text)
-}
 const props_info = computed(() => {
   return props.column.props_info ? props.column.props_info : {}
 })
@@ -46,14 +43,6 @@ const text_field = computed(() => {
 const value_field = computed(() => {
   return props.column.value_field ? props.column.value_field : 'value'
 })
-
-const value_html = (view_card_item: any) => {
-  if (view_card_item.type === 'eval') {
-    return evalF(view_card_item.value_field, props.row)
-  } else {
-    return props.row[view_card_item.value_field]
-  }
-}
 
 const view_card = computed(() => {
   return props_info.value.view_card ? props_info.value.view_card : []

--- a/ui/src/components/dynamics-form/items/table/TableCheckbox.vue
+++ b/ui/src/components/dynamics-form/items/table/TableCheckbox.vue
@@ -35,11 +35,8 @@
           <template v-if="column.type === 'component'">
             <TableColumn :column="column" :row="scope.row"></TableColumn>
           </template>
-          <template v-else-if="column.type === 'eval'">
-            <span v-html="evalF(column.property, scope.row)"></span
-          ></template>
           <template v-else>
-            <span>{{ scope.row[column.property] }}</span></template
+            <span>{{ formatTableValue(column, scope.row) }}</span></template
           >
         </template>
       </el-table-column>
@@ -60,6 +57,7 @@ import type { TableInstance } from 'element-plus'
 
 import _ from 'lodash'
 import TableColumn from '@/components/dynamics-form/items/table/TableColumn.vue'
+import { formatTableValue } from '@/components/dynamics-form/items/table/valueFormatter'
 const filterText = ref<string>('')
 const props = defineProps<{
   formValue?: any
@@ -71,11 +69,6 @@ const props = defineProps<{
   // 选中的值
   modelValue?: Array<any>
 }>()
-const rowTemp = ref<any>()
-const evalF: (text: string, row: any) => string = (text: string, row: any) => {
-  rowTemp.value = row
-  return eval(text)
-}
 const emit = defineEmits(['update:modelValue', 'change'])
 
 const multipleTableRef = ref<TableInstance>()
@@ -124,15 +117,10 @@ const tableData = computed(() => {
     if (filterText.value) {
       return option_list.value.filter((item: any) =>
         tableColumns.value.some((c: any) => {
-          let v = ''
-          if (c.type === 'eval') {
-            v = evalF(c.property, item)
-          } else if (c.type === 'component') {
+          if (c.type === 'component') {
             return false
-          } else {
-            v = item[c.property]
           }
-          return typeof v == 'string' ? v.indexOf(filterText.value) >= 0 : false
+          return formatTableValue(c, item).includes(filterText.value)
         })
       )
     } else {

--- a/ui/src/components/dynamics-form/items/table/TableRadio.vue
+++ b/ui/src/components/dynamics-form/items/table/TableRadio.vue
@@ -39,11 +39,8 @@
           <template v-if="column.type === 'component'">
             <TableColumn :column="column" :row="scope.row"></TableColumn>
           </template>
-          <template v-else-if="column.type === 'eval'">
-            <span v-html="evalF(column.property, scope.row)"></span
-          ></template>
           <template v-else>
-            <span>{{ scope.row[column.property] }}</span></template
+            <span>{{ formatTableValue(column, scope.row) }}</span></template
           >
         </template>
       </el-table-column>
@@ -64,6 +61,7 @@ import type { TableInstance } from 'element-plus'
 
 import _ from 'lodash'
 import TableColumn from '@/components/dynamics-form/items/table/TableColumn.vue'
+import { formatTableValue } from '@/components/dynamics-form/items/table/valueFormatter'
 const filterText = ref<string>('')
 const props = defineProps<{
   formValue?: any
@@ -75,11 +73,6 @@ const props = defineProps<{
   // 选中的值
   modelValue?: any
 }>()
-const rowTemp = ref<any>()
-const evalF = (text: string, row: any) => {
-  rowTemp.value = row
-  return eval(text)
-}
 const emit = defineEmits(['update:modelValue', 'change'])
 
 const singleTableRef = ref<TableInstance>()
@@ -125,15 +118,10 @@ const tableData = computed(() => {
     if (filterText.value) {
       return option_list.value.filter((item: any) =>
         tableColumns.value.some((c: any) => {
-          let v = ''
-          if (c.type === 'eval') {
-            v = evalF(c.property, item)
-          } else if (c.type === 'component') {
+          if (c.type === 'component') {
             return false
-          } else {
-            v = item[c.property]
           }
-          return typeof v == 'string' ? v.indexOf(filterText.value) >= 0 : false
+          return formatTableValue(c, item).includes(filterText.value)
         })
       )
     } else {

--- a/ui/src/components/dynamics-form/items/table/valueFormatter.ts
+++ b/ui/src/components/dynamics-form/items/table/valueFormatter.ts
@@ -1,0 +1,43 @@
+interface ValueFormatConfig {
+  type?: string
+  property?: string
+  value_field?: string
+  value_fields?: Array<string>
+  separator?: string
+  locale?: string
+  minimum_fraction_digits?: number
+  maximum_fraction_digits?: number
+  prefix?: string
+  suffix?: string
+}
+
+const toText = (value: unknown) => (value === null || value === undefined ? '' : String(value))
+
+export const formatTableValue = (config: ValueFormatConfig, row: Record<string, any>) => {
+  let value: string
+
+  if (config.type === 'concat') {
+    value = (config.value_fields || [])
+      .map((field) => toText(row[field]))
+      .join(config.separator || '')
+  } else {
+    const field = config.value_field || config.property || ''
+    const rawValue = row[field]
+
+    if (config.type === 'number') {
+      const numberValue =
+        typeof rawValue === 'number' ? rawValue : Number.parseFloat(toText(rawValue))
+      value = Number.isFinite(numberValue)
+        ? numberValue.toLocaleString(config.locale, {
+            style: 'decimal',
+            minimumFractionDigits: config.minimum_fraction_digits,
+            maximumFractionDigits: config.maximum_fraction_digits,
+          })
+        : toText(rawValue)
+    } else {
+      value = toText(rawValue)
+    }
+  }
+
+  return `${config.prefix || ''}${value}${config.suffix || ''}`
+}

--- a/ui/src/components/dynamics-form/trigger.ts
+++ b/ui/src/components/dynamics-form/trigger.ts
@@ -1,0 +1,81 @@
+import type { TriggerSetting } from '@/components/dynamics-form/type'
+
+type GetRequest = (url: string, params?: unknown, loading?: any) => Promise<any>
+
+interface TriggerContext {
+  triggerValue: any
+  otherParams?: Record<string, any>
+  loading?: any
+  get: GetRequest
+}
+
+const LEGACY_CHILDREN_LOADER =
+  'self.children=()=>request.get(extra.renderTemplate(trigger_setting.url)).then(ok=>{returnok})'
+const UNSAFE_TARGET_FIELDS = new Set(['__proto__', 'prototype', 'constructor'])
+
+export const renderTriggerTemplate = (template: string, data: Record<string, any>) => {
+  return template.replace(/\$\{(\w+)\}/g, (match, key) => {
+    return data[key] !== undefined ? String(data[key]) : match
+  })
+}
+
+const getRequestAction = (setting: TriggerSetting) => {
+  if (setting.request_action) {
+    return setting.request_action
+  }
+  if (!setting.request) {
+    return 'get'
+  }
+  if (setting.request.replace(/\s/g, '') === LEGACY_CHILDREN_LOADER) {
+    return 'set_children_loader'
+  }
+  return undefined
+}
+
+const getResponseValue = (setting: TriggerSetting, response: any) => {
+  if (setting.response_type === 'data') {
+    return response?.data
+  }
+
+  const sharedModels = Array.isArray(response?.data?.shared_model) ? response.data.shared_model : []
+  const workspaceModels = Array.isArray(response?.data?.model) ? response.data.model : []
+  return [
+    ...sharedModels.map((model: any) => ({ ...model, type: 'share' })),
+    ...workspaceModels.map((model: any) => ({ ...model, type: 'workspace' })),
+  ]
+}
+
+const isSafeTargetField = (field: unknown): field is string => {
+  return typeof field === 'string' && field.length > 0 && !UNSAFE_TARGET_FIELDS.has(field)
+}
+
+export const runTrigger = (setting: TriggerSetting, self: any, context: TriggerContext) => {
+  const requestAction = getRequestAction(setting)
+  if (!requestAction || !setting.url) {
+    return
+  }
+
+  const load = () =>
+    context.get(
+      renderTriggerTemplate(setting.url as string, {
+        trigger_value: context.triggerValue,
+        ...context.otherParams,
+      }),
+      {},
+      context.loading,
+    )
+
+  if (requestAction === 'set_children_loader') {
+    self.children = load
+    return
+  }
+
+  const requestCall = load()
+  if (!isSafeTargetField(setting.change_field) || (setting.change && !setting.response_type)) {
+    return requestCall
+  }
+
+  return requestCall.then((response: any) => {
+    self[setting.change_field as string] = getResponseValue(setting, response)
+  })
+}

--- a/ui/src/components/dynamics-form/type.ts
+++ b/ui/src/components/dynamics-form/type.ts
@@ -1,23 +1,49 @@
 import type { Dict } from '@/api/type/common'
 
-interface ViewCardItem {
+interface TriggerSetting {
+  values?: Array<any>
+  url?: string
+  request_action?: 'get' | 'set_children_loader'
+  response_type?: 'data' | 'model_options'
+  change_field?: string
   /**
-   * 类型
+   * 旧版动态脚本，仅用于识别并迁移已知配置，不会执行
    */
-  type: 'eval' | 'default'
+  request?: string
+  change?: string
+}
+
+interface ValueFormat {
+  /**
+   * 字段拼接或数字格式化
+   */
+  type: 'default' | 'concat' | 'number'
+  /**
+   * 拼接时使用的字段
+   */
+  value_fields?: Array<string>
+  separator?: string
+  locale?: string
+  minimum_fraction_digits?: number
+  maximum_fraction_digits?: number
+  prefix?: string
+  suffix?: string
+}
+
+interface ViewCardItem extends ValueFormat {
   /**
    * 标题
    */
   title: string
   /**
-   * 值 根据类型不一样 取值也不一样 default= row[value_field] eval `${parseFloat(row.number).toLocaleString("zh-CN",{style: "decimal",maximumFractionDigits:1})}%&nbsp;&nbsp;&nbsp;`
+   * 数据字段
    */
   value_field: string
 }
 
-interface TableColumn {
+interface TableColumn extends Omit<ValueFormat, 'type'> {
   /**
-   * 字段|组件名称|可计算的模板字符串
+   * 字段或组件名称
    */
   property: string
   /**
@@ -33,7 +59,7 @@ interface TableColumn {
   /**
    * 类型
    */
-  type: 'eval' | 'component' | 'default'
+  type: 'concat' | 'number' | 'component' | 'default'
 
   props_info?: PropsInfo
 }
@@ -137,7 +163,7 @@ interface FormField {
   /**
    * {field:field_value_list} 表示在 field有值 ,并且值在field_value_list中才 执行函数获取 数据
    */
-  relation_trigger_field_dict?: Dict<any>
+  relation_trigger_field_dict?: Dict<TriggerSetting>
   /**
    * 执行器类型  OPTION_LIST请求Option_list数据 CHILD_FORMS请求子表单
    */
@@ -175,4 +201,4 @@ interface FormField {
   required_asterisk?: boolean
   [propName: string]: any
 }
-export type { FormField }
+export type { FormField, TriggerSetting }


### PR DESCRIPTION
#### 此 PR 做了什么 / 为什么需要它？

动态表单的触发器、校验规则和表格渲染此前会通过 `new Function()`、`eval()` 执行配置中的 JavaScript 字符串，部分表格值还会通过 `v-html` 或 `innerHTML` 输出。

这可能使不可信或错误持久化的配置在浏览器中执行代码，带来安全风险。

#### 修改概要

- 使用受限的 `request_action` 和 `response_type` 替代动态触发器脚本。
- 保留对旧版“加载子表单”配置的兼容：识别并转换为固定逻辑，不执行原始脚本。
- 使用声明式 `validator: 'component'` 替代字符串形式的组件校验函数。
- 使用结构化的 `default`、`concat`、`number` 格式化规则替代表格 `eval` 表达式。
- 移除动态表格值中的 `v-html` 和 `innerHTML` 渲染。
- 禁止将 `__proto__`、`prototype`、`constructor` 作为触发器写入目标字段。
- 更新示例表单配置和 TypeScript 类型定义。

#### 请确认已完成以下事项：

 已完成测试，并在需要时补充了覆盖。
  `npm run type-check`
 改动文件定向 ESLint 检查
 `npm run build-only`
 `npm run build-only-chat`
 动态表单行为断言：触发器、格式化、旧版子表单加载器和危险字段拦截
提交信息符合 Conventional Commits 规范。
已评估文档影响。
 不需要新增用户文档；依赖任意脚本执行的旧动态表单配置将不再执行，这是本次安全修复的预期行为。