### PR TITLE
docs: add Parallel Search MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,42 @@ Access MaxKB web interface at `http://your_server_ip:8080` with default admin cr
 
 中国用户如遇到 Docker 镜像 Pull 失败问题，请参照该 [离线安装文档](https://maxkb.cn/docs/v2/installation/offline_installtion/) 进行安装。
 
+## Web search with MCP
+
+To give an agent access to public web search and page extraction, connect
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp)
+through MaxKB's existing MCP tools. No Parallel account or API key is required;
+free access is rate limited. The MaxKB server needs outbound HTTPS access to
+`search.parallel.ai`.
+
+1. Open **Tool**, choose **Create MCP**, and name it `Parallel Search`.
+2. Paste this object into **MCP Server Config**. Use `streamable_http`, not `sse`,
+   and do not add an outer `mcpServers` object or authentication headers.
+
+   ```json
+   {
+     "parallel-search": {
+       "url": "https://search.parallel.ai/mcp",
+       "transport": "streamable_http",
+       "headers": {"User-Agent": "MaxKB"}
+     }
+   }
+   ```
+
+3. Click **Test Connection**, then **Create**, and enable the tool.
+4. In the agent's settings, add an MCP connection under **Capabilities**,
+   choose **Reference MCP**, and select `Parallel Search`. Save the settings.
+   The agent can then use `web_search` and `web_fetch`, for example to find
+   current public documentation and read the source pages.
+
+The `User-Agent` identifies MaxKB so Parallel can measure aggregate free MCP
+usage. Keep it project-wide; do not add user or installation identifiers.
+
+Once selected, the agent may call these tools during a conversation. Queries,
+requested URLs, and any supplied objectives or context are sent to Parallel.
+Only include information you intend to send to that service. To stop using it
+in an agent, remove the connection from that agent's MCP settings and save.
+
 ## Screenshots
 
 <table style="border-collapse: collapse; border: 1px solid black;">

--- a/README_CN.md
+++ b/README_CN.md
@@ -50,6 +50,39 @@ docker run -d --name=maxkb --restart=always -p 8080:8080 -v C:/maxkb:/opt/maxkb 
 
 <image height="150px" width="150px" src="https://github.com/1Panel-dev/MaxKB/assets/52996290/a083d214-02be-4178-a1db-4f428124153a"/>
 
+## 通过 MCP 搜索网页
+
+可以通过 MaxKB 现有的 MCP 工具接入
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp)，
+为智能体提供公开网页搜索和页面内容提取。无需 Parallel 账号或 API 密钥，
+免费访问有速率限制。MaxKB 服务器需要能够通过 HTTPS 访问 `search.parallel.ai`。
+
+1. 打开**工具**，选择**创建 MCP**，名称填写 `Parallel Search`。
+2. 将以下对象粘贴到 **MCP Server Config** 配置框。使用 `streamable_http`，
+   不要使用 `sse`，也不要添加外层 `mcpServers` 对象或身份验证请求头。
+
+   ```json
+   {
+     "parallel-search": {
+       "url": "https://search.parallel.ai/mcp",
+       "transport": "streamable_http",
+       "headers": {"User-Agent": "MaxKB"}
+     }
+   }
+   ```
+
+3. 点击**测试连接**，然后**创建**，并启用该工具。
+4. 在智能体设置的**技能**区域添加 MCP 连接，选择**引用MCP**，
+   选中 `Parallel Search` 并保存。智能体即可使用 `web_search` 和 `web_fetch`，
+   例如查找最新的公开文档并读取来源页面。
+
+`User-Agent` 标识 MaxKB，以便 Parallel 统计项目级的免费 MCP 使用量。
+请保持该标识一致，不要添加用户或安装实例标识。
+
+选中后，智能体可能在对话中自行调用这些工具。查询词、请求的 URL 以及提供的
+目标或上下文会发送给 Parallel，请只提供你愿意发送给该服务的信息。
+如需在某个智能体中停用，请从该智能体的 MCP 设置中移除连接并保存。
+
 ## UI 展示
 
 <table style="border-collapse: collapse; border: 1px solid black;">


### PR DESCRIPTION
#### What this PR does / why we need it?

Adds an English and Chinese setup example for public web search and page extraction through MaxKB’s existing MCP tools. It gives users a working Streamable HTTP configuration that needs no Parallel account or API key.

#### Summary of your change

The READMEs cover creating the MCP tool, selecting it in an agent, and removing the connection. They explain rate limits and which queries, URLs, and context go to Parallel when the agent calls the tools. The example sends `User-Agent: MaxKB` so Parallel can measure aggregate free MCP usage. No runtime code, defaults, or existing connections change.

Validated the exact JSON from both READMEs using MaxKB’s unchanged `validate_mcp_config` and `_initialize_skills` functions in isolation, with its pinned MCP client dependencies. Live discovery, `web_search`, and `web_fetch` succeeded without credentials; outbound request capture confirmed the header on both tool calls. `git diff --check` passes. The full browser/database flow and downstream analytics were not tested.

I work at Parallel, which operates this service.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed. Focused client checks above; no runtime changes or new regression tests.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed. This PR updates both READMEs.
