### PR TITLE
fix: support Cohere v1 rerank fallback

### DIFF
--- a/apps/models_provider/impl/vllm_model_provider/model/reranker.py
+++ b/apps/models_provider/impl/vllm_model_provider/model/reranker.py
@@ -23,7 +23,7 @@ class VllmBgeReranker(MaxKBBaseModel, BaseDocumentCompressor):
         self.api_url = kwargs.get('api_url')
         self.top_n = kwargs.get('top_n', 3)
         self.params.pop('top_n', None)
-        self.client = cohere.ClientV2(kwargs.get('api_key'), base_url=kwargs.get('api_url'))
+        self.client = cohere.Client(kwargs.get('api_key'), base_url=kwargs.get('api_url'))
 
     @staticmethod
     def is_cache_model():
@@ -48,6 +48,20 @@ class VllmBgeReranker(MaxKBBaseModel, BaseDocumentCompressor):
             return []
 
         ds = [d.page_content for d in documents]
-        result = self.client.rerank(model=self.model, query=query, documents=ds, top_n=self.top_n)
-        return [Document(page_content=d.document.get('text'), metadata={'relevance_score': d.relevance_score}) for d in
-                result.results]
+        try:
+            result = self.client.v2.rerank(model=self.model, query=query, documents=ds, top_n=self.top_n)
+        except cohere.NotFoundError:
+            result = self.client.rerank(model=self.model, query=query, documents=ds, top_n=self.top_n)
+
+        reranked_documents = []
+        for item in result.results:
+            if item.index < 0 or item.index >= len(documents):
+                raise ValueError(f'Rerank result index {item.index} is out of range')
+            source = documents[item.index]
+            reranked_documents.append(
+                Document(
+                    page_content=source.page_content,
+                    metadata={**source.metadata, 'relevance_score': item.relevance_score},
+                )
+            )
+        return reranked_documents


### PR DESCRIPTION
#### What this PR does / why we need it?

The vLLM reranker currently uses Cohere ClientV2 and always calls `/v2/rerank`. Cohere-compatible rerank servers that only expose `/v1/rerank`, such as llama.cpp, therefore fail model validation and reranking with HTTP 404.

#### Summary of your change

- Use a single Cohere client for both v2 and v1 rerank requests.
- Keep `/v2/rerank` as the primary path and retry `/v1/rerank` only on `cohere.NotFoundError`.
- Map results back to the original documents by index, preserving document content and metadata.
- Reject negative or out-of-range result indices.
- Add no new dependency.

Validation performed:

- Verified v2 success responses with and without a `document` field.
- Verified 404 fallback to v1.
- Verified 401, 405, and 500 responses do not trigger fallback.
- Verified repeated fallback calls reuse the same HTTP client.
- Verified invalid result indices are rejected.
- Verified the fallback end to end against a llama.cpp rerank endpoint.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

No documentation change is required because this is protocol compatibility within the existing vLLM reranker provider.