### PR TITLE
fix: prevent tsquery stack overflow on repeated hyphens

### DIFF
--- a/apps/common/utils/ts_vecto_util.py
+++ b/apps/common/utils/ts_vecto_util.py
@@ -114,5 +114,16 @@ def to_ts_vector(text: str, user_words: List[str] = None):
 def to_query(text: str, user_words: List[str] = None):
     tokenizer = _build_tokenizer(user_words) if user_words else jieba
     extract_tags = tokenizer.lcut(text, cut_all=True)
-    result = " ".join(extract_tags)
+    query_tokens = []
+    previous_token_is_negation = False
+    for token in extract_tags:
+        if token == '-':
+            # PostgreSQL treats each standalone '-' as a nested NOT operator.
+            if previous_token_is_negation:
+                continue
+            previous_token_is_negation = True
+        elif token.strip():
+            previous_token_is_negation = False
+        query_tokens.append(token)
+    result = " ".join(query_tokens)
     return result


### PR DESCRIPTION
#### What this PR does / why we need it?

Full-text and blended searches pass tokenized input to PostgreSQL's `websearch_to_tsquery`. Jieba tokenizes 33 hyphens into 33 standalone `-` tokens, which PostgreSQL interprets as nested NOT operators and rejects with `tsquery stack too small`.

This change collapses only consecutive standalone negation tokens before the query reaches PostgreSQL. Negations attached to separate search terms remain intact.

Fixes #6637

#### Summary of your change

- collapse consecutive standalone `-` tokens in `to_query`
- preserve negation operators for distinct terms
- add focused regression coverage for both behaviors

#### Validation

- reproduced on PostgreSQL 17: `websearch_to_tsquery('simple', repeat('- ', 33))` returns `ERROR: tsquery stack too small`
- `python -m unittest common.tests -v` — 2 tests passed
- post-fix PostgreSQL smoke: the normalized single `-` returns an empty query notice without raising an error
- `ruff check apps/common/utils/ts_vecto_util.py apps/common/tests.py`

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follows the Conventional Commits specification.
- [x] Considered the docs impact; no documentation change is required for this bug fix.
