### PR TITLE
fix: Importing CSV files with excessively large cell contents into the knowledge base, resulting in empty read content #6756

### DIFF
--- a/apps/maxkb/wsgi/web.py
+++ b/apps/maxkb/wsgi/web.py
@@ -7,6 +7,7 @@
     @desc:
 """
 import builtins
+import csv
 import os
 import sys
 
@@ -33,6 +34,7 @@ builtins.__import__ = TorchBlocker()
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'maxkb.settings')
 os.environ['TIKTOKEN_CACHE_DIR'] = '/opt/maxkb-app/model/tokenizer/openai-tiktoken-cl100k-base'
+csv.field_size_limit(sys.maxsize)
 application = get_wsgi_application()
 
 


### PR DESCRIPTION
fix: Importing CSV files with excessively large cell contents into the knowledge base, resulting in empty read content #6756 