### PR TITLE
fix: If there are empty characters in the output content of the intelligent agent conversation, the conversation will report an error #6722

### DIFF
--- a/apps/application/models/application.py
+++ b/apps/application/models/application.py
@@ -11,6 +11,7 @@ from django.db import models
 from mptt.fields import TreeForeignKey
 from mptt.models import MPTTModel
 
+from common.encoder.encoder import SystemEncoder
 from common.mixins.app_model_mixin import AppModelMixin
 from knowledge.models import Knowledge
 from models_provider.models import Model
@@ -75,7 +76,7 @@ class Application(AppModelMixin):
     stt_model_params_setting = models.JSONField(verbose_name="STT模型参数相关设置", default=dict)
     problem_optimization = models.BooleanField(verbose_name="问题优化", default=False)
     icon = models.CharField(max_length=256, verbose_name="应用icon", default="./favicon.ico")
-    work_flow = models.JSONField(verbose_name="工作流数据", default=dict)
+    work_flow = models.JSONField(verbose_name="工作流数据", default=dict, encoder=SystemEncoder)
     type = models.CharField(verbose_name="应用类型", choices=ApplicationTypeChoices.choices,
                             default=ApplicationTypeChoices.SIMPLE, max_length=256)
     problem_optimization_prompt = models.CharField(verbose_name="问题优化提示词", max_length=102400, blank=True,
@@ -160,7 +161,7 @@ class ApplicationVersion(AppModelMixin):
     stt_model_params_setting = models.JSONField(verbose_name="STT模型参数相关设置", default=dict)
     problem_optimization = models.BooleanField(verbose_name="问题优化", default=False)
     icon = models.CharField(max_length=256, verbose_name="应用icon", default="./favicon.ico")
-    work_flow = models.JSONField(verbose_name="工作流数据", default=dict)
+    work_flow = models.JSONField(verbose_name="工作流数据", default=dict, encoder=SystemEncoder)
     type = models.CharField(verbose_name="应用类型", choices=ApplicationTypeChoices.choices,
                             default=ApplicationTypeChoices.SIMPLE, max_length=256)
     problem_optimization_prompt = models.CharField(verbose_name="问题优化提示词", max_length=102400, blank=True,

--- a/apps/application/models/application_chat.py
+++ b/apps/application/models/application_chat.py
@@ -112,8 +112,8 @@ class ChatRecord(AppModelMixin):
     ip_address = models.CharField(max_length=128, verbose_name="ip地址", default='')
 
     def save(self, *args, **kwargs):
-        self.problem_text = self.problem_text.replace('\\u0000', '')
-        self.answer_text = self.answer_text.replace('\\u0000', '')
+        self.problem_text = self.problem_text.replace('\x00', '')
+        self.answer_text = self.answer_text.replace('\x00', '')
         return super().save(*args, **kwargs)
 
     def get_human_message(self):

--- a/apps/common/encoder/encoder.py
+++ b/apps/common/encoder/encoder.py
@@ -14,12 +14,25 @@ import uuid
 from django.core.files.uploadedfile import InMemoryUploadedFile, TemporaryUploadedFile
 
 
+def strip_nul(obj):
+    if isinstance(obj, str):
+        return obj.replace('\x00', '')  # 注意是 '\x00'，真正的空字符
+    if isinstance(obj, dict):
+        return {k: strip_nul(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [strip_nul(x) for x in obj]
+    return obj
+
+
 class SystemEncoder(json.JSONEncoder):
     def encode(self, obj):
         # 先序列化为字符串
-        json_str = super().encode(obj)
-        # 移除所有空字符
-        json_str = json_str.replace('\\u0000', '')
+        r = obj
+        try:
+            r = strip_nul(obj)
+        except:
+            pass
+        json_str = super().encode(strip_nul(r))
         return json_str
 
     def default(self, obj):


### PR DESCRIPTION
fix: If there are empty characters in the output content of the intelligent agent conversation, the conversation will report an error #6722 