### PR TITLE
fix: assemble Anthropic streamed tool_use blocks before replay

### DIFF
--- a/apps/application/flow/anthropic_tool_content.py
+++ b/apps/application/flow/anthropic_tool_content.py
@@ -1,0 +1,123 @@
+# coding=utf-8
+"""
+@project: maxkb
+@file: anthropic_tool_content.py
+@desc: Normalize Anthropic streamed tool content before message replay.
+"""
+
+from __future__ import annotations
+
+import json
+
+ANTHROPIC_TOOL_STOP_REASONS = ("tool_use",)
+_STREAM_DELTA_TYPES = {"input_json_delta"}
+
+
+def is_anthropic_tool_finish(response_metadata, chunk_position=None) -> bool:
+    meta = response_metadata or {}
+    return (
+        meta.get("finish_reason") == "tool_calls"
+        or meta.get("stop_reason") in ANTHROPIC_TOOL_STOP_REASONS
+        or chunk_position == "last"
+    )
+
+
+def collect_input_json_deltas(content) -> dict:
+    collected = {}
+    if not isinstance(content, list):
+        return collected
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") != "input_json_delta":
+            continue
+        index = block.get("index")
+        if index is None:
+            raise ValueError("Anthropic input_json_delta is missing its content-block index")
+        piece = block.get("partial_json")
+        if piece is None:
+            piece = block.get("input") or ""
+        if not isinstance(piece, str):
+            piece = json.dumps(piece, ensure_ascii=False) if piece else ""
+        collected[index] = collected.get(index, "") + piece
+    return collected
+
+
+def _parse_tool_input(raw):
+    if raw is None or raw == "":
+        return None
+    if isinstance(raw, (dict, list)):
+        return raw
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        raise ValueError("Invalid Anthropic tool input JSON") from None
+    if not isinstance(parsed, (dict, list)):
+        raise ValueError("Anthropic tool input must be an object or array")
+    return parsed
+
+
+def _input_from_tool_calls(block, tool_calls):
+    block_id = block.get("id")
+    for tool_call in tool_calls or []:
+        if not isinstance(tool_call, dict):
+            continue
+        if block_id and tool_call.get("id") == block_id:
+            return _parse_tool_input(tool_call.get("args") or tool_call.get("arguments"))
+        if block.get("index") is not None and tool_call.get("index") == block.get("index"):
+            return _parse_tool_input(tool_call.get("args") or tool_call.get("arguments"))
+    return None
+
+
+def _input_from_fragments(block, fragments):
+    if not fragments:
+        return None
+    block_id = block.get("id")
+    block_index = block.get("index")
+    for entry in fragments.values():
+        if not isinstance(entry, dict):
+            continue
+        if block_id and entry.get("id") == block_id:
+            return _parse_tool_input(entry.get("arguments"))
+        if block_index is not None and entry.get("index") == block_index:
+            return _parse_tool_input(entry.get("arguments"))
+    return None
+
+
+def _is_empty_text_block(block) -> bool:
+    return (
+        isinstance(block, dict)
+        and block.get("type") in ("text", "text_delta")
+        and not str(block.get("text") or "").strip()
+    )
+
+
+def finalize_anthropic_assistant_content(content, tool_calls=None, fragments=None):
+    if not isinstance(content, list):
+        return content
+
+    json_by_index = collect_input_json_deltas(content)
+    finalized = []
+    for block in content:
+        if not isinstance(block, dict):
+            finalized.append(block)
+            continue
+        if block.get("type") in _STREAM_DELTA_TYPES or _is_empty_text_block(block):
+            continue
+        if block.get("type") == "tool_use":
+            new_block = dict(block)
+            new_block.pop("partial_json", None)
+            filled = _input_from_fragments(new_block, fragments)
+            if filled is None:
+                filled = _input_from_tool_calls(new_block, tool_calls)
+            if filled is None:
+                filled = _parse_tool_input(json_by_index.get(new_block.get("index")))
+            current = new_block.get("input")
+            if filled is not None and (current in (None, "", {}, []) or not current):
+                new_block["input"] = filled
+            elif current == "":
+                new_block["input"] = {}
+            finalized.append(new_block)
+            continue
+        finalized.append(block)
+    return finalized

