### PR TITLE
fix: hardcoded default Django SECRET_KEY allows offline forgery of signing-based tokens and unauthenticated file access

### DIFF
--- a/apps/maxkb/settings/base/web.py
+++ b/apps/maxkb/settings/base/web.py
@@ -18,8 +18,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = CONFIG.get("SECRET_KEY") or 'django-insecure-zm^1_^i5)3gp^&0io6zg72&z!a*d=9kf9o2%uft+27l)+t(#3e'
-
+SECRET_KEY = CONFIG.get('SECRET_KEY')
+if not SECRET_KEY:
+    raise RuntimeError(
+        "MAXKB_SECRET_KEY not configured, please provide it in the environment variable or configuration")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = CONFIG.get_debug()
 

--- a/installer/start-maxkb.sh
+++ b/installer/start-maxkb.sh
@@ -23,5 +23,8 @@ if [ -d $_INIT_SHELL_DIR ]; then
         fi
     done
 fi
-
+if [ -z "$MAXKB_SECRET_KEY" ]; then
+    MAXKB_SECRET_KEY=$(python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')
+fi
+export MAXKB_SECRET_KEY
 python /opt/maxkb-app/main.py start


### PR DESCRIPTION
fix: hardcoded default Django SECRET_KEY allows offline forgery of signing-based tokens and unauthenticated file access 