### PR TITLE
fix: remove outdated Tencent WAND ASR and Hunyuan ASR translations from django.po

### DIFF
--- a/apps/locales/zh_CN/LC_MESSAGES/django.po
+++ b/apps/locales/zh_CN/LC_MESSAGES/django.po
@@ -9556,13 +9556,3 @@ msgstr "自动"
 msgid "Tokenhub sync_transcribe endpoint"
 msgstr "Tokenhub 同步转写接口地址"
 
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tokenhub_stt.py:84
-msgid "Tencent WAND ASR online recognition, supports long audio/video. Outputs text with sentence-level timestamps."
-msgstr "腾讯混元 WAND 在线语音识别，支持长音视频。输出带句级时间戳的文本。"
-
-
-#: apps/models_provider/impl/tencent_model_provider/credential/tokenhub_stt.py:90
-msgid "Tencent Hunyuan ASR 3.0 (preview) online recognition. Accepts the same request/response format as wand-asr-v1."
-msgstr "腾讯混元语音识别 3.0（预览版）在线识别。请求/响应格式与 wand-asr-v1 一致。"
-


### PR DESCRIPTION
fix: remove outdated Tencent WAND ASR and Hunyuan ASR translations from django.po 