### PR TITLE
fix: show tool execution source

### DIFF
--- a/apps/tools/serializers/tool.py
+++ b/apps/tools/serializers/tool.py
@@ -1532,7 +1532,7 @@ class ToolSerializer(serializers.Serializer):
             if self.data.get("state"):
                 query_set = query_set.filter(Q(state=self.data.get("state", "")))
             if self.data.get("source_name"):
-                query_set = query_set.filter(Q(tool_name__icontains=self.data.get("source_name", "")))
+                query_set = query_set.filter(Q(source_name__icontains=self.data.get("source_name", "")))
             if self.data.get("record_id"):
                 query_set = query_set.filter(Q(id=self.data.get("record_id")))
             if self.data.get("workspace_id"):
@@ -1545,7 +1545,7 @@ class ToolSerializer(serializers.Serializer):
                 query_set,
                 lambda record: {
                     **ToolRecordModelSerializer(record).data,
-                    "source_name": record.tool_name,
+                    "source_name": record.source_name,
                     "tool_icon": record.tool_icon,
                     "trigger_type": record.trigger_type,
                 },


### PR DESCRIPTION
#### What this PR does / why we need it?

Fixes #6647.

Tool execution records currently show and search the selected tool name in the Trigger Source field instead of the agent, knowledge base, or trigger that invoked it.

#### Summary of your change

- Restore the annotated `source_name` in tool execution record responses.
- Apply source-name searches to that annotation instead of `tool_name`.
- Add a regression test that gives the source and tool distinct names and verifies both behaviors.

## Regression evidence

- Before: `python -m unittest tools.tests.ToolRecordSerializerTestCase.test_get_tool_records_uses_annotated_source_name -v` exited `1` with `('Price Lookup', False)`.

- After: the same command exited `0` with the fix.

## Verification

- `python -m unittest tools.tests -v`
- `.venv/bin/ruff check apps/tools/tests.py`
- `.venv/bin/ruff check --isolated --select E9,F63,F7,F82 apps/tools/serializers/tool.py apps/tools/tests.py`
- `.venv/bin/ruff format --check apps/tools/tests.py`

## Scope

- 2 files changed, +53 / -4 lines

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed. No documentation change is required for this behavior correction.
