### PR TITLE
fix: remove duplicate rowKey attribute in RoleMemberList component

### DIFF
--- a/ui/src/views/system/identity/roles/components/RoleMemberList.vue
+++ b/ui/src/views/system/identity/roles/components/RoleMemberList.vue
@@ -107,7 +107,6 @@ watch(
       @current-change="loadMembers()"
       @size-change="loadMembers()"
       :max-table-height="290"
-      rowKey="user_relation_id"
       @selection-change="handleBatchSelectionChange"
       rowKey="user_relation_id"
     >


### PR DESCRIPTION
fix: remove duplicate rowKey attribute in RoleMemberList component 