### PR TITLE
fix: Internal errors within the loop node cannot propagate to the outer loop

### DIFF
--- a/apps/application/workflow/nodes/loop_node/loop_node.py
+++ b/apps/application/workflow/nodes/loop_node/loop_node.py
@@ -133,6 +133,7 @@ class LoopNode(INode):
 
             if error:
                 self.write_context("error_message", str(error))
+                self.complete(Status.FAIL, error=error)
                 return
 
             self._run_next()


### PR DESCRIPTION
fix: Internal errors within the loop node cannot propagate to the outer loop 