### PR TITLE
fix: normalize vLLM Whisper API base URL

### DIFF
--- a/apps/models_provider/impl/vllm_model_provider/model/whisper_sst.py
+++ b/apps/models_provider/impl/vllm_model_provider/model/whisper_sst.py
@@ -44,8 +44,8 @@ class VllmWhisperSpeechToText(MaxKBBaseModel, BaseSpeechToText):
             self.speech_to_text(audio_file)
 
     def speech_to_text(self, audio_file):
-
-        base_url = self.api_url if self.api_url.endswith('v1') else f"{self.api_url}/v1"
+        base_url = self.api_url.rstrip('/')
+        base_url = base_url if base_url.endswith('/v1') else f"{base_url}/v1"
 
         try:
             client = OpenAI(

--- a/apps/models_provider/tests.py
+++ b/apps/models_provider/tests.py
@@ -1,3 +1,26 @@
-from django.test import TestCase
+from io import BytesIO
+from unittest.mock import patch
 
-# Create your tests here.
+from django.test import SimpleTestCase
+
+from models_provider.impl.vllm_model_provider.model.whisper_sst import VllmWhisperSpeechToText
+
+
+class VllmWhisperSpeechToTextTest(SimpleTestCase):
+    @patch('models_provider.impl.vllm_model_provider.model.whisper_sst.OpenAI')
+    def test_normalizes_trailing_slash_in_v1_base_url(self, openai_mock):
+        openai_mock.return_value.audio.transcriptions.create.return_value.text = 'transcript'
+        model = VllmWhisperSpeechToText(
+            api_key='test-key',
+            api_url='https://vllm.example/v1/',
+            model='whisper',
+            params={},
+        )
+
+        result = model.speech_to_text(BytesIO(b'audio'))
+
+        openai_mock.assert_called_once_with(
+            api_key='test-key',
+            base_url='https://vllm.example/v1',
+        )
+        self.assertEqual(result, 'transcript')


### PR DESCRIPTION
#### What this PR does / why we need it?

The vLLM Whisper provider appends `/v1` unless the configured URL ends exactly with `v1`. A valid URL ending in `/v1/` therefore becomes `/v1//v1`, while provider credential validation accepts the same configuration. This breaks transcription requests at runtime.

#### Summary of your change

- Strip trailing slashes before checking and appending the vLLM API version path.
- Add a focused regression test for an API URL ending in `/v1/`.

Validation:
- Focused runtime smoke with a stubbed OpenAI client: passed.
- Ruff fatal/static checks for the changed files: passed.
- Python syntax compilation and `git diff --check`: passed.

#### Please indicate you have done the following:

- [x] Made sure focused tests are passing and test coverage is added where needed.
- [x] Made sure the commit message follows the Conventional Commits specification.
- [x] Considered the docs impact; no documentation change is needed for this normalization fix.