--- a/apps/application/flow/tools.py
+++ b/apps/application/flow/tools.py
@@ -46,6 +46,11 @@ from langchain_core.messages import AIMessageChunk, BaseMessage, BaseMessageChun
 from langchain_core.tools import StructuredTool
 from langchain_core.utils._merge import merge_lists as _original_merge_lists
 from langchain_mcp_adapters.client import MultiServerMCPClient
+from .anthropic_tool_content import (
+    collect_input_json_deltas,
+    finalize_anthropic_assistant_content,
+    is_anthropic_tool_finish,
+)
 from langgraph.checkpoint.memory import MemorySaver
 from maxkb.const import CONFIG
 from pydantic import Field, create_model
@@ -482,6 +487,7 @@ async def _yield_mcp_response(
         tool_calls_info = {}  # tool_id -> {'name': ..., 'input': ...}
         # key(index/id) -> {'id': ..., 'name': ..., 'arguments': ...}
         _tool_fragments = {}
+        _anthropic_chunks = []
 
         def _merge_arguments(entry, part_args):
             if not isinstance(part_args, str):
@@ -519,10 +525,12 @@ async def _yield_mcp_response(
                 return f"id:{_extract_tool_id(str(raw_id).strip())}"
             return None
 
-        def _upsert_fragment(key, raw_id, func_name, part_args):
+        def _upsert_fragment(key, raw_id, func_name, part_args, index=None):
             if key is None:
                 return
-            entry = _tool_fragments.setdefault(key, {"id": "", "name": "", "arguments": ""})
+            entry = _tool_fragments.setdefault(key, {"id": "", "name": "", "arguments": "", "index": index})
+            if index is not None:
+                entry["index"] = index
 
             if raw_id and str(raw_id).strip():
                 new_id = str(raw_id).strip()
@@ -548,7 +556,7 @@ async def _yield_mcp_response(
                 for tc_chunk in chunk[0].tool_call_chunks or []:
                     raw_id = tc_chunk.get("id")
                     key = _get_fragment_key(tc_chunk.get("index"), raw_id)
-                    _upsert_fragment(key, raw_id, tc_chunk.get("name"), tc_chunk.get("args", ""))
+                    _upsert_fragment(key, raw_id, tc_chunk.get("name"), tc_chunk.get("args", ""), tc_chunk.get("index"))
 
                 # ----------------------------------------------------------------
                 # 1.1 兼容部分模型将工具调用放在 chunk.tool_calls，且 tool_call_chunks
@@ -563,7 +571,7 @@ async def _yield_mcp_response(
                     if has_tool_call_chunks and (part_args == "" or part_args == {} or part_args == []):
                         part_args = ""
                     key = _get_fragment_key(tool_call.get("index"), raw_id)
-                    _upsert_fragment(key, raw_id, tool_call.get("name"), part_args)
+                    _upsert_fragment(key, raw_id, tool_call.get("name"), part_args, tool_call.get("index"))
 
                 # ----------------------------------------------------------------
                 # 1.2 兼容 invalid_tool_calls 分片（部分模型会把中间 JSON 片段放这里）
@@ -571,7 +579,13 @@ async def _yield_mcp_response(
                 for invalid_tool_call in chunk[0].invalid_tool_calls or []:
                     raw_id = invalid_tool_call.get("id")
                     key = _get_fragment_key(invalid_tool_call.get("index"), raw_id)
-                    _upsert_fragment(key, raw_id, invalid_tool_call.get("name"), invalid_tool_call.get("args", ""))
+                    _upsert_fragment(
+                        key,
+                        raw_id,
+                        invalid_tool_call.get("name"),
+                        invalid_tool_call.get("args", ""),
+                        invalid_tool_call.get("index"),
+                    )
 
                 # ----------------------------------------------------------------
                 # 2. 兼容 additional_kwargs['tool_calls'] 方式（旧格式/非流式情况）
@@ -587,14 +601,28 @@ async def _yield_mcp_response(
                         func_name = tool_call.get("name")
                         part_args = tool_call.get("arguments", "")
                     key = _get_fragment_key(tool_call.get("index"), raw_id)
-                    _upsert_fragment(key, raw_id, func_name, part_args)
+                    _upsert_fragment(key, raw_id, func_name, part_args, tool_call.get("index"))
+
+                if isinstance(chunk[0].content, list):
+                    for block in chunk[0].content:
+                        if isinstance(block, dict) and block.get("type") == "tool_use":
+                            key = _get_fragment_key(block.get("index"), block.get("id"))
+                            _upsert_fragment(
+                                key,
+                                block.get("id"),
+                                block.get("name"),
+                                block.get("input", ""),
+                                block.get("index"),
+                            )
+                    for index, partial_json in collect_input_json_deltas(chunk[0].content).items():
+                        key = _get_fragment_key(index, None)
+                        if key is not None:
+                            _upsert_fragment(key, None, None, partial_json, index)
 
                 # ----------------------------------------------------------------
                 # 3. 检测工具调用结束，更新 tool_calls_info
                 # ----------------------------------------------------------------
-                is_finish_chunk = (
-                    chunk[0].response_metadata.get("finish_reason") == "tool_calls" or chunk[0].chunk_position == "last"
-                )
+                is_finish_chunk = is_anthropic_tool_finish(chunk[0].response_metadata, chunk[0].chunk_position)
 
                 if is_finish_chunk:
                     # 在 finish chunk 时，将所有未完成的 fragment 标记完成并更新 tool_calls_info
@@ -604,11 +632,9 @@ async def _yield_mcp_response(
                             maxkb_logger.debug(f"Skipping fragment {idx}: already completed")
                             continue
                         if not entry.get("id"):
-                            maxkb_logger.debug(f"Skipping fragment {idx}: missing id. Fragment: {entry}")
-                            continue
+                            raise RuntimeError(f"Anthropic tool fragment {idx} is missing its tool ID")
                         if not entry.get("arguments"):
-                            maxkb_logger.debug(f"Skipping fragment {idx}: missing arguments. Fragment: {entry}")
-                            continue
+                            raise RuntimeError(f"Anthropic tool fragment {idx} is missing its arguments")
 
                         if not entry.get("completed") and entry.get("id") and entry.get("arguments"):
                             try:
@@ -626,22 +652,9 @@ async def _yield_mcp_response(
                                 entry["completed"] = True
                                 maxkb_logger.debug(f"Added tool call {entry['id']} to tool_calls_info")
                             except (json.JSONDecodeError, ValueError) as e:
-                                # JSON parsing failed, but still add to tool_calls_info with raw arguments
-                                # to prevent "Tool ID not found" errors when ToolMessage arrives
-                                maxkb_logger.warning(
-                                    f"Failed to parse tool arguments at finish for tool {entry.get('id', 'unknown')}: "
-                                    f"{entry['arguments']}, error: {e}. Using raw arguments."
-                                )
-                                normalized_id = _extract_tool_id(entry["id"])
-                                info = {
-                                    "name": entry["name"],
-                                    # Use raw arguments
-                                    "input": entry["arguments"],
-                                }
-                                tool_calls_info[entry["id"]] = info
-                                if normalized_id and normalized_id != entry["id"]:
-                                    tool_calls_info[normalized_id] = info
-                                entry["completed"] = True
+                                raise RuntimeError(
+                                    f"Failed to parse tool arguments for {entry.get('id', 'unknown')}: {e}"
+                                ) from e
 
                 # ----------------------------------------------------------------
                 # 4. 修复 tool_call_chunks 中的空 id（回填已知 id）
@@ -675,6 +688,27 @@ async def _yield_mcp_response(
                         fixed_tool_calls.append(tc)
                     chunk[0].additional_kwargs["tool_calls"] = fixed_tool_calls
 
+                has_anthropic_content = isinstance(chunk[0].content, list) and any(
+                    isinstance(block, dict) and block.get("type") in ("tool_use", "input_json_delta")
+                    for block in chunk[0].content
+                )
+                if _anthropic_chunks or has_anthropic_content:
+                    _anthropic_chunks.append(chunk[0])
+                    if not is_finish_chunk:
+                        continue
+                    combined_chunk = _anthropic_chunks[0]
+                    for buffered_chunk in _anthropic_chunks[1:]:
+                        combined_chunk += buffered_chunk
+                    chunk[0] = combined_chunk
+                    _anthropic_chunks.clear()
+
+                if isinstance(chunk[0].content, list):
+                    chunk[0].content = finalize_anthropic_assistant_content(
+                        chunk[0].content,
+                        tool_calls=chunk[0].tool_calls,
+                        fragments=_tool_fragments,
+                    )
+
                 yield chunk[0]
 
             if mcp_output_enable and isinstance(chunk[0], ToolMessage):
@@ -698,24 +732,37 @@ async def _yield_mcp_response(
                             tool_lib_id = text_result.pop("tool_id") if "tool_id" in text_result else None
                         else:
                             tool_lib_id = tool_result.pop("tool_id") if "tool_id" in tool_result else None
+                    except (AttributeError, KeyError, TypeError, ValueError) as error:
+                        raise RuntimeError(f"Failed to parse tool result: {error}") from error
+                    else:
                         if tool_lib_id:
                             await save_tool_record(tool_lib_id, tool_info, tool_result, source_id, source_type)
                         tool_result = json.dumps(text_result, ensure_ascii=False)
-                    except Exception as e:
-                        tool_result = chunk[0].content
                     content = generate_tool_message_complete(
                         tool_info.get("icon", ""), tool_info["name"], tool_info["input"], tool_result
                     )
                     chunk[0].content = content
                 else:
-                    maxkb_logger.warning(
-                        f"Tool ID {tool_id} not found in tool_calls_info. "
-                        f"Normalized Tool ID: {normalized_tool_id}. "
-                        f"Available IDs: {list(tool_calls_info.keys())}. "
-                        f"Tool fragments at this point: {_tool_fragments}"
+                    raise RuntimeError(
+                        f"Tool ID {tool_id} not found in tool_calls_info "
+                        f"(normalized: {normalized_tool_id})"
                     )
 
                 yield chunk[0]
+
+        if _anthropic_chunks:
+            for idx, entry in _tool_fragments.items():
+                if not entry.get("id") or not entry.get("arguments"):
+                    raise RuntimeError(f"Incomplete Anthropic tool fragment at stream end: {idx}")
+            combined_chunk = _anthropic_chunks[0]
+            for buffered_chunk in _anthropic_chunks[1:]:
+                combined_chunk += buffered_chunk
+            combined_chunk.content = finalize_anthropic_assistant_content(
+                combined_chunk.content,
+                tool_calls=combined_chunk.tool_calls,
+                fragments=_tool_fragments,
+            )
+            yield combined_chunk
 
     except ExceptionGroup as eg:
 

--- a/tests/test_anthropic_tool_content.py
+++ b/tests/test_anthropic_tool_content.py
@@ -1,0 +1,94 @@
+import sys
+import unittest
+from pathlib import Path
+
+from langchain_core.messages import AIMessageChunk
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "apps"))
+
+from application.flow.anthropic_tool_content import (
+    collect_input_json_deltas,
+    finalize_anthropic_assistant_content,
+    is_anthropic_tool_finish,
+)
+
+
+class AnthropicToolContentTests(unittest.TestCase):
+    def test_finish_detects_anthropic_stop_reason(self):
+        self.assertTrue(is_anthropic_tool_finish({"stop_reason": "tool_use"}))
+        self.assertTrue(is_anthropic_tool_finish({"finish_reason": "tool_calls"}))
+        self.assertTrue(is_anthropic_tool_finish({}, chunk_position="last"))
+        self.assertFalse(is_anthropic_tool_finish({"stop_reason": "end_turn"}))
+        self.assertFalse(is_anthropic_tool_finish({"stop_reason": "pause_turn"}))
+
+    def test_strips_input_json_delta_and_empty_text(self):
+        content = [
+            {"type": "text", "text": ""},
+            {"type": "tool_use", "id": "toolu_1", "name": "live_price", "input": {}, "index": 1},
+            {"type": "input_json_delta", "index": 1, "partial_json": '{"query":'},
+            {"type": "input_json_delta", "index": 1, "partial_json": ' "DJI Neo"}'},
+        ]
+        finalized = finalize_anthropic_assistant_content(content)
+        self.assertEqual(len(finalized), 1)
+        self.assertEqual(finalized[0]["type"], "tool_use")
+        self.assertEqual(finalized[0]["id"], "toolu_1")
+        self.assertEqual(finalized[0]["input"], {"query": "DJI Neo"})
+        self.assertNotIn("input_json_delta", [block.get("type") for block in finalized])
+
+    def test_fills_tool_use_input_from_tool_calls(self):
+        content = [{"type": "tool_use", "id": "toolu_2", "name": "live_price", "input": ""}]
+        tool_calls = [{"id": "toolu_2", "name": "live_price", "args": {"query": "in stock"}}]
+        finalized = finalize_anthropic_assistant_content(content, tool_calls=tool_calls)
+        self.assertEqual(finalized[0]["input"], {"query": "in stock"})
+
+    def test_fills_tool_use_input_from_fragments(self):
+        content = [{"type": "tool_use", "id": "toolu_3", "name": "live_price", "input": {}}]
+        fragments = {"1": {"id": "toolu_3", "name": "live_price", "arguments": '{"query": "GEL"}'}}
+        finalized = finalize_anthropic_assistant_content(content, fragments=fragments)
+        self.assertEqual(finalized[0]["input"], {"query": "GEL"})
+
+    def test_fills_tool_use_input_after_deltas_arrive_in_later_chunk(self):
+        fragments = {"idx:1": {"id": "toolu_4", "index": 1, "arguments": '{"query": "later"}'}}
+        content = [{"type": "tool_use", "id": "toolu_4", "name": "live_price", "input": {}, "index": 1}]
+        finalized = finalize_anthropic_assistant_content(content, fragments=fragments)
+        self.assertEqual(finalized[0]["input"], {"query": "later"})
+
+    def test_finalizes_combined_stream_chunks_before_replay(self):
+        chunks = [
+            AIMessageChunk(
+                content=[{"type": "tool_use", "id": "toolu_5", "name": "live_price", "input": {}, "index": 0}]
+            ),
+            AIMessageChunk(content=[{"type": "input_json_delta", "index": 0, "partial_json": '{"q":'}]),
+            AIMessageChunk(content=[{"type": "input_json_delta", "index": 0, "partial_json": '"value"}'}]),
+        ]
+        combined = chunks[0] + chunks[1] + chunks[2]
+        finalized = finalize_anthropic_assistant_content(
+            combined.content,
+            fragments={"idx:0": {"id": "toolu_5", "index": 0, "arguments": '{"q":"value"}'}},
+        )
+        self.assertEqual(finalized[0]["input"], {"q": "value"})
+        self.assertNotIn("input_json_delta", [block.get("type") for block in finalized])
+
+    def test_collect_input_json_deltas_concatenates_partial_json(self):
+        content = [
+            {"type": "input_json_delta", "index": 0, "partial_json": '{"a":'},
+            {"type": "input_json_delta", "index": 0, "input": " 1}"},
+        ]
+        self.assertEqual(collect_input_json_deltas(content), {0: '{"a": 1}'})
+
+    def test_plain_string_content_is_unchanged(self):
+        self.assertEqual(finalize_anthropic_assistant_content("hello"), "hello")
+
+    def test_invalid_tool_input_json_is_rejected(self):
+        content = [{"type": "tool_use", "id": "toolu_6", "input": {}, "index": 0}]
+        fragments = {"idx:0": {"id": "toolu_6", "index": 0, "arguments": '{"query":'}}
+        with self.assertRaises(ValueError):
+            finalize_anthropic_assistant_content(content, fragments=fragments)
+
+    def test_delta_without_index_is_rejected(self):
+        with self.assertRaises(ValueError):
+            collect_input_json_deltas([{"type": "input_json_delta", "partial_json": "{}"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Anthropic streams tool arguments as input_json_delta events, which were replayed as invalid message content. Assemble those fragments into completed tool_use.input blocks and reject incomplete or unmatched tool state.

Fixes #6480

## Reviewers

CaptainB, shenkaibo, wxg0103