### PR TITLE
fix(docs): repair root-relative README and tool guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://github.com/1Panel-dev/maxkb/releases/latest"><img src="https://img.shields.io/github/v/release/1Panel-dev/maxkb" alt="Latest release"></a>
   <a href="https://github.com/1Panel-dev/maxkb"><img src="https://img.shields.io/github/stars/1Panel-dev/maxkb?color=%231890FF&style=flat-square" alt="Stars"></a>    
   <a href="https://hub.docker.com/r/1panel/maxkb"><img src="https://img.shields.io/docker/pulls/1panel/maxkb?label=downloads" alt="Download"></a><br/>
- [<a href="/README_CN.md">中文(简体)</a>] | [<a href="/README.md">English</a>] 
+ [<a href="README_CN.md">中文(简体)</a>] | [<a href="README.md">English</a>] 
 </p>
 <hr/>
 

--- a/ui/public/tool/bochaai/detail.md
+++ b/ui/public/tool/bochaai/detail.md
@@ -7,10 +7,10 @@
 
 1. 获取API Key 
 在[博查开放平台](https://open.bochaai.com/overview) 上申请 API 密钥。
-![API Key](/admin/tool/img/bocha_APIKey.jpg)
+![API Key](../img/bocha_APIKey.jpg)
 2. 在函数库中配置
 在函数库的博查函数面板中，点击 … > 启动参数，填写 API 密钥，并启用该函数。   
-![启动参数](/admin/tool/img/bocha_setting.jpg)
+![启动参数](../img/bocha_setting.jpg)
 3. 在应用中使用
 在高级编排应用中，点击添加组件->函数库->博查，设置使用参数。
-![应用中使用](/admin/tool/img/bocha_app_used.jpg)
+![应用中使用](../img/bocha_app_used.jpg)

--- a/ui/public/tool/google_search/detail.md
+++ b/ui/public/tool/google_search/detail.md
@@ -6,16 +6,16 @@ Google 搜索工具是一个实时 API，可提取搜索引擎结果，提供来
 
 1. 创建 Google Custom Search Engine
 在[Programmable Search Engine](https://programmablesearchengine.google.com/)中 添加 Search Engine
-![google 创建引擎](/admin/tool/img/google_AddSearchEngine.jpg)
+![google 创建引擎](../img/google_AddSearchEngine.jpg)
 2. 获取cx参数
 进入添加的引擎详情中，在【基本】菜单中获取搜索引擎的ID，即cx。
-![google cx ](/admin/tool/img/google_cx.jpg)
+![google cx ](../img/google_cx.jpg)
 3. 获取 API Key
 打开 https://developers.google.com/custom-search/v1/overview?hl=zh-cn 获取API Key。
-![google API Key](/admin/tool/img/google_APIKey.jpg)
+![google API Key](../img/google_APIKey.jpg)
 4. 配置启动参数
 在Google 搜索函数的启动参数中填写配置以上参数，并启用该函数。
-![启动参数](/admin/tool/img/google_setting.jpg)
+![启动参数](../img/google_setting.jpg)
 5. 在应用中使用
 在高级编排应用中，点击添加组件->函数库->Google搜索，设置使用参数。
-![应用中使用](/admin/tool/img/google_app_used.jpg)
+![应用中使用](../img/google_app_used.jpg)

--- a/ui/public/tool/langsearch/detail.md
+++ b/ui/public/tool/langsearch/detail.md
@@ -7,11 +7,11 @@ LangSearch 是一个提供免费Web Search API和Rerank API的服务，支持新
 
 1. 获取API Key 
 在[LangSearch](https://langsearch.com/overview) 上申请 API 密钥。
-![API Key](/admin/tool/img/langsearch_APIKey.jpg)
+![API Key](../img/langsearch_APIKey.jpg)
 2. 在函数库中配置
 在函数库的LangSearch函数面板中，点击 … > 启动参数，填写 API 密钥，并启用该函数。   
-![启动参数](/admin/tool/img/langsearch_setting.jpg)
+![启动参数](../img/langsearch_setting.jpg)
 3. 在应用中使用
 在高级编排应用中，点击添加组件->函数库->LangSearch，设置使用参数。
-![应用中使用](/admin/tool/img/langsearch_app_used.jpg)
+![应用中使用](../img/langsearch_app_used.jpg)
  

--- a/ui/public/tool/mysql/detail.md
+++ b/ui/public/tool/mysql/detail.md
@@ -7,8 +7,8 @@ MySQL查询是一个连接MySQL数据库执行SQL查询的工具。
  
 1. 在函数库中配置启动参数
 在函数库的MySQL函数面板中，点击 … > 启动参数，填写数据库连接参数，并启用该函数。   
-![启动参数](/admin/tool/img/MySQL_setting.jpg)
+![启动参数](../img/MySQL_setting.jpg)
 2. 在应用中使用
 在高级编排应用中，点击添加组件->函数库->MySQL查询，设置查询内容。
-![应用中使用](/admin/tool/img/MySQL_app_used.jpg)
+![应用中使用](../img/MySQL_app_used.jpg)
  

--- a/ui/public/tool/postgresql/detail.md
+++ b/ui/public/tool/postgresql/detail.md
@@ -7,8 +7,8 @@ PostgreSQL查询是一个连接PostgreSQL数据库执行SQL查询的工具。
  
 1. 在函数库中配置启动参数
 在函数库的PostgreSQL函数面板中，点击 … > 启动参数，填写数据库连接参数，并启用该函数。   
-![启动参数](/admin/tool/img/PostgreSQL_setting.jpg)
+![启动参数](../img/PostgreSQL_setting.jpg)
 2. 在应用中使用
 在高级编排应用中，点击添加组件->函数库->PostgreSQL查询，设置查询内容。
-![应用中使用](/admin/tool/img/PostgreSQL_app_used.jpg)
+![应用中使用](../img/PostgreSQL_app_used.jpg)
  


### PR DESCRIPTION
- README.md language switcher used href="/README_CN.md" and
  href="/README.md"; on GitHub absolute paths resolve against the
  domain, not the repo, so both 404. Drop the leading slash so they
  resolve to the sibling files in the repository root.
- ui/public/tool/*/detail.md referenced screenshots via
  /admin/tool/img/*.jpg. The images actually live in ui/public/tool/img/
  and the /admin/ prefix is host-absolute: it only happens to work in a
  default MaxKB deployment (ADMIN_PATH=/admin) and breaks on GitHub or
  any custom ADMIN_PATH. Replace with relative ../img/ paths that point
  at the real files in the repo.