### PR TITLE
fix: filter NUL characters from chat records

### DIFF
--- a/apps/application/models/application_chat.py
+++ b/apps/application/models/application_chat.py
@@ -109,6 +109,11 @@ class ChatRecord(AppModelMixin):
     source = models.JSONField(verbose_name="来源", default=dict)
     ip_address = models.CharField(max_length=128, verbose_name="ip地址", default='')
 
+    def save(self, *args, **kwargs):
+        self.problem_text = self.problem_text.replace("\x00", "")
+        self.answer_text = self.answer_text.replace("\x00", "")
+        return super().save(*args, **kwargs)
+
     def get_human_message(self):
         if 'problem_padding' in self.details:
             return HumanMessage(content=self.details.get('problem_padding').get('padding_problem_text'))

--- a/apps/application/tests.py
+++ b/apps/application/tests.py
@@ -1,3 +1,17 @@
-from django.test import TestCase
+from unittest import mock
 
-# Create your tests here.
+from django.test import SimpleTestCase
+
+from application.models import ChatRecord
+
+
+class ChatRecordTestCase(SimpleTestCase):
+    def test_save_removes_nul_characters(self):
+        chat_record = ChatRecord(problem_text="question\x00text", answer_text="answer\x00text")
+
+        with mock.patch("django.db.models.Model.save") as model_save:
+            chat_record.save()
+
+        self.assertEqual(chat_record.problem_text, "questiontext")
+        self.assertEqual(chat_record.answer_text, "answertext")
+        model_save.assert_called_once_with()


### PR DESCRIPTION
#### What this PR does / why we need it?

PostgreSQL rejects native NUL (0x00) characters in text fields. Workflow output can reach `ChatRecord.problem_text` or `ChatRecord.answer_text` and cause the record write to fail.

Related to #6722.

#### Summary of your change

- Remove NUL characters from chat record question and answer text before persistence.
- Keep the fix scoped to `ChatRecord` instead of changing every model.
- Add a regression test that exercises the real `ChatRecord.save()` sanitization path.

#### Validation

- `ChatRecordTestCase.test_save_removes_nul_characters`
- `ruff check apps/application/models/application_chat.py apps/application/tests.py`
- Python compilation and diff checks

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact; no documentation change is required for this fix.
