### PR TITLE
Register MiniMax-M3 as a vision model

### DIFF
--- a/apps/models_provider/impl/minimax_model_provider/credential/image.py
+++ b/apps/models_provider/impl/minimax_model_provider/credential/image.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+from typing import Dict
+
+from django.utils.translation import gettext_lazy as _, gettext
+from langchain_core.messages import HumanMessage
+
+from common import forms
+from common.exception.app_exception import AppApiException
+from common.forms import BaseForm, TooltipLabel
+from common.utils.logger import maxkb_logger
+from models_provider.base_model_provider import BaseModelCredential, ValidCode
+
+
+class MiniMaxImageModelParams(BaseForm):
+    temperature = forms.SliderField(TooltipLabel(_('Temperature'),
+                                                 _('Higher values make the output more random, while lower values make it more focused and deterministic')),
+                                    required=True, default_value=1.0,
+                                    _min=0.01,
+                                    _max=1.0,
+                                    _step=0.01,
+                                    precision=2)
+
+    max_tokens = forms.SliderField(
+        TooltipLabel(_('Output the maximum Tokens'),
+                     _('Specify the maximum number of tokens that the model can generate')),
+        required=True, default_value=8192,
+        _min=1,
+        _max=192000,
+        _step=1,
+        precision=0)
+
+
+class MiniMaxImageModelCredential(BaseForm, BaseModelCredential):
+
+    def is_valid(self, model_type: str, model_name, model_credential: Dict[str, object], model_params, provider,
+                 raise_exception=False):
+        model_type_list = provider.get_model_type_list()
+        if not any(list(filter(lambda mt: mt.get('value') == model_type, model_type_list))):
+            raise AppApiException(ValidCode.valid_error.value,
+                                  gettext('{model_type} Model type is not supported').format(model_type=model_type))
+
+        for key in ['api_base', 'api_key']:
+            if key not in model_credential:
+                if raise_exception:
+                    raise AppApiException(ValidCode.valid_error.value, gettext('{key}  is required').format(key=key))
+                else:
+                    return False
+        try:
+            model = provider.get_model(model_type, model_name, model_credential, **model_params)
+            res = model.stream([HumanMessage(content=[{"type": "text", "text": gettext('Hello')}])])
+            for chunk in res:
+                maxkb_logger.info(chunk)
+        except Exception as e:
+            maxkb_logger.error(f'Exception: {e}', exc_info=True)
+            if isinstance(e, AppApiException):
+                raise e
+            if raise_exception:
+                raise AppApiException(ValidCode.valid_error.value,
+                                      gettext(
+                                          'Verification failed, please check whether the parameters are correct: {error}').format(
+                                          error=str(e)))
+            else:
+                return False
+        return True
+
+    def encryption_dict(self, model: Dict[str, object]):
+        return {**model, 'api_key': super().encryption(model.get('api_key', ''))}
+
+    api_base = forms.TextInputField('API URL', required=True,
+                                    default_value='https://api.minimaxi.com/v1')
+    api_key = forms.PasswordInputField('API Key', required=True)
+
+    def get_model_params_setting_form(self, model_name):
+        return MiniMaxImageModelParams()

--- a/apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py
+++ b/apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py
@@ -9,11 +9,13 @@ from models_provider.base_model_provider import (
     ModelTypeConst,
     ModelInfoManage,
 )
+from models_provider.impl.minimax_model_provider.credential.image import MiniMaxImageModelCredential
 from models_provider.impl.minimax_model_provider.credential.itv import ImageToVideoModelCredential
 from models_provider.impl.minimax_model_provider.credential.llm import MiniMaxLLMModelCredential
 from models_provider.impl.minimax_model_provider.credential.tti import MiniMaxTextToImageModelCredential
 from models_provider.impl.minimax_model_provider.credential.tts import MiniMaxTTSModelCredential
 from models_provider.impl.minimax_model_provider.credential.ttv import TextToVideoModelCredential
+from models_provider.impl.minimax_model_provider.model.image import MiniMaxImageModel
 from models_provider.impl.minimax_model_provider.model.llm import MiniMaxChatModel
 from models_provider.impl.minimax_model_provider.model.tti import MiniMaxTextToImageModel
 from models_provider.impl.minimax_model_provider.model.tts import MiniMaxTextToSpeech
