### PR TITLE
fix: strip embedded markup before text conversion

### DIFF
--- a/apps/common/tests.py
+++ b/apps/common/tests.py
@@ -1,0 +1,16 @@
+from django.test import SimpleTestCase
+
+from common.utils.common import markdown_to_plain_text
+
+
+class MarkdownToPlainTextTestCase(SimpleTestCase):
+    def test_removes_embedded_markup_contents(self):
+        cases = {
+            'before <audio src="clip.mp3">audio fallback</audio> after': "before after",
+            'before <video src="clip.mp4">video fallback</video> after': "before after",
+            'before <form_rander>{"label":"private"}</form_rander> after': "before after",
+        }
+
+        for markup, expected in cases.items():
+            with self.subTest(markup=markup):
+                self.assertEqual(markdown_to_plain_text(markup), expected)

--- a/apps/common/utils/common.py
+++ b/apps/common/utils/common.py
@@ -159,8 +159,18 @@ def _remove_empty_lines(text):
 
 
 def markdown_to_plain_text(md: str) -> str:
+    # 先移除特定媒体标签（优先级高于通用 Markdown 和 HTML 处理）
+    text = re.sub(
+        r"<(audio|video)(?:\s+[^>]*)?>.*?</\1>",
+        "",
+        md,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    text = re.sub(r"<img[^>]*>", "", text)  # 匹配图片标签
+    # 去除表单渲染
+    text = re.sub(r"<form_rander>.*?<\/form_rander>", "", text, flags=re.DOTALL)
     # 移除图片 ![alt](url)
-    text = re.sub(r"!\[.*?\]\(.*?\)", "", md)
+    text = re.sub(r"!\[.*?\]\(.*?\)", "", text)
     # 移除链接 [text](url)
     text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
     # 移除 Markdown 标题符号 (#, ##, ###)
@@ -179,15 +189,8 @@ def markdown_to_plain_text(md: str) -> str:
     text = re.sub(r"\n{2,}", "\n", text)
     # 使用正则表达式去除所有 HTML 标签
     text = re.sub(r"<[^>]+>", "", text)
-    # 先移除特定媒体标签（优先级高于通用HTML标签移除）
-    text = re.sub(
-        r"<(?:audio|video)(?:\s+[^>]*)?>.*?(?:</(?:audio|video)>)?", "", text, flags=re.DOTALL | re.IGNORECASE
-    )
-    text = re.sub(r"<img[^>]*>", "", text)  # 匹配图片标签
     # 去除多余的空白字符（包括换行符、制表符等）
     text = re.sub(r"\s+", " ", text)
-    # 去除表单渲染
-    text = re.sub(r"<form_rander>.*?<\/form_rander>", "", text, flags=re.DOTALL)
     # 去除首尾空格
     text = text.strip()
     return text


### PR DESCRIPTION
#### What this PR does / why we need it?

`markdown_to_plain_text` currently applies generic Markdown and HTML cleanup before removing MaxKB's embedded media and form markup. This means:

- the optional closing-tag branch can remove only an `<audio>` or `<video>` opening tag and leave fallback content behind;
- Markdown underscore handling rewrites `<form_rander>` before its JSON payload can be removed.

Those leftovers can reach downstream text-to-speech output.

#### Summary of your change

- Remove paired audio/video markup, image tags, and `form_rander` payloads before generic Markdown/HTML conversion.
- Require audio/video closing tags to match their corresponding opening tags.
- Add focused regression coverage for audio fallback text, video fallback text, and form-render JSON.

#### Validation

- Focused current-source smoke: PASS (audio, video, form-render, and existing Markdown conversion cases)
- `ruff check apps/common/utils/common.py apps/common/tests.py`
- `ruff format --check apps/common/tests.py`
- `git diff --check`

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follows the Conventional Commits specification.
- [x] Considered the docs impact; no documentation changes are needed for this bug fix.