@@ -23,6 +25,7 @@ from django.utils.translation import gettext_lazy as _
 from models_provider.impl.minimax_model_provider.model.ttv import GenerationVideoModel
 
 minimax_llm_model_credential = MiniMaxLLMModelCredential()
+minimax_image_model_credential = MiniMaxImageModelCredential()
 minimax_tts_model_credential = MiniMaxTTSModelCredential()
 minimax_tti_model_credential = MiniMaxTextToImageModelCredential()
 minimax_ttv_model_credential = TextToVideoModelCredential()
@@ -86,6 +89,13 @@ minimax_tts_turbo = ModelInfo(
 minimax_tti_list = [
     ModelInfo("image-01", _(""), ModelTypeConst.TTI, minimax_tti_model_credential, MiniMaxTextToImageModel),
 ]
+
+# MiniMax-M3 accepts image and video inputs alongside text, so it is also
+# registered as a vision model so existing image/video input workflows can
+# select it.
+minimax_image_list = [
+    ModelInfo("MiniMax-M3", _(""), ModelTypeConst.IMAGE, minimax_image_model_credential, MiniMaxImageModel),
+]
 minimax_ttv_list = [
     ModelInfo("MiniMax-Hailuo-2.3", _(""), ModelTypeConst.TTV, minimax_ttv_model_credential, GenerationVideoModel),
 ]
@@ -106,6 +116,8 @@ model_info_manage = (
     .append_default_model_info(minimax_tts_hd)
     .append_model_info_list(minimax_tti_list)
     .append_default_model_info(minimax_tti_list[0])
+    .append_model_info_list(minimax_image_list)
+    .append_default_model_info(minimax_image_list[0])
     .append_model_info_list(minimax_ttv_list)
     .append_default_model_info(minimax_ttv_list[0])
     .append_model_info_list(model_info_itv_list)

--- a/apps/models_provider/impl/minimax_model_provider/model/image.py
+++ b/apps/models_provider/impl/minimax_model_provider/model/image.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+from typing import Dict
+
+from models_provider.base_model_provider import MaxKBBaseModel
+from models_provider.impl.base_chat_open_ai import BaseChatOpenAI
+
+
+class MiniMaxImageModel(MaxKBBaseModel, BaseChatOpenAI):
+
+    @staticmethod
+    def is_cache_model():
+        return False
+
+    @staticmethod
+    def new_instance(model_type, model_name, model_credential: Dict[str, object], **model_kwargs):
+        optional_params = MaxKBBaseModel.filter_optional_params(model_kwargs)
+        extra_body = optional_params.get('extra_body', {})
+        if not isinstance(extra_body, dict):
+            extra_body = {}
+        if 'reasoning_split' not in extra_body:
+            extra_body['reasoning_split'] = True
+        optional_params['extra_body'] = extra_body
+        return MiniMaxImageModel(
+            model=model_name,
+            openai_api_base=model_credential.get('api_base') or 'https://api.minimaxi.com/v1',
+            openai_api_key=model_credential.get('api_key'),
+            streaming=True,
+            stream_usage=True,
+            **optional_params,
+        )


### PR DESCRIPTION
Reason: MiniMax-M3 was registered only as an LLM, so image and video input workflows could not select it as a vision model.

## Summary
- Add a MiniMax vision (IMAGE) model entry for MiniMax-M3 so existing image/video input workflows can select it as a vision model.
- Add `MiniMaxImageModel` (`model/image.py`) backed by the OpenAI-compatible chat endpoint, mirroring the existing LLM chat model (keeps `reasoning_split` and the MiniMax API base).
- Add `MiniMaxImageModelCredential` (`credential/image.py`) with `api_base`/`api_key` fields and validation that streams a text message, mirroring other providers' image credentials.
- Register MiniMax-M3 under `ModelTypeConst.IMAGE` (with a default vision entry) in the MiniMax provider, following the same pattern used by other providers.

## Checks
- `python3 -m py_compile apps/models_provider/impl/minimax_model_provider/minimax_model_provider.py apps/models_provider/impl/minimax_model_provider/model/image.py apps/models_provider/impl/minimax_model_provider/credential/image.py`
